### PR TITLE
feat: add static series support (array-valued encodings)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1169,6 +1169,7 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1179,6 +1180,7 @@
       "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.59.3",
@@ -1208,6 +1210,7 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -1539,6 +1542,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1850,6 +1854,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1904,6 +1909,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2772,6 +2778,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2821,6 +2828,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3327,6 +3335,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3389,6 +3398,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/chartjs/assemble.ts
+++ b/src/chartjs/assemble.ts
@@ -40,6 +40,7 @@ import { filterOverflow } from '../core/filter-overflow';
 import { computeLayout, computeChannelBudgets } from '../core/compute-layout';
 import { decideColorMaps } from '../core/color-decisions';
 import { cjsApplyLayoutToSpec, cjsApplyTooltips } from './instantiate-spec';
+import { normalizeStaticSeries } from '../core/static-series';
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -61,8 +62,6 @@ import { cjsApplyLayoutToSpec, cjsApplyTooltips } from './instantiate-spec';
  */
 export function assembleChartjs(input: ChartAssemblyInput): any {
     const chartType = input.chart_spec.chartType;
-    const rawEncodings = input.chart_spec.encodings;
-    const data = input.data.values ?? [];
     const semanticTypes = input.semantic_types ?? {};
     const canvasSize = input.chart_spec.canvasSize ?? { width: 400, height: 320 };
     const chartProperties = input.chart_spec.chartProperties;
@@ -72,13 +71,23 @@ export function assembleChartjs(input: ChartAssemblyInput): any {
         throw new Error(`Unknown Chart.js chart type: ${chartType}. Use cjsAllTemplateDefs to see available types.`);
     }
 
+    const warnings: ChartWarning[] = [];
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // PRE-PHASE: Static Series Normalization
+    // ═══════════════════════════════════════════════════════════════════════
+    const rawData = input.data.values ?? [];
+    const normalized = normalizeStaticSeries(
+        input.chart_spec.encodings, rawData, semanticTypes,
+    );
+    const data = normalized.data;
+    const staticSeries = normalized.staticSeries;
+
     // Compose Category-B encoding-action overrides (stored by the host in
     // chartProperties, keyed by action key) onto the base encodings before any
     // pipeline phase runs. Flint owns the transform; the host only stores the
     // override value. See applyEncodingOverrides / EncodingActionDef.
-    const encodings = applyEncodingOverrides(chartTemplate, rawEncodings, chartProperties);
-
-    const warnings: ChartWarning[] = [];
+    const encodings = applyEncodingOverrides(chartTemplate, normalized.encodings, chartProperties);
 
     // ═══════════════════════════════════════════════════════════════════════
     // PHASE 0: Resolve Semantics (shared with VL + EC — completely target-agnostic)
@@ -189,6 +198,7 @@ export function assembleChartjs(input: ChartAssemblyInput): any {
         resolvedEncodings,
         encodings,
         chartProperties,
+        staticSeries,
         canvasSize,
         semanticTypes,
         chartType,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -17,6 +17,8 @@ export {
     channelGroups,
     type ChartAssemblyInput,
     type ChartEncoding,
+    type EncodingValue,
+    type StaticSeriesMetadata,
     type AssembleOptions,
     type ChartTemplateDef,
     type ChartWarning,
@@ -89,6 +91,12 @@ export {
 export { resolveChannelSemantics, convertTemporalData } from './resolve-semantics';
 export { filterOverflow } from './filter-overflow';
 export { computeLayout, computeChannelBudgets } from './compute-layout';
+export {
+    normalizeStaticSeries,
+    STATIC_SERIES_KEY_COLUMN,
+    STATIC_SERIES_VALUE_COLUMN,
+    type NormalizeStaticSeriesResult,
+} from './static-series';
 
 // Recommendation & adaptation engine
 export {

--- a/src/core/static-series.ts
+++ b/src/core/static-series.ts
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Static Series Normalization
+ *
+ * Detects array-valued encodings (static series) in the input spec,
+ * validates them, and folds (unpivots) the data into long form so
+ * the rest of the pipeline can process it as a standard single-field
+ * encoding with a color discriminator.
+ *
+ * This runs BEFORE Phase 0 (resolveChannelSemantics).
+ */
+
+import type { ChartEncoding, EncodingValue, StaticSeriesMetadata } from './types';
+import type { SemanticAnnotation } from './field-semantics';
+import { getVisCategory, inferVisCategory } from './semantic-types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Synthetic column names injected by the fold transform */
+export const STATIC_SERIES_KEY_COLUMN = '__flint_series_key';
+export const STATIC_SERIES_VALUE_COLUMN = '__flint_series_value';
+
+/** Channels that may accept array-valued (multi-field) encodings */
+const MEASURE_CHANNELS = new Set(['x', 'y']);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of normalizing static series from the input spec.
+ */
+export interface NormalizeStaticSeriesResult {
+    /** Normalized encodings (all single-valued) */
+    encodings: Record<string, ChartEncoding>;
+    /** Folded data (or original if no static series detected) */
+    data: any[];
+    /** Static series metadata (present only when fold was applied) */
+    staticSeries?: StaticSeriesMetadata;
+}
+
+/**
+ * Detect, validate, and normalize static series (array-valued encodings).
+ *
+ * If no array-valued encodings are present, returns the input unchanged.
+ * If one is found, validates constraints and returns folded data +
+ * rewritten encodings.
+ *
+ * @throws Error if validation fails (non-quantitative field, conflicting
+ *         color binding, multiple array channels, etc.)
+ */
+export function normalizeStaticSeries(
+    encodings: Record<string, EncodingValue>,
+    data: any[],
+    semanticTypes: Record<string, string | SemanticAnnotation>,
+): NormalizeStaticSeriesResult {
+    // Find array-valued channels
+    const arrayChannels: { channel: string; entries: ChartEncoding[] }[] = [];
+    for (const [channel, enc] of Object.entries(encodings)) {
+        if (Array.isArray(enc)) {
+            arrayChannels.push({ channel, entries: enc });
+        }
+    }
+
+    // No static series — pass through unchanged
+    if (arrayChannels.length === 0) {
+        return {
+            encodings: encodings as Record<string, ChartEncoding>,
+            data,
+        };
+    }
+
+    // --- Validation ---
+
+    // Only one channel may have an array encoding
+    if (arrayChannels.length > 1) {
+        const channelNames = arrayChannels.map(c => c.channel).join(', ');
+        throw new Error(
+            `Static series (array encoding) found on multiple channels: ${channelNames}. ` +
+            `Only one channel may use array encoding at a time.`
+        );
+    }
+
+    const { channel, entries } = arrayChannels[0];
+
+    // Must be a measure channel
+    if (!MEASURE_CHANNELS.has(channel)) {
+        throw new Error(
+            `Static series (array encoding) is only allowed on measure channels (${[...MEASURE_CHANNELS].join(', ')}), ` +
+            `not "${channel}".`
+        );
+    }
+
+    // Must have at least 2 entries
+    if (entries.length < 2) {
+        throw new Error(
+            `Static series requires at least 2 fields, got ${entries.length} on channel "${channel}".`
+        );
+    }
+
+    // Each entry must specify a field
+    const fields: string[] = [];
+    for (const entry of entries) {
+        if (!entry.field) {
+            throw new Error(
+                `Each static series entry must have a "field" property.`
+            );
+        }
+        fields.push(entry.field);
+    }
+
+    // Duplicate field check
+    const fieldSet = new Set(fields);
+    if (fieldSet.size !== fields.length) {
+        throw new Error(
+            `Static series contains duplicate fields. Each field must be unique.`
+        );
+    }
+
+    // Fields must exist in data columns (if data is available)
+    if (data.length > 0) {
+        const dataColumns = new Set(Object.keys(data[0]));
+        for (const field of fields) {
+            if (!dataColumns.has(field)) {
+                throw new Error(
+                    `Static series field "${field}" not found in data columns. ` +
+                    `Available columns: ${[...dataColumns].join(', ')}`
+                );
+            }
+        }
+    }
+
+    // Fields must resolve to quantitative (not nominal/ordinal)
+    for (const entry of entries) {
+        const field = entry.field!;
+        const explicitType = entry.type;
+        if (explicitType === 'nominal' || explicitType === 'ordinal') {
+            throw new Error(
+                `Static series field "${field}" has type "${explicitType}" — ` +
+                `only quantitative or temporal fields are allowed in static series.`
+            );
+        }
+        // Infer if no explicit type
+        if (!explicitType && data.length > 0) {
+            const semType = semanticTypes[field];
+            const semTypeStr = typeof semType === 'string' ? semType : semType?.semanticType || '';
+            // Try semantic type registry first, then infer from data values
+            const fromRegistry = semTypeStr ? getVisCategory(semTypeStr) : null;
+            const inferred = fromRegistry ?? inferVisCategory(data.map(r => r[field]));
+            if (inferred === 'nominal' || inferred === 'ordinal') {
+                throw new Error(
+                    `Static series field "${field}" infers as "${inferred}" from data — ` +
+                    `only quantitative or temporal fields are allowed in static series.`
+                );
+            }
+        }
+    }
+
+    // Cannot combine with explicit color field binding
+    const colorEnc = encodings.color;
+    if (colorEnc && !Array.isArray(colorEnc) && colorEnc.field) {
+        throw new Error(
+            `Cannot use static series on "${channel}" when the color channel is already bound to ` +
+            `field "${colorEnc.field}". Static series implicitly uses the color channel for ` +
+            `series discrimination.`
+        );
+    }
+
+    // --- Fold (unpivot) the data ---
+    const foldedData = foldData(data, fields);
+
+    // --- Rewrite encodings ---
+    const normalizedEncodings: Record<string, ChartEncoding> = {};
+    for (const [ch, enc] of Object.entries(encodings)) {
+        if (ch === channel) {
+            // Replace array with single encoding on the synthetic value column
+            normalizedEncodings[ch] = { field: STATIC_SERIES_VALUE_COLUMN, type: 'quantitative' };
+        } else if (Array.isArray(enc)) {
+            // Shouldn't reach here (validated above), but handle gracefully
+            normalizedEncodings[ch] = enc[0];
+        } else {
+            normalizedEncodings[ch] = enc;
+        }
+    }
+
+    // Add color encoding for the synthetic key column (preserving any user-specified scheme)
+    const colorScheme = (!Array.isArray(colorEnc) && colorEnc?.scheme) ? colorEnc.scheme : undefined;
+    normalizedEncodings.color = {
+        field: STATIC_SERIES_KEY_COLUMN,
+        type: 'nominal',
+        ...(colorScheme ? { scheme: colorScheme } : {}),
+    };
+
+    const metadata: StaticSeriesMetadata = {
+        channel,
+        fields,
+        keyColumn: STATIC_SERIES_KEY_COLUMN,
+        valueColumn: STATIC_SERIES_VALUE_COLUMN,
+    };
+
+    return {
+        encodings: normalizedEncodings,
+        data: foldedData,
+        staticSeries: metadata,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: fold/unpivot
+// ---------------------------------------------------------------------------
+
+/**
+ * Unpivot (fold) wide-format data into long form.
+ *
+ * Each input row produces N output rows (one per field in `fields`).
+ * Non-measure columns are preserved. Two synthetic columns are added:
+ * - `__flint_series_key`: the field name (series identifier)
+ * - `__flint_series_value`: the value from that field
+ *
+ * Rows where all fold values are null/undefined are skipped.
+ */
+function foldData(data: any[], fields: string[]): any[] {
+    const fieldSet = new Set(fields);
+    const result: any[] = [];
+
+    for (const row of data) {
+        // Collect non-fold columns
+        const baseRow: Record<string, any> = {};
+        for (const [key, value] of Object.entries(row)) {
+            if (!fieldSet.has(key)) {
+                baseRow[key] = value;
+            }
+        }
+
+        // Create one row per fold field
+        for (const field of fields) {
+            const value = row[field];
+            // Skip null/undefined values to avoid phantom data points
+            if (value == null) continue;
+            result.push({
+                ...baseRow,
+                [STATIC_SERIES_KEY_COLUMN]: field,
+                [STATIC_SERIES_VALUE_COLUMN]: value,
+            });
+        }
+    }
+
+    return result;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -48,6 +48,34 @@ export interface ChartEncoding {
     scheme?: string;
 }
 
+/**
+ * An encoding value that allows either a single encoding or an array of
+ * encodings (static series). Array form is only valid on measure channels
+ * (y, x-as-measure) where all fields resolve to quantitative.
+ *
+ * When an array is provided, the assembler folds (unpivots) the specified
+ * fields into a long-form representation with a synthesized key column
+ * (for color/legend) and value column (for the measure axis).
+ */
+export type EncodingValue = ChartEncoding | ChartEncoding[];
+
+/**
+ * Metadata produced by static series normalization.
+ * Captures the original multi-field intent so backends can emit
+ * appropriate legend labels and the pipeline can short-circuit
+ * series counting.
+ */
+export interface StaticSeriesMetadata {
+    /** Which channel had the array encoding ('y' or 'x') */
+    channel: string;
+    /** Original field names from the array entries */
+    fields: string[];
+    /** Synthetic column name for the series discriminator */
+    keyColumn: string;
+    /** Synthetic column name for the measure values */
+    valueColumn: string;
+}
+
 // ============================================================================
 // Phase 0: Semantic Resolution Types
 // ============================================================================
@@ -418,6 +446,9 @@ export interface InstantiateContext {
     /** User-configured chart properties */
     chartProperties?: Record<string, any>;
 
+    /** Static series metadata (present when input used array-valued encoding) */
+    staticSeries?: StaticSeriesMetadata;
+
     /** Target canvas dimensions */
     canvasSize: { width: number; height: number };
 
@@ -783,7 +814,7 @@ export interface ChartAssemblyInput {
         /** Template name, e.g. `"Scatter Plot"`, `"Bar Chart"` */
         chartType: string;
         /** Channel → encoding map (e.g., `{ x: { field: 'weight' }, y: { field: 'mpg' } }`) */
-        encodings: Record<string, ChartEncoding>;
+        encodings: Record<string, EncodingValue>;
         /** Target canvas size in pixels (default: `{ width: 400, height: 320 }`) */
         canvasSize?: { width: number; height: number };
         /** Template-specific configurable properties (e.g., bar corner radius, show labels) */

--- a/src/echarts/assemble.ts
+++ b/src/echarts/assemble.ts
@@ -71,6 +71,7 @@ import { DEFAULT_COLORS } from './templates/utils';
 import { inferVisCategory, computeZeroDecision } from '../core/semantic-types';
 import { decideColorMaps } from '../core/color-decisions';
 import { getPaletteForScheme } from './colormap';
+import { normalizeStaticSeries } from '../core/static-series';
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -92,8 +93,6 @@ import { getPaletteForScheme } from './colormap';
  */
 export function assembleECharts(input: ChartAssemblyInput): any {
     const chartType = input.chart_spec.chartType;
-    const rawEncodings = input.chart_spec.encodings;
-    const data = input.data.values ?? [];
     const semanticTypes = input.semantic_types ?? {};
     const canvasSize = input.chart_spec.canvasSize ?? { width: 400, height: 320 };
     const chartProperties = input.chart_spec.chartProperties;
@@ -103,13 +102,23 @@ export function assembleECharts(input: ChartAssemblyInput): any {
         throw new Error(`Unknown ECharts chart type: ${chartType}. Use ecAllTemplateDefs to see available types.`);
     }
 
+    const warnings: ChartWarning[] = [];
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // PRE-PHASE: Static Series Normalization
+    // ═══════════════════════════════════════════════════════════════════════
+    const rawData = input.data.values ?? [];
+    const normalized = normalizeStaticSeries(
+        input.chart_spec.encodings, rawData, semanticTypes,
+    );
+    const data = normalized.data;
+    const staticSeries = normalized.staticSeries;
+
     // Compose Category-B encoding-action overrides (stored by the host in
     // chartProperties, keyed by action key) onto the base encodings before any
     // pipeline phase runs. Flint owns the transform; the host only stores the
     // override value. See applyEncodingOverrides / EncodingActionDef.
-    const encodings = applyEncodingOverrides(chartTemplate, rawEncodings, chartProperties);
-
-    const warnings: ChartWarning[] = [];
+    const encodings = applyEncodingOverrides(chartTemplate, normalized.encodings, chartProperties);
 
     // ═══════════════════════════════════════════════════════════════════════
     // PHASE 0: Resolve Semantics (shared with VL — completely target-agnostic)
@@ -244,6 +253,7 @@ export function assembleECharts(input: ChartAssemblyInput): any {
         resolvedEncodings,
         encodings,
         chartProperties,
+        staticSeries,
         canvasSize,
         semanticTypes,
         chartType,

--- a/src/gofish/assemble.ts
+++ b/src/gofish/assemble.ts
@@ -47,6 +47,7 @@ import { resolveChannelSemantics, convertTemporalData } from '../core/resolve-se
 import { computeZeroDecision } from '../core/semantic-types';
 import { filterOverflow } from '../core/filter-overflow';
 import { computeLayout, computeChannelBudgets } from '../core/compute-layout';
+import { normalizeStaticSeries } from '../core/static-series';
 
 // ---------------------------------------------------------------------------
 // GoFish Spec Type
@@ -335,8 +336,6 @@ function buildSpecDescription(gfDesc: any): string {
  */
 export function assembleGoFish(input: ChartAssemblyInput): GoFishSpec {
     const chartType = input.chart_spec.chartType;
-    const rawEncodings = input.chart_spec.encodings;
-    const data = input.data.values ?? [];
     const semanticTypes = input.semantic_types ?? {};
     const canvasSize = input.chart_spec.canvasSize ?? { width: 400, height: 320 };
     const chartProperties = input.chart_spec.chartProperties;
@@ -346,13 +345,23 @@ export function assembleGoFish(input: ChartAssemblyInput): GoFishSpec {
         throw new Error(`Unknown GoFish chart type: ${chartType}. Use gfAllTemplateDefs to see available types.`);
     }
 
+    const warnings: ChartWarning[] = [];
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // PRE-PHASE: Static Series Normalization
+    // ═══════════════════════════════════════════════════════════════════════
+    const rawData = input.data.values ?? [];
+    const normalized = normalizeStaticSeries(
+        input.chart_spec.encodings, rawData, semanticTypes,
+    );
+    const data = normalized.data;
+    const staticSeries = normalized.staticSeries;
+
     // Compose Category-B encoding-action overrides (stored by the host in
     // chartProperties, keyed by action key) onto the base encodings before any
     // pipeline phase runs. Flint owns the transform; the host only stores the
     // override value. See applyEncodingOverrides / EncodingActionDef.
-    const encodings = applyEncodingOverrides(chartTemplate, rawEncodings, chartProperties);
-
-    const warnings: ChartWarning[] = [];
+    const encodings = applyEncodingOverrides(chartTemplate, normalized.encodings, chartProperties);
 
     // ═══════════════════════════════════════════════════════════════════════
     // PHASE 0: Resolve Semantics (shared with all backends)
@@ -454,6 +463,7 @@ export function assembleGoFish(input: ChartAssemblyInput): GoFishSpec {
         resolvedEncodings,
         encodings,
         chartProperties,
+        staticSeries,
         canvasSize,
         semanticTypes,
         chartType,

--- a/src/test-data/index.ts
+++ b/src/test-data/index.ts
@@ -76,6 +76,15 @@ export type {
     GalleryPageRender,
     SingleRenderLibrary,
 } from './gallery-tree';
+export {
+    STATIC_SERIES_GALLERY_EXAMPLES,
+    STATIC_SERIES_LINE_BASIC,
+    STATIC_SERIES_LINE_THREE_KPIS,
+    STATIC_SERIES_LINE_MANY_SERIES,
+    STATIC_SERIES_DOTTED_LINE_STOCKS,
+    STATIC_SERIES_AREA_STACKED,
+    STATIC_SERIES_SCATTER,
+} from './static-series-tests';
 
 // ---------------------------------------------------------------------------
 // Master TEST_GENERATORS map

--- a/src/test-data/static-series-tests.ts
+++ b/src/test-data/static-series-tests.ts
@@ -1,0 +1,243 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Static Series Gallery Examples
+ *
+ * Demonstrates the static series feature (array-valued encodings) across
+ * multiple chart types and data scenarios. These examples use wide-format
+ * data where multiple columns represent different measures.
+ */
+
+import type { ChartAssemblyInput } from '../core/types';
+
+// ---------------------------------------------------------------------------
+// Datasets (wide-format)
+// ---------------------------------------------------------------------------
+
+/** Monthly sales performance — two measure columns */
+const MONTHLY_SALES_DATA = [
+    { Month: '2024-01-01', Revenue: 125000, Expenses: 89000 },
+    { Month: '2024-02-01', Revenue: 138000, Expenses: 92000 },
+    { Month: '2024-03-01', Revenue: 155000, Expenses: 95000 },
+    { Month: '2024-04-01', Revenue: 142000, Expenses: 88000 },
+    { Month: '2024-05-01', Revenue: 168000, Expenses: 97000 },
+    { Month: '2024-06-01', Revenue: 175000, Expenses: 101000 },
+    { Month: '2024-07-01', Revenue: 162000, Expenses: 98000 },
+    { Month: '2024-08-01', Revenue: 189000, Expenses: 105000 },
+    { Month: '2024-09-01', Revenue: 195000, Expenses: 108000 },
+    { Month: '2024-10-01', Revenue: 210000, Expenses: 112000 },
+    { Month: '2024-11-01', Revenue: 225000, Expenses: 118000 },
+    { Month: '2024-12-01', Revenue: 248000, Expenses: 125000 },
+];
+
+/** Quarterly KPIs — three measure columns */
+const QUARTERLY_KPIS_DATA = [
+    { Quarter: 'Q1 2023', NPS: 72, CSAT: 85, CES: 68 },
+    { Quarter: 'Q2 2023', NPS: 75, CSAT: 87, CES: 71 },
+    { Quarter: 'Q3 2023', NPS: 68, CSAT: 82, CES: 65 },
+    { Quarter: 'Q4 2023', NPS: 79, CSAT: 89, CES: 74 },
+    { Quarter: 'Q1 2024', NPS: 81, CSAT: 91, CES: 77 },
+    { Quarter: 'Q2 2024', NPS: 84, CSAT: 90, CES: 79 },
+    { Quarter: 'Q3 2024', NPS: 82, CSAT: 92, CES: 80 },
+    { Quarter: 'Q4 2024', NPS: 88, CSAT: 94, CES: 83 },
+];
+
+/** Weather comparison — temperatures from multiple cities */
+const WEATHER_DATA = [
+    { Date: '2024-06-01', Seattle: 18, Portland: 20, SanFrancisco: 16, LosAngeles: 24 },
+    { Date: '2024-06-15', Seattle: 21, Portland: 23, SanFrancisco: 17, LosAngeles: 26 },
+    { Date: '2024-07-01', Seattle: 24, Portland: 27, SanFrancisco: 18, LosAngeles: 28 },
+    { Date: '2024-07-15', Seattle: 27, Portland: 30, SanFrancisco: 19, LosAngeles: 30 },
+    { Date: '2024-08-01', Seattle: 26, Portland: 29, SanFrancisco: 18, LosAngeles: 29 },
+    { Date: '2024-08-15', Seattle: 25, Portland: 28, SanFrancisco: 18, LosAngeles: 28 },
+    { Date: '2024-09-01', Seattle: 22, Portland: 25, SanFrancisco: 19, LosAngeles: 27 },
+    { Date: '2024-09-15', Seattle: 19, Portland: 21, SanFrancisco: 18, LosAngeles: 25 },
+];
+
+/** Stock comparison — closing prices for tech companies */
+const STOCK_DATA = [
+    { Day: '2024-11-01', MSFT: 375, GOOG: 140, AMZN: 185 },
+    { Day: '2024-11-04', MSFT: 378, GOOG: 142, AMZN: 188 },
+    { Day: '2024-11-05', MSFT: 382, GOOG: 138, AMZN: 190 },
+    { Day: '2024-11-06', MSFT: 380, GOOG: 141, AMZN: 187 },
+    { Day: '2024-11-07', MSFT: 385, GOOG: 145, AMZN: 192 },
+    { Day: '2024-11-08', MSFT: 390, GOOG: 148, AMZN: 195 },
+    { Day: '2024-11-11', MSFT: 388, GOOG: 146, AMZN: 193 },
+    { Day: '2024-11-12', MSFT: 392, GOOG: 150, AMZN: 198 },
+    { Day: '2024-11-13', MSFT: 395, GOOG: 152, AMZN: 200 },
+    { Day: '2024-11-14', MSFT: 398, GOOG: 149, AMZN: 197 },
+    { Day: '2024-11-15', MSFT: 402, GOOG: 155, AMZN: 205 },
+];
+
+/** Annual metrics — area chart use case */
+const ANNUAL_METRICS_DATA = [
+    { Year: '2019', OnlineRevenue: 45000, InStoreRevenue: 120000, WholesaleRevenue: 78000 },
+    { Year: '2020', OnlineRevenue: 85000, InStoreRevenue: 72000, WholesaleRevenue: 65000 },
+    { Year: '2021', OnlineRevenue: 110000, InStoreRevenue: 95000, WholesaleRevenue: 82000 },
+    { Year: '2022', OnlineRevenue: 135000, InStoreRevenue: 108000, WholesaleRevenue: 90000 },
+    { Year: '2023', OnlineRevenue: 160000, InStoreRevenue: 115000, WholesaleRevenue: 95000 },
+    { Year: '2024', OnlineRevenue: 190000, InStoreRevenue: 120000, WholesaleRevenue: 100000 },
+];
+
+// ---------------------------------------------------------------------------
+// Gallery examples — each is a ready-to-use ChartAssemblyInput
+// ---------------------------------------------------------------------------
+
+/** Simple two-series line chart — Revenue vs Expenses */
+export const STATIC_SERIES_LINE_BASIC: ChartAssemblyInput = {
+    data: { values: MONTHLY_SALES_DATA },
+    semantic_types: {
+        Month: 'Date',
+        Revenue: 'Quantity',
+        Expenses: 'Quantity',
+    },
+    chart_spec: {
+        chartType: 'Line Chart',
+        encodings: {
+            x: { field: 'Month' },
+            y: [{ field: 'Revenue' }, { field: 'Expenses' }],
+        },
+        canvasSize: { width: 600, height: 380 },
+    },
+    field_display_names: {
+        Revenue: 'Revenue ($)',
+        Expenses: 'Expenses ($)',
+    },
+};
+
+/** Three-metric KPI dashboard line chart */
+export const STATIC_SERIES_LINE_THREE_KPIS: ChartAssemblyInput = {
+    data: { values: QUARTERLY_KPIS_DATA },
+    semantic_types: {
+        Quarter: 'Category',
+        NPS: 'Quantity',
+        CSAT: 'Quantity',
+        CES: 'Quantity',
+    },
+    chart_spec: {
+        chartType: 'Line Chart',
+        encodings: {
+            x: { field: 'Quarter' },
+            y: [{ field: 'NPS' }, { field: 'CSAT' }, { field: 'CES' }],
+        },
+        canvasSize: { width: 600, height: 380 },
+    },
+    field_display_names: {
+        NPS: 'Net Promoter Score',
+        CSAT: 'Customer Satisfaction',
+        CES: 'Customer Effort Score',
+    },
+};
+
+/** Four-city temperature comparison (many series) */
+export const STATIC_SERIES_LINE_MANY_SERIES: ChartAssemblyInput = {
+    data: { values: WEATHER_DATA },
+    semantic_types: {
+        Date: 'Date',
+        Seattle: 'Quantity',
+        Portland: 'Quantity',
+        SanFrancisco: 'Quantity',
+        LosAngeles: 'Quantity',
+    },
+    chart_spec: {
+        chartType: 'Line Chart',
+        encodings: {
+            x: { field: 'Date' },
+            y: [
+                { field: 'Seattle' },
+                { field: 'Portland' },
+                { field: 'SanFrancisco' },
+                { field: 'LosAngeles' },
+            ],
+        },
+        canvasSize: { width: 650, height: 400 },
+    },
+    field_display_names: {
+        SanFrancisco: 'San Francisco',
+        LosAngeles: 'Los Angeles',
+    },
+};
+
+/** Stock price comparison — dotted line variant */
+export const STATIC_SERIES_DOTTED_LINE_STOCKS: ChartAssemblyInput = {
+    data: { values: STOCK_DATA },
+    semantic_types: {
+        Day: 'Date',
+        MSFT: 'Quantity',
+        GOOG: 'Quantity',
+        AMZN: 'Quantity',
+    },
+    chart_spec: {
+        chartType: 'Dotted Line Chart',
+        encodings: {
+            x: { field: 'Day' },
+            y: [{ field: 'MSFT' }, { field: 'GOOG' }, { field: 'AMZN' }],
+        },
+        canvasSize: { width: 600, height: 380 },
+    },
+    field_display_names: {
+        MSFT: 'Microsoft',
+        GOOG: 'Alphabet',
+        AMZN: 'Amazon',
+    },
+};
+
+/** Stacked area chart — revenue channels over time */
+export const STATIC_SERIES_AREA_STACKED: ChartAssemblyInput = {
+    data: { values: ANNUAL_METRICS_DATA },
+    semantic_types: {
+        Year: 'Year',
+        OnlineRevenue: 'Quantity',
+        InStoreRevenue: 'Quantity',
+        WholesaleRevenue: 'Quantity',
+    },
+    chart_spec: {
+        chartType: 'Area Chart',
+        encodings: {
+            x: { field: 'Year' },
+            y: [
+                { field: 'OnlineRevenue' },
+                { field: 'InStoreRevenue' },
+                { field: 'WholesaleRevenue' },
+            ],
+        },
+        canvasSize: { width: 600, height: 380 },
+    },
+    field_display_names: {
+        OnlineRevenue: 'Online',
+        InStoreRevenue: 'In-Store',
+        WholesaleRevenue: 'Wholesale',
+    },
+};
+
+/** Scatter plot with static series — Revenue vs Expenses with labeled points */
+export const STATIC_SERIES_SCATTER: ChartAssemblyInput = {
+    data: { values: MONTHLY_SALES_DATA },
+    semantic_types: {
+        Month: 'Date',
+        Revenue: 'Quantity',
+        Expenses: 'Quantity',
+    },
+    chart_spec: {
+        chartType: 'Scatter Plot',
+        encodings: {
+            x: { field: 'Month' },
+            y: [{ field: 'Revenue' }, { field: 'Expenses' }],
+        },
+        canvasSize: { width: 600, height: 380 },
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Collected gallery examples list
+// ---------------------------------------------------------------------------
+
+export const STATIC_SERIES_GALLERY_EXAMPLES = [
+    { label: 'Revenue vs Expenses (Line)', input: STATIC_SERIES_LINE_BASIC },
+    { label: 'KPI Dashboard (3 metrics)', input: STATIC_SERIES_LINE_THREE_KPIS },
+    { label: 'City Temperatures (4 series)', input: STATIC_SERIES_LINE_MANY_SERIES },
+    { label: 'Stock Comparison (Dotted Line)', input: STATIC_SERIES_DOTTED_LINE_STOCKS },
+    { label: 'Revenue Channels (Stacked Area)', input: STATIC_SERIES_AREA_STACKED },
+    { label: 'Measures as Scatter', input: STATIC_SERIES_SCATTER },
+];

--- a/src/vegalite/assemble.ts
+++ b/src/vegalite/assemble.ts
@@ -61,6 +61,7 @@ import { toTypeString, type SemanticAnnotation } from '../core/field-semantics';
 import { filterOverflow } from '../core/filter-overflow';
 import { computeLayout, computeChannelBudgets, computeMinSubplotDimensions } from '../core/compute-layout';
 import { vlApplyLayoutToSpec, vlApplyTooltips } from './instantiate-spec';
+import { normalizeStaticSeries } from '../core/static-series';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -103,8 +104,6 @@ const escapeVlFieldName = (name: string): string =>
  */
 export function assembleVegaLite(input: ChartAssemblyInput): any {
     const chartType = input.chart_spec.chartType;
-    const rawEncodings = input.chart_spec.encodings;
-    const data = input.data.values ?? [];
     const semanticTypes = input.semantic_types ?? {};
     const canvasSize = input.chart_spec.canvasSize ?? { width: 400, height: 320 };
     const chartProperties = input.chart_spec.chartProperties;
@@ -113,6 +112,19 @@ export function assembleVegaLite(input: ChartAssemblyInput): any {
     if (!chartTemplate) {
         throw new Error(`Unknown chart type: ${chartType}`);
     }
+
+    const warnings: ChartWarning[] = [];
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // PRE-PHASE: Static Series Normalization
+    // ═══════════════════════════════════════════════════════════════════════
+    // Detect array-valued encodings (static series), validate, and fold data.
+    const rawData = input.data.values ?? [];
+    const normalized = normalizeStaticSeries(
+        input.chart_spec.encodings, rawData, semanticTypes,
+    );
+    const data = normalized.data;
+    const staticSeries = normalized.staticSeries;
 
     // Compose Category-B encoding-action overrides (stored by the host in
     // chartProperties, keyed by action key) onto the base encodings before any
@@ -126,12 +138,12 @@ export function assembleVegaLite(input: ChartAssemblyInput): any {
     // the overrides onto the type-enriched encodings, then re-resolve semantics
     // on the result below (so that, e.g., a value-sort correctly suppresses the
     // field's canonical ordinal ordering).
-    const convertedData = convertTemporalData(data, semanticTypes);
+    const prelimConvertedData = convertTemporalData(data, semanticTypes);
     const prelimSemantics = resolveChannelSemantics(
-        rawEncodings, data, semanticTypes, convertedData,
+        normalized.encodings, data, semanticTypes, prelimConvertedData,
     );
     const typedRawEncodings: Record<string, ChartEncoding> = {};
-    for (const [ch, enc] of Object.entries(rawEncodings)) {
+    for (const [ch, enc] of Object.entries(normalized.encodings)) {
         typedRawEncodings[ch] = enc.type
             ? enc
             : { ...enc, type: prelimSemantics[ch]?.type };
@@ -153,14 +165,15 @@ export function assembleVegaLite(input: ChartAssemblyInput): any {
     }
     const encodings = applyEncodingOverrides(chartTemplate, typedRawEncodings, chartProperties);
 
-    const warnings: ChartWarning[] = [];
-
     // ═══════════════════════════════════════════════════════════════════════
     // PHASE 0: Resolve Semantics (VL-free)
     // ═══════════════════════════════════════════════════════════════════════
 
     const tplMark = chartTemplate.template?.mark;
     const templateMarkType = typeof tplMark === 'string' ? tplMark : tplMark?.type;
+
+    // Convert temporal data on the (possibly folded) dataset for Phase 0+
+    const convertedData = convertTemporalData(data, semanticTypes);
 
     const channelSemantics = resolveChannelSemantics(
         encodings, data, semanticTypes, convertedData,
@@ -359,7 +372,18 @@ export function assembleVegaLite(input: ChartAssemblyInput): any {
 
     // --- Build VL encodings (abstract semantics → VL encoding objects) ---
 
-    const fieldDisplayNames = input.field_display_names;
+    // For static series, suppress the synthetic key column's axis title
+    // (show "Series" instead of "__flint_series_key") and map field names to display names
+    let fieldDisplayNames = input.field_display_names;
+    if (staticSeries) {
+        fieldDisplayNames = { ...fieldDisplayNames };
+        // Hide the synthetic key column name from the legend title
+        if (!fieldDisplayNames[staticSeries.keyColumn]) {
+            fieldDisplayNames[staticSeries.keyColumn] = 'Series';
+        }
+        // Map each series field name to its display name (if available) for legend labels
+        // This uses VL's labelExpr or scale domain in the encoding
+    }
 
     const resolvedEncodings = buildVLEncodings(
         encodings, channelSemantics, declaration, data,
@@ -423,6 +447,7 @@ export function assembleVegaLite(input: ChartAssemblyInput): any {
         resolvedEncodings,
         encodings,
         chartProperties,
+        staticSeries,
         canvasSize,
         semanticTypes,
         chartType,

--- a/tests/static-series-gallery.test.ts
+++ b/tests/static-series-gallery.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from 'vitest';
+import {
+    assembleVegaLite,
+    assembleECharts,
+    assembleChartjs,
+    assembleGoFish,
+} from '../src';
+import {
+    STATIC_SERIES_GALLERY_EXAMPLES,
+} from '../src/test-data/static-series-tests';
+
+/**
+ * Verify that all static series gallery examples compile through every backend
+ * without throwing. This catches regressions in the normalization + downstream
+ * pipeline when examples are added/modified.
+ *
+ * Note: Not all chart types are available in all backends (e.g., Dotted Line
+ * is VL/EC only), so we catch unknown-type errors gracefully.
+ */
+describe('static series gallery examples', () => {
+    for (const { label, input } of STATIC_SERIES_GALLERY_EXAMPLES) {
+        describe(label, () => {
+            it('assembles via Vega-Lite (if supported)', () => {
+                try {
+                    const spec = assembleVegaLite(input as any);
+                    expect(spec).toBeDefined();
+                    expect(spec.encoding || spec.layer).toBeDefined();
+                } catch (e: any) {
+                    expect(e.message).toContain('Unknown chart type');
+                }
+            });
+
+            it('assembles via ECharts (if supported)', () => {
+                try {
+                    const option = assembleECharts(input as any);
+                    expect(option).toBeDefined();
+                    expect(option.series?.length).toBeGreaterThanOrEqual(2);
+                } catch (e: any) {
+                    expect(e.message).toContain('Unknown ECharts chart type');
+                }
+            });
+
+            it('assembles via Chart.js (if supported)', () => {
+                try {
+                    const config = assembleChartjs(input as any);
+                    expect(config).toBeDefined();
+                } catch (e: any) {
+                    // Chart type not supported in Chart.js backend — expected
+                    expect(e.message).toContain('Unknown Chart.js chart type');
+                }
+            });
+
+            it('assembles via GoFish (if supported)', () => {
+                try {
+                    const spec = assembleGoFish(input as any);
+                    expect(spec).toBeDefined();
+                    expect(spec._gofish).toBeDefined();
+                } catch (e: any) {
+                    // Chart type not supported in GoFish backend — expected
+                    expect(e.message).toContain('Unknown GoFish chart type');
+                }
+            });
+        });
+    }
+});

--- a/tests/static-series.test.ts
+++ b/tests/static-series.test.ts
@@ -1,0 +1,275 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from 'vitest';
+import {
+    normalizeStaticSeries,
+    STATIC_SERIES_KEY_COLUMN,
+    STATIC_SERIES_VALUE_COLUMN,
+} from '../src/core/static-series';
+import {
+    assembleVegaLite,
+    assembleECharts,
+    assembleChartjs,
+    assembleGoFish,
+} from '../src';
+
+// ---------------------------------------------------------------------------
+// Test data (wide-format: one column per measure)
+// ---------------------------------------------------------------------------
+
+const WIDE_DATA = [
+    { Month: '2018-07-01', 'Sales Amount': 2939690.99, 'Sales Due Date': 2304212.57 },
+    { Month: '2018-08-01', 'Sales Amount': 3964801.20, 'Sales Due Date': 3636830.87 },
+    { Month: '2018-09-01', 'Sales Amount': 3287605.93, 'Sales Due Date': 3707611.99 },
+];
+
+// ---------------------------------------------------------------------------
+// normalizeStaticSeries — validation tests
+// ---------------------------------------------------------------------------
+
+describe('normalizeStaticSeries validation', () => {
+    it('passes through when no array encodings are present', () => {
+        const result = normalizeStaticSeries(
+            { x: { field: 'Month' }, y: { field: 'Sales Amount' } },
+            WIDE_DATA,
+            {},
+        );
+        expect(result.staticSeries).toBeUndefined();
+        expect(result.data).toBe(WIDE_DATA); // same reference
+        expect(result.encodings.y).toEqual({ field: 'Sales Amount' });
+    });
+
+    it('rejects array encoding on non-measure channel', () => {
+        expect(() => normalizeStaticSeries(
+            { x: { field: 'Month' }, color: [{ field: 'Sales Amount' }, { field: 'Sales Due Date' }] },
+            WIDE_DATA,
+            {},
+        )).toThrow(/only allowed on measure channels/);
+    });
+
+    it('rejects array encoding with fewer than 2 entries', () => {
+        expect(() => normalizeStaticSeries(
+            { x: { field: 'Month' }, y: [{ field: 'Sales Amount' }] },
+            WIDE_DATA,
+            {},
+        )).toThrow(/at least 2 fields/);
+    });
+
+    it('rejects entry without a field', () => {
+        expect(() => normalizeStaticSeries(
+            { x: { field: 'Month' }, y: [{ field: 'Sales Amount' }, { aggregate: 'count' }] },
+            WIDE_DATA,
+            {},
+        )).toThrow(/must have a "field" property/);
+    });
+
+    it('rejects duplicate fields', () => {
+        expect(() => normalizeStaticSeries(
+            { x: { field: 'Month' }, y: [{ field: 'Sales Amount' }, { field: 'Sales Amount' }] },
+            WIDE_DATA,
+            {},
+        )).toThrow(/duplicate fields/);
+    });
+
+    it('rejects field not present in data', () => {
+        expect(() => normalizeStaticSeries(
+            { x: { field: 'Month' }, y: [{ field: 'Sales Amount' }, { field: 'NonExistent' }] },
+            WIDE_DATA,
+            {},
+        )).toThrow(/not found in data columns/);
+    });
+
+    it('rejects explicitly nominal field', () => {
+        expect(() => normalizeStaticSeries(
+            { x: { field: 'Month' }, y: [{ field: 'Sales Amount', type: 'nominal' }, { field: 'Sales Due Date' }] },
+            WIDE_DATA,
+            {},
+        )).toThrow(/only quantitative or temporal/);
+    });
+
+    it('rejects when color channel is already bound', () => {
+        expect(() => normalizeStaticSeries(
+            {
+                x: { field: 'Month' },
+                y: [{ field: 'Sales Amount' }, { field: 'Sales Due Date' }],
+                color: { field: 'SomeCategory' },
+            },
+            WIDE_DATA,
+            {},
+        )).toThrow(/color channel is already bound/);
+    });
+
+    it('allows color with scheme-only (no field)', () => {
+        const result = normalizeStaticSeries(
+            {
+                x: { field: 'Month' },
+                y: [{ field: 'Sales Amount' }, { field: 'Sales Due Date' }],
+                color: { scheme: 'tableau10' },
+            },
+            WIDE_DATA,
+            {},
+        );
+        expect(result.staticSeries).toBeDefined();
+        expect(result.encodings.color.scheme).toBe('tableau10');
+    });
+
+    it('rejects multiple array channels', () => {
+        expect(() => normalizeStaticSeries(
+            {
+                x: [{ field: 'Sales Amount' }, { field: 'Sales Due Date' }],
+                y: [{ field: 'Sales Amount' }, { field: 'Sales Due Date' }],
+            },
+            WIDE_DATA,
+            {},
+        )).toThrow(/multiple channels/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeStaticSeries — fold/normalization tests
+// ---------------------------------------------------------------------------
+
+describe('normalizeStaticSeries fold', () => {
+    it('folds data correctly', () => {
+        const result = normalizeStaticSeries(
+            { x: { field: 'Month' }, y: [{ field: 'Sales Amount' }, { field: 'Sales Due Date' }] },
+            WIDE_DATA,
+            {},
+        );
+
+        // 3 rows × 2 fields = 6 folded rows
+        expect(result.data.length).toBe(6);
+
+        // Check first folded row
+        const first = result.data[0];
+        expect(first.Month).toBe('2018-07-01');
+        expect(first[STATIC_SERIES_KEY_COLUMN]).toBe('Sales Amount');
+        expect(first[STATIC_SERIES_VALUE_COLUMN]).toBe(2939690.99);
+
+        // Original wide columns should not be in folded rows
+        expect(first['Sales Amount']).toBeUndefined();
+        expect(first['Sales Due Date']).toBeUndefined();
+    });
+
+    it('produces correct metadata', () => {
+        const result = normalizeStaticSeries(
+            { x: { field: 'Month' }, y: [{ field: 'Sales Amount' }, { field: 'Sales Due Date' }] },
+            WIDE_DATA,
+            {},
+        );
+
+        expect(result.staticSeries).toEqual({
+            channel: 'y',
+            fields: ['Sales Amount', 'Sales Due Date'],
+            keyColumn: STATIC_SERIES_KEY_COLUMN,
+            valueColumn: STATIC_SERIES_VALUE_COLUMN,
+        });
+    });
+
+    it('rewrites encodings with synthetic columns', () => {
+        const result = normalizeStaticSeries(
+            { x: { field: 'Month' }, y: [{ field: 'Sales Amount' }, { field: 'Sales Due Date' }] },
+            WIDE_DATA,
+            {},
+        );
+
+        expect(result.encodings.x).toEqual({ field: 'Month' });
+        expect(result.encodings.y).toEqual({ field: STATIC_SERIES_VALUE_COLUMN, type: 'quantitative' });
+        expect(result.encodings.color).toEqual({ field: STATIC_SERIES_KEY_COLUMN, type: 'nominal' });
+    });
+
+    it('skips null values in fold', () => {
+        const dataWithNull = [
+            { Month: '2018-07-01', 'Sales Amount': 100, 'Sales Due Date': null },
+            { Month: '2018-08-01', 'Sales Amount': 200, 'Sales Due Date': 300 },
+        ];
+        const result = normalizeStaticSeries(
+            { x: { field: 'Month' }, y: [{ field: 'Sales Amount' }, { field: 'Sales Due Date' }] },
+            dataWithNull,
+            {},
+        );
+
+        // First row has null for Sales Due Date → only 3 folded rows (not 4)
+        expect(result.data.length).toBe(3);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: assembler integration tests
+// ---------------------------------------------------------------------------
+
+const STATIC_SERIES_INPUT = {
+    data: { values: WIDE_DATA },
+    semantic_types: { Month: 'Year', 'Sales Amount': 'Quantity', 'Sales Due Date': 'Quantity' },
+    chart_spec: {
+        chartType: 'Line Chart',
+        encodings: {
+            x: { field: 'Month' },
+            y: [{ field: 'Sales Amount' }, { field: 'Sales Due Date' }],
+        },
+        canvasSize: { width: 600, height: 400 },
+    },
+} as const;
+
+describe('static series end-to-end: Vega-Lite', () => {
+    it('produces a valid spec with fold encoding', () => {
+        const spec = assembleVegaLite(STATIC_SERIES_INPUT) as any;
+        expect(spec).toBeDefined();
+        // Should have color encoding derived from the synthetic key column
+        const colorEnc = spec.encoding?.color;
+        expect(colorEnc).toBeDefined();
+        expect(colorEnc.field).toBe(STATIC_SERIES_KEY_COLUMN);
+        expect(colorEnc.type).toBe('nominal');
+    });
+
+    it('Y encoding uses synthetic value column', () => {
+        const spec = assembleVegaLite(STATIC_SERIES_INPUT) as any;
+        const yEnc = spec.encoding?.y;
+        expect(yEnc).toBeDefined();
+        expect(yEnc.field).toBe(STATIC_SERIES_VALUE_COLUMN);
+        expect(yEnc.type).toBe('quantitative');
+    });
+
+    it('data contains folded rows', () => {
+        const spec = assembleVegaLite(STATIC_SERIES_INPUT) as any;
+        const data = spec.data?.values;
+        expect(data).toBeDefined();
+        expect(data.length).toBe(6); // 3 rows × 2 series
+        expect(data[0][STATIC_SERIES_KEY_COLUMN]).toBeDefined();
+    });
+});
+
+describe('static series end-to-end: ECharts', () => {
+    it('produces multi-series ECharts option', () => {
+        const option = assembleECharts(STATIC_SERIES_INPUT) as any;
+        expect(option).toBeDefined();
+        // ECharts should produce 2 series (one per static series field)
+        expect(option.series).toBeDefined();
+        expect(option.series.length).toBe(2);
+    });
+
+    it('series names match field names', () => {
+        const option = assembleECharts(STATIC_SERIES_INPUT) as any;
+        const seriesNames = option.series.map((s: any) => s.name);
+        expect(seriesNames).toContain('Sales Amount');
+        expect(seriesNames).toContain('Sales Due Date');
+    });
+});
+
+describe('static series end-to-end: Chart.js', () => {
+    it('produces multi-dataset config', () => {
+        const config = assembleChartjs(STATIC_SERIES_INPUT) as any;
+        expect(config).toBeDefined();
+        // Chart.js should have 2 datasets
+        expect(config.data?.datasets?.length).toBe(2);
+    });
+});
+
+describe('static series end-to-end: GoFish', () => {
+    it('produces a GoFish spec without errors', () => {
+        const spec = assembleGoFish(STATIC_SERIES_INPUT) as any;
+        expect(spec).toBeDefined();
+        expect(spec._gofish).toBeDefined();
+    });
+});


### PR DESCRIPTION
Cherry-picks PR #11 (static series support) onto current main with proper conflict resolution.

## Changes from PR #11
- Add `EncodingValue` union type (`ChartEncoding | ChartEncoding[]`)
- Add `StaticSeriesMetadata` interface to track fold context
- Implement `normalizeStaticSeries()` with validation
- Data fold (unpivot) runs before Phase 0, so all backends work unchanged
- Wire normalization into VL, ECharts, Chart.js, and GoFish assemblers
- 21 new static series tests + 24 gallery examples tests

## Conflict Resolution
The original PR was based on an older main. Key merge decisions:
- **Preserved** all new main additions (encoding-overrides, encoding-actions, docs, kpi-card, codeql, XSS fix)
- **Composed** static series normalization to run before `applyEncodingOverrides` (since normalization handles array-valued encodings that the override system does not support)
- **Fixed** gallery test to gracefully handle unsupported chart types across all backends (not just Chart.js/GoFish)
- **Dropped** regional-survey re-exports from `test-data/index.ts` that referenced files removed in current main

## Verification
- ✅ TypeScript type-check passes
- ✅ All 51 tests pass (6 smoke + 21 static-series + 24 gallery)

Closes #10, supersedes #11