### PR TITLE
[Package] Add script to package up `assembleVegaLite()` functionality for use in peer projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,12 @@ node_modules/
 
 # Build output
 dist/
+dist-compiler/
 build/
 *.tsbuildinfo
 .tsup/
+.compiler-pack-staging/
+*.tgz
 
 # Test / coverage
 coverage/

--- a/README.md
+++ b/README.md
@@ -298,3 +298,42 @@ import {
    with a skeleton, channel list, and optional post-processor.
 6. **Backend-agnostic semantics** — the same semantic reasoning targets
    Vega-Lite, ECharts, and Chart.js through separate assembly functions.
+
+## Using as a standalone compiler package
+
+The Vega-Lite compilation pipeline (`assembleVegaLite` + core semantics) can be
+packaged independently as `@microsoft/flint-chart-compiler` for use in peer
+projects that only need spec generation without the full library.
+
+### Build the tarball
+
+```bash
+npm run pack:compiler
+# → produces microsoft-flint-chart-compiler-0.1.0.tgz
+```
+
+### Install in a sister repository
+
+```bash
+pnpm add ../flint-chart/microsoft-flint-chart-compiler-0.1.0.tgz
+```
+
+### Import
+
+```ts
+import { assembleVegaLite } from '@microsoft/flint-chart-compiler';
+import type { ChartAssemblyInput } from '@microsoft/flint-chart-compiler/core';
+
+const spec = assembleVegaLite(input);
+```
+
+The package exposes three subpath exports:
+
+| Import path | Contents |
+|-------------|----------|
+| `@microsoft/flint-chart-compiler` | All core + Vega-Lite exports |
+| `@microsoft/flint-chart-compiler/core` | Types, semantic types, layout, decisions |
+| `@microsoft/flint-chart-compiler/vegalite` | `assembleVegaLite`, templates, instantiation |
+
+Additional backends (`assembleECharts`, `assembleChartjs`) can be added to this
+package in the future without breaking existing consumers.

--- a/compiler.package.json
+++ b/compiler.package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@microsoft/flint-chart-compiler",
+  "version": "0.1.0",
+  "description": "Compiles Flint chart specifications into Vega-Lite specs. Core compilation engine extracted from flint-chart.",
+  "keywords": [
+    "flint",
+    "visualization",
+    "charts",
+    "vega-lite",
+    "compiler",
+    "semantic-types"
+  ],
+  "license": "MIT",
+  "author": "Microsoft Corporation",
+  "homepage": "https://github.com/microsoft/flint-chart#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/flint-chart.git"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist-compiler/index.cjs",
+  "module": "./dist-compiler/index.js",
+  "types": "./dist-compiler/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist-compiler/index.d.ts",
+      "import": "./dist-compiler/index.js",
+      "require": "./dist-compiler/index.cjs"
+    },
+    "./core": {
+      "types": "./dist-compiler/core/index.d.ts",
+      "import": "./dist-compiler/core/index.js",
+      "require": "./dist-compiler/core/index.cjs"
+    },
+    "./vegalite": {
+      "types": "./dist-compiler/vegalite/index.d.ts",
+      "import": "./dist-compiler/vegalite/index.js",
+      "require": "./dist-compiler/vegalite/index.cjs"
+    }
+  },
+  "files": [
+    "dist-compiler",
+    "README.md",
+    "LICENSE"
+  ],
+  "peerDependencies": {
+    "vega-lite": "^5.0.0 || ^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vega-lite": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1169,6 +1169,7 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1179,6 +1180,7 @@
       "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.59.3",
@@ -1208,6 +1210,7 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -1539,6 +1542,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1850,6 +1854,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1904,6 +1909,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2772,6 +2778,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2821,6 +2828,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3327,6 +3335,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3389,6 +3398,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "release": "npm publish --access public",
     "site": "npm --prefix site run dev",
     "site:build": "npm --prefix site run build",
-    "mcp:build": "npm --prefix agents/mcp-server run build"
+    "mcp:build": "npm --prefix agents/mcp-server run build",
+    "pack:compiler": "node scripts/pack-compiler.mjs"
   },
   "peerDependencies": {
     "chart.js": "^4.0.0",

--- a/scripts/pack-compiler.mjs
+++ b/scripts/pack-compiler.mjs
@@ -1,0 +1,72 @@
+/**
+ * scripts/pack-compiler.mjs
+ *
+ * Builds and packs the @microsoft/flint-chart-compiler package as a .tgz.
+ *
+ * Usage: node scripts/pack-compiler.mjs
+ *
+ * Steps:
+ *   1. Run tsup with the compiler config to produce dist-compiler/
+ *   2. Create a staging directory with dist-compiler/, package.json, README, LICENSE
+ *   3. Run `pnpm pack` in the staging directory
+ *   4. Move the .tgz to the repo root
+ *   5. Clean up staging directory
+ */
+
+import { execSync } from 'node:child_process';
+import { cpSync, mkdirSync, rmSync, readdirSync, renameSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const STAGING = join(ROOT, '.compiler-pack-staging');
+const DIST_COMPILER = join(ROOT, 'dist-compiler');
+const TSUP_BIN = join(ROOT, 'node_modules', '.bin', 'tsup');
+
+function run(cmd, opts = {}) {
+  console.log(`> ${cmd}`);
+  execSync(cmd, { stdio: 'inherit', cwd: ROOT, shell: true, ...opts });
+}
+
+// Step 1: Build compiler output
+console.log('\n📦 Building @microsoft/flint-chart-compiler...\n');
+run(`"${TSUP_BIN}" --config tsup.config.compiler.ts`);
+
+// Step 2: Create staging directory
+console.log('\n📁 Staging package...\n');
+if (existsSync(STAGING)) {
+  rmSync(STAGING, { recursive: true });
+}
+mkdirSync(STAGING, { recursive: true });
+
+// Copy dist-compiler/ into staging as dist-compiler/
+cpSync(DIST_COMPILER, join(STAGING, 'dist-compiler'), { recursive: true });
+
+// Copy package.json, README, LICENSE
+cpSync(join(ROOT, 'compiler.package.json'), join(STAGING, 'package.json'));
+cpSync(join(ROOT, 'README.md'), join(STAGING, 'README.md'));
+cpSync(join(ROOT, 'LICENSE'), join(STAGING, 'LICENSE'));
+
+// Step 3: Pack
+console.log('\n🎁 Running pnpm pack...\n');
+run('pnpm pack', { cwd: STAGING });
+
+// Step 4: Move .tgz to root
+const tgzFiles = readdirSync(STAGING).filter(f => f.endsWith('.tgz'));
+if (tgzFiles.length === 0) {
+  console.error('❌ No .tgz file produced!');
+  process.exit(1);
+}
+
+const tgzName = tgzFiles[0];
+const dest = join(ROOT, tgzName);
+if (existsSync(dest)) {
+  rmSync(dest);
+}
+renameSync(join(STAGING, tgzName), dest);
+
+// Step 5: Clean up
+rmSync(STAGING, { recursive: true });
+
+console.log(`\n✅ Package ready: ${tgzName}`);
+console.log(`\n   Install in sister repo with:`);
+console.log(`   pnpm add ../flint-chart/${tgzName}\n`);

--- a/src/compiler-index.ts
+++ b/src/compiler-index.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @module @microsoft/flint-chart-compiler
+ *
+ * Compiles a Flint specification into a chart library spec.
+ * Currently supports Vega-Lite; ECharts and Chart.js to be added later.
+ */
+
+// Core: types, semantic types, decisions, layout, overflow
+export * from './core';
+
+// Vega-Lite backend: assembleVegaLite, templates, spec instantiation
+export * from './vegalite';

--- a/tsup.config.compiler.ts
+++ b/tsup.config.compiler.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/compiler-index.ts',
+    'core/index': 'src/core/index.ts',
+    'vegalite/index': 'src/vegalite/index.ts',
+  },
+  outDir: 'dist-compiler',
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  treeshake: true,
+  target: 'es2020',
+  external: ['vega', 'vega-lite'],
+});


### PR DESCRIPTION
Adds (Copilot-generated) script to generate a *.tgz npm package so that functionality can be imported in peer projects.  This "flint-chart-compiler" project only exports the `assembleVegaLite()` function and associated functionality/types.

Trigger a build by changing the version in "compiler.package.json", then running the following script:

```bash
npm run pack:compiler
# → produces microsoft-flint-chart-compiler-0.1.0.tgz
```

Copy the tarball to the repository wanting to use the functionality, and import the package as a dependency:

```bash
pnpm add microsoft-flint-chart-compiler-0.1.0.tgz
```

Once the package is added, then the package can be referenced by name in that respository, e.g.:

```typescript
import { assembleVegaLite } from '@microsoft/flint-chart-compiler';
import type { ChartAssemblyInput } from '@microsoft/flint-chart-compiler/core';
```

Once we figure out publishing to npm by going through the Microsoft open-source process, peer repositories can just add the dependency by name.