### PR TITLE
feat: restructure gallery organized by backend with chart icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,16 +7,19 @@
       "name": "flint-chart-monorepo",
       "workspaces": [
         "packages/flint-js",
-        "agent-skills/*",
         "site"
       ],
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.0.0"
       }
     },
     "agent-skills/mcp-server": {
       "name": "flint-chart-mcp-server",
       "version": "0.0.1",
+      "extraneous": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "flint-chart": "*",
@@ -33,6 +36,91 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.27.7",
       "cpu": [
@@ -43,6 +131,346 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -219,18 +647,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "dev": true,
@@ -318,67 +734,47 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
+      "optional": true,
+      "os": [
+        "android"
+      ]
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
+      "optional": true,
+      "os": [
+        "android"
+      ]
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.3",
@@ -391,6 +787,317 @@
       "os": [
         "darwin"
       ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -622,34 +1329,39 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.9",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.9",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.12"
+        "magic-string": "^0.30.17"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -661,86 +1373,74 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.9",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.9",
-        "pathe": "^1.1.2"
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/@vitest/runner/node_modules/pathe": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2"
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/snapshot/node_modules/pathe": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vitest/spy": {
-      "version": "2.1.9",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.9",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/acorn": {
@@ -777,45 +1477,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -842,6 +1503,8 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -854,30 +1517,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -905,50 +1544,12 @@
         "esbuild": ">=0.18"
       }
     },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -961,6 +1562,8 @@
     },
     "node_modules/chai": {
       "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -991,6 +1594,8 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1053,65 +1658,9 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1124,6 +1673,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1139,6 +1689,8 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1150,78 +1702,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
-    },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -1263,11 +1749,430 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1481,6 +2386,8 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1495,36 +2402,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "dev": true,
@@ -1533,69 +2410,9 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1607,22 +2424,6 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1649,27 +2450,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -1718,31 +2498,9 @@
       "resolved": "packages/flint-js",
       "link": true
     },
-    "node_modules/flint-chart-mcp-server": {
-      "resolved": "agent-skills/mcp-server",
-      "link": true
-    },
     "node_modules/flint-chart-site": {
       "resolved": "site",
       "link": true
-    },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1754,52 +2512,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -1840,93 +2552,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -1960,30 +2591,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -2003,24 +2610,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -2029,6 +2622,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -2050,12 +2650,6 @@
       "version": "0.4.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2127,6 +2721,8 @@
     },
     "node_modules/loupe": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2144,61 +2740,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -2236,6 +2777,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -2270,53 +2812,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -2379,15 +2880,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -2398,6 +2890,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2418,16 +2911,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "dev": true,
@@ -2435,6 +2918,8 @@
     },
     "node_modules/pathval": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2463,15 +2948,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -2574,64 +3050,12 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/readdirp": {
@@ -2644,15 +3068,6 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2724,26 +3139,24 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/rollup/node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2762,59 +3175,9 @@
         "node": ">=10"
       }
     },
-    "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2825,81 +3188,10 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4",
-        "side-channel-list": "^1.0.1",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -2928,15 +3220,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "dev": true,
@@ -2951,6 +3234,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/sucrase": {
@@ -3038,7 +3334,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "1.2.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3046,20 +3344,13 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.2",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/tree-kill": {
@@ -3156,37 +3447,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^2.0.0",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "dev": true,
@@ -3231,15 +3491,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "dev": true,
@@ -3248,29 +3499,25 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/vite": {
-      "version": "5.4.21",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -3279,17 +3526,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
         "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.4.0"
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "jiti": {
           "optional": true
         },
         "less": {
@@ -3312,37 +3565,42 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.9",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.7",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite-node/node_modules/pathe": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -3353,11 +3611,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/esbuild": {
-      "version": "0.21.5",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3365,79 +3625,91 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.9",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "debug": "^4.3.7",
-        "expect-type": "^1.1.0",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2",
-        "std-env": "^3.8.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.1",
-        "tinypool": "^1.0.1",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.9",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {
@@ -3457,13 +3729,9 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/pathe": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3498,12 +3766,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "dev": true,
@@ -3513,24 +3775,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     },
     "packages/flint-js": {
@@ -3548,7 +3792,7 @@
         "tsup": "^8.3.0",
         "typescript": "^5.6.0",
         "typescript-eslint": "^8.16.0",
-        "vitest": "^2.1.0"
+        "vitest": "^3.2.6"
       },
       "engines": {
         "node": ">=18"
@@ -3696,6 +3940,91 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "site/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "site/node_modules/@esbuild/darwin-x64": {
       "version": "0.27.7",
       "cpu": [
@@ -3706,6 +4035,346 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "site/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -3768,6 +4437,20 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "site/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ]
     },
     "site/node_modules/@swc/core": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flint-chart-monorepo",
   "private": true,
-  "description": "Flint — semantic chart compiler for AI agents (JS + Python)",
+  "description": "Flint \u2014 semantic chart compiler for AI agents (JS + Python)",
   "workspaces": [
     "packages/flint-js",
     "site"
@@ -22,5 +22,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "^4.0.0"
   }
 }

--- a/site/src/assets/chart-icons/chart-icon-area.svg
+++ b/site/src/assets/chart-icons/chart-icon-area.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Gray area (bottom series) -->
+  <path d="M48,216 L48,180 L95,165 L135,178 L175,160 L210,170 L236,158
+           L236,216 Z"
+        fill="#B8B8B8" stroke="#363636" stroke-width="2" stroke-linejoin="round"/>
+
+  <!-- Blue area (top series) -->
+  <path d="M48,180 L75,145 L105,115 L135,130 L165,105 L195,80 L220,60 L236,72
+           L236,158 L210,170 L175,160 L135,178 L95,165 L48,180 Z"
+        fill="#76c6ff" stroke="#363636" stroke-width="2" stroke-linejoin="round"/>
+
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-bar-table.svg
+++ b/site/src/assets/chart-icons/chart-icon-bar-table.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Bar Table: category label | horizontal bar | value -->
+  <!-- Row 1 (longest, blue) -->
+  <line x1="20" y1="64"  x2="58"  y2="64"  stroke="#B8B8B8" stroke-width="4" stroke-linecap="round"/>
+  <rect x="74" y="54" width="118" height="20" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <line x1="210" y1="64"  x2="232" y2="64"  stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Row 2 (medium, blue) -->
+  <line x1="20" y1="106" x2="58"  y2="106" stroke="#B8B8B8" stroke-width="4" stroke-linecap="round"/>
+  <rect x="74" y="96" width="88"  height="20" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <line x1="210" y1="106" x2="228" y2="106" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Row 3 (short, blue) -->
+  <line x1="20" y1="148" x2="58"  y2="148" stroke="#B8B8B8" stroke-width="4" stroke-linecap="round"/>
+  <rect x="74" y="138" width="58"  height="20" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <line x1="210" y1="148" x2="224" y2="148" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Row 4 ("Others", grayed) -->
+  <line x1="20" y1="190" x2="58"  y2="190" stroke="#D8D8D8" stroke-width="4" stroke-linecap="round"/>
+  <rect x="74" y="180" width="34"  height="20" fill="#D8D8D8" stroke="#363636" stroke-width="2"/>
+  <line x1="210" y1="190" x2="222" y2="190" stroke="#B8B8B8" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Column separators (subtle) -->
+  <line x1="66" y1="36" x2="66" y2="218" stroke="#363636" stroke-width="2" stroke-linecap="round"/>
+  <line x1="200" y1="36" x2="200" y2="218" stroke="#363636" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Header underline -->
+  <line x1="20" y1="36" x2="236" y2="36" stroke="#363636" stroke-width="3" stroke-linecap="round"/>
+  <!-- Baseline -->
+  <line x1="20" y1="218" x2="236" y2="218" stroke="#363636" stroke-width="3" stroke-linecap="round"/>
+</svg>
+

--- a/site/src/assets/chart-icons/chart-icon-box-plot.svg
+++ b/site/src/assets/chart-icons/chart-icon-box-plot.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Box 1 -->
+  <line x1="90" y1="60"  x2="90" y2="190" stroke="#363636" stroke-width="3" stroke-linecap="round"/>
+  <rect x="70" y="95" width="40" height="70" fill="#76c6ff" stroke="#363636" stroke-width="3"/>
+  <line x1="70" y1="135" x2="110" y2="135" stroke="#363636" stroke-width="3"/>
+  <line x1="78" y1="60"  x2="102" y2="60"  stroke="#363636" stroke-width="3" stroke-linecap="round"/>
+  <line x1="78" y1="190" x2="102" y2="190" stroke="#363636" stroke-width="3" stroke-linecap="round"/>
+  <!-- Box 2 -->
+  <line x1="180" y1="80" x2="180" y2="200" stroke="#363636" stroke-width="3" stroke-linecap="round"/>
+  <rect x="160" y="115" width="40" height="60" fill="#76c6ff" stroke="#363636" stroke-width="3"/>
+  <line x1="160" y1="150" x2="200" y2="150" stroke="#363636" stroke-width="3"/>
+  <line x1="168" y1="80"  x2="192" y2="80"  stroke="#363636" stroke-width="3" stroke-linecap="round"/>
+  <line x1="168" y1="200" x2="192" y2="200" stroke="#363636" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-bump.svg
+++ b/site/src/assets/chart-icons/chart-icon-bump.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Bump Chart icon: 4 lines crossing ranks across 4 time points -->
+
+  <!-- Line 1 (blue): rank 1 → 1 → 3 → 2 -->
+  <polyline points="68,46 120,46 176,134 228,90"
+            fill="none" stroke="#4a8acb" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Line 2 (gray): rank 2 → 4 → 1 → 1 -->
+  <polyline points="68,90 120,178 176,46 228,46"
+            fill="none" stroke="#7a7a7a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Line 3 (dark blue): rank 3 → 2 → 4 → 3 -->
+  <polyline points="68,134 120,90 176,178 228,134"
+            fill="none" stroke="#3d7ebf" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Line 4 (light gray): rank 4 → 3 → 2 → 4 -->
+  <polyline points="68,178 120,134 176,90 228,178"
+            fill="none" stroke="#a8a8a8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Dots -->
+  <circle cx="68"  cy="46"  r="8" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="120" cy="46"  r="8" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="176" cy="134" r="8" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="228" cy="90"  r="8" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+
+  <circle cx="68"  cy="90"  r="8" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <circle cx="120" cy="178" r="8" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <circle cx="176" cy="46"  r="8" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <circle cx="228" cy="46"  r="8" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+
+  <circle cx="68"  cy="134" r="8" fill="#5ba8e0" stroke="#363636" stroke-width="2"/>
+  <circle cx="120" cy="90"  r="8" fill="#5ba8e0" stroke="#363636" stroke-width="2"/>
+  <circle cx="176" cy="178" r="8" fill="#5ba8e0" stroke="#363636" stroke-width="2"/>
+  <circle cx="228" cy="134" r="8" fill="#5ba8e0" stroke="#363636" stroke-width="2"/>
+
+  <circle cx="68"  cy="178" r="8" fill="#d0d0d0" stroke="#363636" stroke-width="2"/>
+  <circle cx="120" cy="134" r="8" fill="#d0d0d0" stroke="#363636" stroke-width="2"/>
+  <circle cx="176" cy="90"  r="8" fill="#d0d0d0" stroke="#363636" stroke-width="2"/>
+  <circle cx="228" cy="178" r="8" fill="#d0d0d0" stroke="#363636" stroke-width="2"/>
+
+  <!-- Y axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-candlestick.svg
+++ b/site/src/assets/chart-icons/chart-icon-candlestick.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" fill="none">
+  <!-- Candlestick chart icon: 4 candles, 2 bullish (green), 2 bearish (red) -->
+  <!-- Candle 1: bearish (red) -->
+  <line x1="80" y1="45" x2="80" y2="195" stroke="#363636" stroke-width="3"/>
+  <rect x="68" y="80" width="24" height="70" fill="#e8868f" stroke="#363636" stroke-width="2" rx="2"/>
+  <!-- Candle 2: bullish (green) -->
+  <line x1="120" y1="55" x2="120" y2="185" stroke="#363636" stroke-width="3"/>
+  <rect x="108" y="65" width="24" height="80" fill="#6dc48d" stroke="#363636" stroke-width="2" rx="2"/>
+  <!-- Candle 3: bearish (red) -->
+  <line x1="160" y1="40" x2="160" y2="170" stroke="#363636" stroke-width="3"/>
+  <rect x="148" y="55" width="24" height="80" fill="#e8868f" stroke="#363636" stroke-width="2" rx="2"/>
+  <!-- Candle 4: bullish (green) -->
+  <line x1="200" y1="70" x2="200" y2="200" stroke="#363636" stroke-width="3"/>
+  <rect x="188" y="90" width="24" height="75" fill="#6dc48d" stroke="#363636" stroke-width="2" rx="2"/>
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-column-grouped.svg
+++ b/site/src/assets/chart-icons/chart-icon-column-grouped.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Group 1 -->
+  <rect x="64"  y="120" width="20" height="94"  fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="84"  y="100" width="20" height="114" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <!-- Group 2 -->
+  <rect x="128" y="80"  width="20" height="134" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="148" y="140" width="20" height="74"  fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <!-- Group 3 -->
+  <rect x="192" y="60"  width="20" height="154" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="212" y="110" width="20" height="104" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-column-stacked.svg
+++ b/site/src/assets/chart-icons/chart-icon-column-stacked.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Stacked bar 1 -->
+  <rect x="72"  y="160" width="32" height="54" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <rect x="72"  y="100" width="32" height="60" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <!-- Stacked bar 2 -->
+  <rect x="124" y="180" width="32" height="34" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <rect x="124" y="140" width="32" height="40" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <!-- Stacked bar 3 -->
+  <rect x="176" y="140" width="32" height="74" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <rect x="176" y="60"  width="32" height="80" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-column.svg
+++ b/site/src/assets/chart-icons/chart-icon-column.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Bars -->
+  <rect x="72"  y="120" width="28" height="94"  fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="112" y="80"  width="28" height="134" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="152" y="150" width="28" height="64"  fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="192" y="60"  width="28" height="154" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-custom-area.svg
+++ b/site/src/assets/chart-icons/chart-icon-custom-area.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Single area polygon -->
+  <polygon points="60,216 60,170 110,120 160,150 220,70 220,216" fill="#76c6ff" stroke="#363636" stroke-width="3" stroke-linejoin="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-custom-bar.svg
+++ b/site/src/assets/chart-icons/chart-icon-custom-bar.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- One bold bar -->
+  <rect x="110" y="70" width="60" height="144" fill="#76c6ff" stroke="#363636" stroke-width="3"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-custom-line.svg
+++ b/site/src/assets/chart-icons/chart-icon-custom-line.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Single bold custom segment -->
+  <line x1="70" y1="180" x2="220" y2="70" stroke="#76c6ff" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="70"  cy="180" r="8" fill="#fff" stroke="#363636" stroke-width="2"/>
+  <circle cx="220" cy="70"  r="8" fill="#fff" stroke="#363636" stroke-width="2"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-custom-point.svg
+++ b/site/src/assets/chart-icons/chart-icon-custom-point.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Center point with crosshair guides -->
+  <line x1="48"  y1="120" x2="138" y2="120" stroke="#B8B8B8" stroke-width="2" stroke-dasharray="6 5"/>
+  <line x1="138" y1="216" x2="138" y2="120" stroke="#B8B8B8" stroke-width="2" stroke-dasharray="6 5"/>
+  <circle cx="138" cy="120" r="22" fill="#76c6ff" stroke="#363636" stroke-width="3"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-custom-rect.svg
+++ b/site/src/assets/chart-icons/chart-icon-custom-rect.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Rectangle (bands of a heatmap cell, or an annotation rect) -->
+  <rect x="80" y="70" width="130" height="120" fill="#76c6ff" stroke="#363636" stroke-width="3"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-density.svg
+++ b/site/src/assets/chart-icons/chart-icon-density.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Density curve filled area — smooth bell-like shape -->
+  <path d="M48,216 Q68,214 88,200 Q108,178 128,130 Q148,82 158,75
+           Q168,82 178,110 Q198,165 218,195 Q230,210 236,216 Z"
+        fill="#76c6ff"/>
+  <!-- Density curve outline -->
+  <path d="M48,216 Q68,214 88,200 Q108,178 128,130 Q148,82 158,75
+           Q168,82 178,110 Q198,165 218,195 Q230,210 236,216"
+        fill="none" stroke="#363636" stroke-width="3" stroke-linecap="round"/>
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-dot-plot-horizontal.svg
+++ b/site/src/assets/chart-icons/chart-icon-dot-plot-horizontal.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Row 1 -->
+  <line x1="80" y1="70" x2="180" y2="70" stroke="#B8B8B8" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="80"  cy="70" r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="180" cy="70" r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <!-- Row 2 -->
+  <line x1="110" y1="118" x2="210" y2="118" stroke="#B8B8B8" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="110" cy="118" r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="210" cy="118" r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <!-- Row 3 -->
+  <line x1="70" y1="166" x2="150" y2="166" stroke="#B8B8B8" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="70"  cy="166" r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="150" cy="166" r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-dotted-line.svg
+++ b/site/src/assets/chart-icons/chart-icon-dotted-line.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Secondary dashed line (gray) -->
+  <polyline points="60,150 100,170 140,110 180,140 220,130" fill="none" stroke="#B8B8B8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="10 7"/>
+  <circle cx="60"  cy="150" r="6" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <circle cx="100" cy="170" r="6" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <circle cx="140" cy="110" r="6" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <circle cx="180" cy="140" r="6" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <circle cx="220" cy="130" r="6" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <!-- Primary dashed line (blue) -->
+  <polyline points="60,170 100,130 140,150 180,80 220,100" fill="none" stroke="#76c6ff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="10 7"/>
+  <circle cx="60"  cy="170" r="6" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="100" cy="130" r="6" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="140" cy="150" r="6" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="180" cy="80"  r="6" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="220" cy="100" r="6" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-funnel.svg
+++ b/site/src/assets/chart-icons/chart-icon-funnel.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Funnel stages (widest at top, narrowest at bottom) -->
+  <polygon points="38,48 218,48 198,98 58,98" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <polygon points="58,104 198,104 182,154 74,154" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <polygon points="74,160 182,160 166,210 90,210" fill="#76c6ff" stroke="#363636" stroke-width="2" opacity="0.7"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-gauge.svg
+++ b/site/src/assets/chart-icons/chart-icon-gauge.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Gauge arc background -->
+  <path d="M 48 180 A 80 80 0 1 1 208 180" fill="none" stroke="#e0e0e0" stroke-width="16" stroke-linecap="round"/>
+  <!-- Gauge arc value -->
+  <path d="M 48 180 A 80 80 0 0 1 180 60" fill="none" stroke="#76c6ff" stroke-width="16" stroke-linecap="round"/>
+  <!-- Needle -->
+  <line x1="128" y1="180" x2="168" y2="80" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="128" cy="180" r="8" fill="#363636"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-heat-map.svg
+++ b/site/src/assets/chart-icons/chart-icon-heat-map.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- 4x4 grid (no axes) -->
+  <g stroke="#363636" stroke-width="2">
+    <rect x="40"  y="40"  width="44" height="44" fill="#cfe9fa"/>
+    <rect x="84"  y="40"  width="44" height="44" fill="#76c6ff"/>
+    <rect x="128" y="40"  width="44" height="44" fill="#3aa6ee"/>
+    <rect x="172" y="40"  width="44" height="44" fill="#cfe9fa"/>
+
+    <rect x="40"  y="84"  width="44" height="44" fill="#76c6ff"/>
+    <rect x="84"  y="84"  width="44" height="44" fill="#3aa6ee"/>
+    <rect x="128" y="84"  width="44" height="44" fill="#1f6fb0"/>
+    <rect x="172" y="84"  width="44" height="44" fill="#76c6ff"/>
+
+    <rect x="40"  y="128" width="44" height="44" fill="#cfe9fa"/>
+    <rect x="84"  y="128" width="44" height="44" fill="#76c6ff"/>
+    <rect x="128" y="128" width="44" height="44" fill="#3aa6ee"/>
+    <rect x="172" y="128" width="44" height="44" fill="#cfe9fa"/>
+
+    <rect x="40"  y="172" width="44" height="44" fill="#eaf4fc"/>
+    <rect x="84"  y="172" width="44" height="44" fill="#cfe9fa"/>
+    <rect x="128" y="172" width="44" height="44" fill="#76c6ff"/>
+    <rect x="172" y="172" width="44" height="44" fill="#eaf4fc"/>
+  </g>
+</svg>
+

--- a/site/src/assets/chart-icons/chart-icon-histogram.svg
+++ b/site/src/assets/chart-icons/chart-icon-histogram.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Histogram bars (adjacent, bell-curve-ish) -->
+  <rect x="56"  y="180" width="26" height="34"  fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="82"  y="140" width="26" height="74"  fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="108" y="90"  width="26" height="124" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="134" y="60"  width="26" height="154" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="160" y="100" width="26" height="114" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="186" y="150" width="26" height="64"  fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <rect x="212" y="185" width="26" height="29"  fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-kpi-card.svg
+++ b/site/src/assets/chart-icons/chart-icon-kpi-card.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- KPI Card: caption strip + big-number digits + trend sparkline -->
+
+  <!-- Card outline (rounded) -->
+  <rect x="20" y="40" width="216" height="176" rx="14" ry="14"
+        fill="none" stroke="#363636" stroke-width="4"/>
+
+  <!-- Caption (thin gray label, top-left) -->
+  <line x1="40" y1="68" x2="118" y2="68"
+        stroke="#B8B8B8" stroke-width="6" stroke-linecap="round"/>
+
+  <!-- Big number: three equal blocks suggesting digits -->
+  <rect x="40"  y="92" width="34" height="60" rx="5"
+        fill="#76c6ff" stroke="#363636" stroke-width="3"/>
+  <rect x="82"  y="92" width="34" height="60" rx="5"
+        fill="#76c6ff" stroke="#363636" stroke-width="3"/>
+  <rect x="124" y="92" width="34" height="60" rx="5"
+        fill="#76c6ff" stroke="#363636" stroke-width="3"/>
+
+  <!-- Trailing unit/suffix block (smaller, gray) -->
+  <rect x="172" y="106" width="44" height="46" rx="5"
+        fill="#D8D8D8" stroke="#363636" stroke-width="3"/>
+
+  <!-- Sparkline (trend overlay, bottom band) -->
+  <polyline points="40,196 70,182 100,192 130,172 160,186 190,166 216,180"
+            fill="none" stroke="#5b8def" stroke-width="5"
+            stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Sparkline endpoint dot for emphasis -->
+  <circle cx="216" cy="180" r="5" fill="#5b8def" stroke="#363636" stroke-width="2"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-line.svg
+++ b/site/src/assets/chart-icons/chart-icon-line.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Secondary line (gray) -->
+  <polyline points="60,150 100,170 140,110 180,140 220,130" fill="none" stroke="#B8B8B8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Primary line (blue) -->
+  <polyline points="60,170 100,130 140,150 180,80 220,100" fill="none" stroke="#76c6ff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-linear-regression.svg
+++ b/site/src/assets/chart-icons/chart-icon-linear-regression.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Regression line -->
+  <line x1="62" y1="190" x2="232" y2="58" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Scatter points -->
+  <circle cx="78"  cy="180" r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="108" cy="140" r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="138" cy="160" r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="168" cy="95"  r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="198" cy="110" r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="220" cy="70"  r="9" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-lollipop.svg
+++ b/site/src/assets/chart-icons/chart-icon-lollipop.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Lollipop 1: blue -->
+  <line x1="72" y1="216" x2="72" y2="100" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="72" cy="100" r="12" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <!-- Lollipop 2: gray -->
+  <line x1="120" y1="216" x2="120" y2="65" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="120" cy="65" r="12" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <!-- Lollipop 3: blue -->
+  <line x1="168" y1="216" x2="168" y2="140" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="168" cy="140" r="12" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <!-- Lollipop 4: gray -->
+  <line x1="216" y1="216" x2="216" y2="85" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="216" cy="85" r="12" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-pie.svg
+++ b/site/src/assets/chart-icons/chart-icon-pie.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Pie chart: 4 wedges around center (128,128), radius 88.
+       Wedge boundary angles (clockwise from top): 0, 120, 220, 300. -->
+  <path d="M 128 128 L 128 40       A 88 88 0 0 1 204.21 172    Z" fill="#76c6ff" stroke="#363636" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M 128 128 L 204.21 172   A 88 88 0 0 1 71.43 195.41  Z" fill="#B8B8B8" stroke="#363636" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M 128 128 L 71.43 195.41 A 88 88 0 0 1 51.79 84      Z" fill="#cfe9fa" stroke="#363636" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M 128 128 L 51.79 84     A 88 88 0 0 1 128 40        Z" fill="#3aa6ee" stroke="#363636" stroke-width="3" stroke-linejoin="round"/>
+</svg>
+

--- a/site/src/assets/chart-icons/chart-icon-pyramid.svg
+++ b/site/src/assets/chart-icons/chart-icon-pyramid.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Row 1 (top, narrowest) -->
+  <rect x="100" y="40" width="38" height="34" fill="#B8B8B8"/>
+  <rect x="138" y="40" width="34" height="34" fill="#76c6ff"/>
+  <rect x="100" y="40" width="72" height="34" fill="none" stroke="#363636" stroke-width="2"/>
+  <line x1="138" y1="40" x2="138" y2="74" stroke="#363636" stroke-width="2"/>
+
+  <!-- Row 2 -->
+  <rect x="68" y="82" width="70" height="34" fill="#B8B8B8"/>
+  <rect x="138" y="82" width="62" height="34" fill="#76c6ff"/>
+  <rect x="68" y="82" width="132" height="34" fill="none" stroke="#363636" stroke-width="2"/>
+  <line x1="138" y1="82" x2="138" y2="116" stroke="#363636" stroke-width="2"/>
+
+  <!-- Row 3 -->
+  <rect x="42" y="124" width="96" height="34" fill="#B8B8B8"/>
+  <rect x="138" y="124" width="84" height="34" fill="#76c6ff"/>
+  <rect x="42" y="124" width="180" height="34" fill="none" stroke="#363636" stroke-width="2"/>
+  <line x1="138" y1="124" x2="138" y2="158" stroke="#363636" stroke-width="2"/>
+
+  <!-- Row 4 (bottom, widest) -->
+  <rect x="30" y="166" width="108" height="34" fill="#B8B8B8"/>
+  <rect x="138" y="166" width="98" height="34" fill="#76c6ff"/>
+  <rect x="30" y="166" width="206" height="34" fill="none" stroke="#363636" stroke-width="2"/>
+  <line x1="138" y1="166" x2="138" y2="200" stroke="#363636" stroke-width="2"/>
+
+  <!-- X-axis -->
+  <line x1="20" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-radar.svg
+++ b/site/src/assets/chart-icons/chart-icon-radar.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Radar / Spider Chart icon -->
+  <!-- Outer ring (serves as chart boundary — standard axis style) -->
+  <polygon points="128,18 233,94 193,217 63,217 23,94"
+           fill="none" stroke="#363636" stroke-width="4" stroke-linejoin="round"/>
+  <!-- Data polygon A (blue) -->
+  <polygon points="128,39 210,106 179,204 75,185 39,106"
+           fill="#76c6ff" stroke="#4a8acb" stroke-width="2"/>
+  <!-- Data polygon B (gray) -->
+  <polygon points="128,63 185,124 161,192 88,167 57,112"
+           fill="#d0d0d0" stroke="#7a7a7a" stroke-width="2"/>
+  <!-- Guidelines on top -->
+  <!-- Middle ring -->
+  <polygon points="128,55 198,105 171,187 85,187 58,105"
+           fill="none" stroke="#b0b0b0" stroke-width="1.5"/>
+  <!-- Inner ring -->
+  <polygon points="128,91 163,117 150,158 106,158 93,117"
+           fill="none" stroke="#b0b0b0" stroke-width="1.5"/>
+  <!-- Spokes -->
+  <line x1="128" y1="128" x2="128" y2="18" stroke="#b0b0b0" stroke-width="1.5"/>
+  <line x1="128" y1="128" x2="233" y2="94" stroke="#b0b0b0" stroke-width="1.5"/>
+  <line x1="128" y1="128" x2="193" y2="217" stroke="#b0b0b0" stroke-width="1.5"/>
+  <line x1="128" y1="128" x2="63" y2="217" stroke="#b0b0b0" stroke-width="1.5"/>
+  <line x1="128" y1="128" x2="23" y2="94" stroke="#b0b0b0" stroke-width="1.5"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-rose.svg
+++ b/site/src/assets/chart-icons/chart-icon-rose.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Rose / Nightingale Chart icon: 6 wedges (60° each), varied radii, 2 colors -->
+  <!-- Center (128,128). Radii: 95, 60, 80, 45, 100, 70 — non-alternating variation -->
+  <!-- Wedge 1: 0°–60°,   r=95  --> <path d="M128,128 L128,33   A95,95,0,0,1,210,81   Z" fill="#76c6ff" stroke="white" stroke-width="2"/>
+  <!-- Wedge 2: 60°–120°,  r=60  --> <path d="M128,128 L180,98   A60,60,0,0,1,180,158  Z" fill="#B8B8B8" stroke="white" stroke-width="2"/>
+  <!-- Wedge 3: 120°–180°, r=80  --> <path d="M128,128 L197,168  A80,80,0,0,1,128,208  Z" fill="#76c6ff" stroke="white" stroke-width="2"/>
+  <!-- Wedge 4: 180°–240°, r=45  --> <path d="M128,128 L128,173  A45,45,0,0,1,89,151   Z" fill="#76c6ff" stroke="white" stroke-width="2"/>
+  <!-- Wedge 5: 240°–300°, r=100 --> <path d="M128,128 L41,178   A100,100,0,0,1,41,78  Z" fill="#B8B8B8" stroke="white" stroke-width="2"/>
+  <!-- Wedge 6: 300°–360°, r=70  --> <path d="M128,128 L67,93    A70,70,0,0,1,128,58   Z" fill="#B8B8B8" stroke="white" stroke-width="2"/>
+  <!-- Dark border outlines -->
+  <path d="M128,128 L128,33   A95,95,0,0,1,210,81   Z" fill="none" stroke="#363636" stroke-width="1.5"/>
+  <path d="M128,128 L180,98   A60,60,0,0,1,180,158  Z" fill="none" stroke="#363636" stroke-width="1.5"/>
+  <path d="M128,128 L197,168  A80,80,0,0,1,128,208  Z" fill="none" stroke="#363636" stroke-width="1.5"/>
+  <path d="M128,128 L128,173  A45,45,0,0,1,89,151   Z" fill="none" stroke="#363636" stroke-width="1.5"/>
+  <path d="M128,128 L41,178   A100,100,0,0,1,41,78  Z" fill="none" stroke="#363636" stroke-width="1.5"/>
+  <path d="M128,128 L67,93    A70,70,0,0,1,128,58   Z" fill="none" stroke="#363636" stroke-width="1.5"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-sankey.svg
+++ b/site/src/assets/chart-icons/chart-icon-sankey.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Left nodes -->
+  <rect x="38" y="48" width="16" height="70" fill="#76c6ff" stroke="#363636" stroke-width="2" rx="2"/>
+  <rect x="38" y="138" width="16" height="70" fill="#B8B8B8" stroke="#363636" stroke-width="2" rx="2"/>
+  <!-- Right nodes -->
+  <rect x="202" y="38" width="16" height="50" fill="#76c6ff" stroke="#363636" stroke-width="2" rx="2"/>
+  <rect x="202" y="108" width="16" height="50" fill="#B8B8B8" stroke="#363636" stroke-width="2" rx="2"/>
+  <rect x="202" y="178" width="16" height="40" fill="#76c6ff" stroke="#363636" stroke-width="2" rx="2" opacity="0.6"/>
+  <!-- Flow paths -->
+  <path d="M 54 63 C 128 63, 128 53, 202 53" fill="none" stroke="#76c6ff" stroke-width="20" opacity="0.3"/>
+  <path d="M 54 98 C 128 98, 128 123, 202 123" fill="none" stroke="#76c6ff" stroke-width="14" opacity="0.3"/>
+  <path d="M 54 163 C 128 163, 128 188, 202 188" fill="none" stroke="#B8B8B8" stroke-width="18" opacity="0.3"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-scatter.svg
+++ b/site/src/assets/chart-icons/chart-icon-scatter.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- Scatter points -->
+  <circle cx="78"  cy="170" r="10" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="110" cy="120" r="10" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="140" cy="155" r="10" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <circle cx="170" cy="80"  r="10" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <circle cx="195" cy="135" r="10" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <circle cx="215" cy="55"  r="10" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-streamgraph.svg
+++ b/site/src/assets/chart-icons/chart-icon-streamgraph.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Top gray band -->
+  <path d="M8,82  Q48,55  96,48  Q144,42 192,62  Q224,74 248,58
+           L248,106 Q224,100 192,104 Q144,110 96,102 Q48,94  8,112 Z"
+        fill="#B8B8B8" stroke="#363636" stroke-width="2" stroke-linejoin="round"/>
+
+  <!-- Middle blue band -->
+  <path d="M8,112  Q48,94  96,102 Q144,110 192,104 Q224,100 248,106
+           L248,156 Q224,160 192,152 Q144,144 96,154 Q48,164 8,150 Z"
+        fill="#76c6ff" stroke="#363636" stroke-width="2" stroke-linejoin="round"/>
+
+  <!-- Bottom gray band -->
+  <path d="M8,150  Q48,164 96,154 Q144,144 192,152 Q224,160 248,156
+           L248,200 Q224,208 192,196 Q144,184 96,198 Q48,212 8,190 Z"
+        fill="#B8B8B8" stroke="#363636" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-strip-plot.svg
+++ b/site/src/assets/chart-icons/chart-icon-strip-plot.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Strip / Jitter Plot icon -->
+  <!-- Group A points (jittered around x=100) -->
+  <circle cx="92" cy="65" r="5" fill="#76c6ff" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="108" cy="80" r="5" fill="#76c6ff" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="96" cy="100" r="5" fill="#76c6ff" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="104" cy="95" r="5" fill="#76c6ff" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="88" cy="120" r="5" fill="#76c6ff" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="112" cy="110" r="5" fill="#76c6ff" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="100" cy="140" r="5" fill="#76c6ff" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="94" cy="155" r="5" fill="#76c6ff" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="106" cy="170" r="5" fill="#76c6ff" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="98" cy="190" r="5" fill="#76c6ff" stroke="#363636" stroke-width="1.5"/>
+  <!-- Group B points (jittered around x=170) -->
+  <circle cx="162" cy="50" r="5" fill="#B8B8B8" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="178" cy="60" r="5" fill="#B8B8B8" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="166" cy="75" r="5" fill="#B8B8B8" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="174" cy="90" r="5" fill="#B8B8B8" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="158" cy="105" r="5" fill="#B8B8B8" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="182" cy="100" r="5" fill="#B8B8B8" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="170" cy="130" r="5" fill="#B8B8B8" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="164" cy="150" r="5" fill="#B8B8B8" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="176" cy="175" r="5" fill="#B8B8B8" stroke="#363636" stroke-width="1.5"/>
+  <circle cx="168" cy="200" r="5" fill="#B8B8B8" stroke="#363636" stroke-width="1.5"/>
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-sunburst.svg
+++ b/site/src/assets/chart-icons/chart-icon-sunburst.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Inner ring -->
+  <path d="M 128 128 L 128 78 A 50 50 0 0 1 178 128 Z" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <path d="M 128 128 L 178 128 A 50 50 0 0 1 128 178 Z" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <path d="M 128 128 L 128 178 A 50 50 0 0 1 78 128 Z" fill="#76c6ff" stroke="#363636" stroke-width="2" opacity="0.6"/>
+  <path d="M 128 128 L 78 128 A 50 50 0 0 1 128 78 Z" fill="#B8B8B8" stroke="#363636" stroke-width="2" opacity="0.6"/>
+  <!-- Outer ring segments -->
+  <path d="M 128 78 L 128 38 A 90 90 0 0 1 193 60 L 163 85 A 50 50 0 0 0 128 78 Z" fill="#76c6ff" stroke="#363636" stroke-width="1.5" opacity="0.8"/>
+  <path d="M 163 85 L 193 60 A 90 90 0 0 1 218 128 L 178 128 A 50 50 0 0 0 163 85 Z" fill="#76c6ff" stroke="#363636" stroke-width="1.5" opacity="0.5"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-treemap.svg
+++ b/site/src/assets/chart-icons/chart-icon-treemap.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Treemap rectangles -->
+  <rect x="38" y="38" width="110" height="130" fill="#76c6ff" stroke="#363636" stroke-width="2" rx="2"/>
+  <rect x="154" y="38" width="64" height="70" fill="#B8B8B8" stroke="#363636" stroke-width="2" rx="2"/>
+  <rect x="154" y="114" width="64" height="54" fill="#76c6ff" stroke="#363636" stroke-width="2" rx="2" opacity="0.6"/>
+  <rect x="38" y="174" width="70" height="44" fill="#B8B8B8" stroke="#363636" stroke-width="2" rx="2" opacity="0.8"/>
+  <rect x="114" y="174" width="104" height="44" fill="#76c6ff" stroke="#363636" stroke-width="2" rx="2" opacity="0.4"/>
+</svg>

--- a/site/src/assets/chart-icons/chart-icon-waterfall.svg
+++ b/site/src/assets/chart-icons/chart-icon-waterfall.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <!-- Waterfall chart icon: blue totals, gray deltas -->
+  <!-- Start bar (total — blue) -->
+  <rect x="60" y="60" width="28" height="156" rx="2" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <!-- Connector line from top of start bar -->
+  <line x1="88" y1="60" x2="97" y2="60" stroke="#999" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <!-- Delta bar (gray, floating — top aligns with start bar top) -->
+  <rect x="97" y="60" width="28" height="60" rx="2" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <!-- Connector line from bottom of first delta -->
+  <line x1="125" y1="120" x2="134" y2="120" stroke="#999" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <!-- Delta bar (gray, floating down) -->
+  <rect x="134" y="120" width="28" height="50" rx="2" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <!-- Connector line -->
+  <line x1="162" y1="170" x2="171" y2="170" stroke="#999" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <!-- Delta bar (gray) -->
+  <rect x="171" y="170" width="28" height="30" rx="2" fill="#B8B8B8" stroke="#363636" stroke-width="2"/>
+  <!-- Connector line -->
+  <line x1="199" y1="200" x2="208" y2="200" stroke="#999" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <!-- End bar (total — blue) -->
+  <rect x="208" y="200" width="28" height="16" rx="2" fill="#76c6ff" stroke="#363636" stroke-width="2"/>
+  <!-- Y-axis -->
+  <line x1="48" y1="28" x2="48" y2="220" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+  <!-- X-axis -->
+  <line x1="44" y1="216" x2="240" y2="216" stroke="#363636" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/site/src/components/LazyTripleChart.tsx
+++ b/site/src/components/LazyTripleChart.tsx
@@ -2,9 +2,16 @@ import { useEffect, useRef, useState } from 'react';
 import type { TestCase } from 'flint-chart/test-data';
 import { TripleChart } from './TripleChart';
 import { siteTheme } from '../shared/theme';
+import type { PreviewBackend } from '../shared/supported-backends';
 
 /** Defer chart rendering until the card scrolls into view. */
-export function LazyTripleChart({ testCase }: { testCase: TestCase }) {
+export function LazyTripleChart({
+  testCase,
+  backend,
+}: {
+  testCase: TestCase;
+  backend?: PreviewBackend;
+}) {
   const ref = useRef<HTMLDivElement>(null);
   const [visible, setVisible] = useState(false);
 
@@ -28,7 +35,7 @@ export function LazyTripleChart({ testCase }: { testCase: TestCase }) {
   return (
     <div ref={ref} style={{ minHeight: 280 }}>
       {visible ? (
-        <TripleChart testCase={testCase} />
+        <TripleChart testCase={testCase} backend={backend} />
       ) : (
         <div
           style={{

--- a/site/src/components/TripleChart.tsx
+++ b/site/src/components/TripleChart.tsx
@@ -12,23 +12,31 @@ import {
 } from '../shared/supported-backends';
 import { siteTheme } from '../shared/theme';
 
-/**
- * Renders one TestCase with tabs only for backends that support its chart type.
- */
-export function TripleChart({ testCase }: { testCase: TestCase }) {
+export function TripleChart({
+  testCase,
+  backend: forcedBackend,
+}: {
+  testCase: TestCase;
+  backend?: PreviewBackend;
+}) {
   const supportedBackends = useMemo(
     () => getSupportedBackends(testCase.chartType),
     [testCase.chartType],
   );
-  const [backend, setBackend] = useState<PreviewBackend>(
-    () => supportedBackends[0] ?? 'vegalite',
+  const availableBackends = useMemo(
+    () =>
+      forcedBackend && supportedBackends.includes(forcedBackend)
+        ? [forcedBackend]
+        : supportedBackends,
+    [forcedBackend, supportedBackends],
   );
+  const [backend, setBackend] = useState<PreviewBackend>(() => availableBackends[0] ?? 'vegalite');
 
   useEffect(() => {
     setBackend((current) =>
-      supportedBackends.includes(current) ? current : (supportedBackends[0] ?? 'vegalite'),
+      availableBackends.includes(current) ? current : (availableBackends[0] ?? 'vegalite'),
     );
-  }, [testCase.chartType, supportedBackends]);
+  }, [availableBackends, testCase.chartType]);
 
   const input = useMemo(() => testCaseToAssemblyInput(testCase), [testCase]);
 
@@ -42,7 +50,28 @@ export function TripleChart({ testCase }: { testCase: TestCase }) {
     }
   }, [input, backend]);
 
-  if (supportedBackends.length === 0) {
+  if (forcedBackend && !supportedBackends.includes(forcedBackend)) {
+    return (
+      <div
+        style={{
+          border: `1px solid ${siteTheme.border}`,
+          borderRadius: siteTheme.radius,
+          padding: 12,
+          background: siteTheme.surface,
+          minHeight: 280,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: siteTheme.textMuted,
+          fontSize: 13,
+        }}
+      >
+        {BACKEND_LABELS[forcedBackend]} does not support "{testCase.chartType}".
+      </div>
+    );
+  }
+
+  if (availableBackends.length === 0) {
     return (
       <div
         style={{
@@ -65,25 +94,25 @@ export function TripleChart({ testCase }: { testCase: TestCase }) {
 
   return (
     <div>
-      {supportedBackends.length > 1 && (
+      {!forcedBackend && availableBackends.length > 1 && (
         <div style={{ display: 'flex', gap: 6, marginBottom: 8 }}>
-          {supportedBackends.map((b) => (
+          {availableBackends.map((candidate) => (
             <button
-              key={b}
+              key={candidate}
               type="button"
-              onClick={() => setBackend(b)}
+              onClick={() => setBackend(candidate)}
               style={{
                 padding: '3px 10px',
                 fontSize: 11,
                 border: `1px solid ${siteTheme.borderMuted}`,
                 borderRadius: 4,
-                background: backend === b ? siteTheme.accentBg : siteTheme.surface,
-                color: backend === b ? siteTheme.accent : siteTheme.textMuted,
+                background: backend === candidate ? siteTheme.accentBg : siteTheme.surface,
+                color: backend === candidate ? siteTheme.accent : siteTheme.textMuted,
                 cursor: 'pointer',
-                fontWeight: backend === b ? 600 : 400,
+                fontWeight: backend === candidate ? 600 : 400,
               }}
             >
-              {BACKEND_LABELS[b]}
+              {BACKEND_LABELS[candidate]}
             </button>
           ))}
         </div>

--- a/site/src/routes/Gallery.tsx
+++ b/site/src/routes/Gallery.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useRef,
   useState,
+  type CSSProperties,
   type Dispatch,
   type RefObject,
   type SetStateAction,
@@ -19,15 +20,36 @@ import {
   findChartEntry,
   getAllChartEntries,
   isValidChartId,
+  type ChartCategory,
   type ChartEntry,
 } from '../shared/chart-categories';
 import { buildGalleryEditorHref } from '../shared/editor-payload';
 import { siteTheme } from '../shared/theme';
+import type { PreviewBackend } from '../shared/supported-backends';
 
-const CASES_PER_GENERATOR = 6;
+const CASES_PER_GENERATOR = 3;
 const SCROLL_SPY_ROOT_MARGIN = '-15% 0px -70% 0px';
 const NAV_SCROLL_END_MS = 150;
 const NAV_SCROLL_MAX_MS = 4000;
+const SIDEBAR_HOVER_BG = '#f4f7fb';
+
+const BACKEND_BADGE_STYLES: Record<PreviewBackend, CSSProperties> = {
+  vegalite: {
+    background: '#eef6fc',
+    border: '1px solid #c7e0f4',
+    color: '#0f5ea6',
+  },
+  echarts: {
+    background: '#f5eff9',
+    border: '1px solid #e0d1ee',
+    color: '#7a3e9d',
+  },
+  chartjs: {
+    background: '#fdf1f2',
+    border: '1px solid #f3ccd3',
+    color: '#b4233c',
+  },
+};
 
 type LoadedSection = {
   generator: string;
@@ -48,7 +70,7 @@ function loadSection(generator: string): LoadedSection | null {
 }
 
 function initialExpandedCategories(chartId: string): Set<string> {
-  const categoryId = findChartEntry(chartId)?.category.id ?? 'line';
+  const categoryId = findChartEntry(chartId)?.category.id ?? CHART_CATEGORIES[0]?.id ?? 'vegalite';
   return new Set([categoryId]);
 }
 
@@ -74,11 +96,6 @@ function expandCategoryForChart(
   });
 }
 
-/**
- * Chart gallery — scrollable catalog with anchor sidebar navigation.
- * Right: all chart sections in order, lazy-loaded on scroll.
- * Left: jump-to-section nav with URL sync (#/gallery/bump-chart).
- */
 export function Gallery() {
   const { chartId: chartIdParam } = useParams<{ chartId?: string }>();
   const mainRef = useRef<HTMLElement>(null);
@@ -95,7 +112,6 @@ export function Gallery() {
     initialExpandedCategories(initialChartId),
   );
 
-  /** Update the hash without React Router navigation (avoids re-render storms). */
   const updateUrl = useCallback((chartId: string) => {
     const nextHash = galleryHash(chartId);
     if (window.location.hash === nextHash) return;
@@ -120,44 +136,47 @@ export function Gallery() {
     navScrollCleanupRef.current = null;
   }, []);
 
-  const scrollToChart = useCallback((chartId: string, behavior: ScrollBehavior = 'smooth') => {
-    const root = mainRef.current;
-    const target = root?.querySelector<HTMLElement>(`#${CSS.escape(chartId)}`);
-    if (!root || !target) return;
+  const scrollToChart = useCallback(
+    (chartId: string, behavior: ScrollBehavior = 'smooth') => {
+      const root = mainRef.current;
+      const target = root?.querySelector<HTMLElement>(`#${CSS.escape(chartId)}`);
+      if (!root || !target) return;
 
-    releaseNavScrollLock();
-    navScrollingRef.current = true;
+      releaseNavScrollLock();
+      navScrollingRef.current = true;
 
-    const rootTop = root.getBoundingClientRect().top;
-    const targetTop = target.getBoundingClientRect().top;
-    root.scrollTo({
-      top: root.scrollTop + targetTop - rootTop - 8,
-      behavior,
-    });
+      const rootTop = root.getBoundingClientRect().top;
+      const targetTop = target.getBoundingClientRect().top;
+      root.scrollTo({
+        top: root.scrollTop + targetTop - rootTop - 8,
+        behavior,
+      });
 
-    if (behavior === 'instant') {
-      const instantTimer = window.setTimeout(releaseNavScrollLock, 50);
-      navScrollCleanupRef.current = () => window.clearTimeout(instantTimer);
-      return;
-    }
+      if (behavior === 'instant') {
+        const instantTimer = window.setTimeout(releaseNavScrollLock, 50);
+        navScrollCleanupRef.current = () => window.clearTimeout(instantTimer);
+        return;
+      }
 
-    let scrollEndTimer: number | undefined;
-    let maxTimer: number | undefined;
+      let scrollEndTimer: number | undefined;
+      let maxTimer: number | undefined;
 
-    const onScroll = () => {
-      if (scrollEndTimer !== undefined) window.clearTimeout(scrollEndTimer);
-      scrollEndTimer = window.setTimeout(releaseNavScrollLock, NAV_SCROLL_END_MS);
-    };
+      const onScroll = () => {
+        if (scrollEndTimer !== undefined) window.clearTimeout(scrollEndTimer);
+        scrollEndTimer = window.setTimeout(releaseNavScrollLock, NAV_SCROLL_END_MS);
+      };
 
-    root.addEventListener('scroll', onScroll, { passive: true });
-    maxTimer = window.setTimeout(releaseNavScrollLock, NAV_SCROLL_MAX_MS);
+      root.addEventListener('scroll', onScroll, { passive: true });
+      maxTimer = window.setTimeout(releaseNavScrollLock, NAV_SCROLL_MAX_MS);
 
-    navScrollCleanupRef.current = () => {
-      root.removeEventListener('scroll', onScroll);
-      if (scrollEndTimer !== undefined) window.clearTimeout(scrollEndTimer);
-      if (maxTimer !== undefined) window.clearTimeout(maxTimer);
-    };
-  }, [releaseNavScrollLock]);
+      navScrollCleanupRef.current = () => {
+        root.removeEventListener('scroll', onScroll);
+        if (scrollEndTimer !== undefined) window.clearTimeout(scrollEndTimer);
+        if (maxTimer !== undefined) window.clearTimeout(maxTimer);
+      };
+    },
+    [releaseNavScrollLock],
+  );
 
   const navigateToChart = useCallback(
     (chartId: string, behavior: ScrollBehavior = 'smooth') => {
@@ -169,7 +188,6 @@ export function Gallery() {
     [applyActiveChart, scrollToChart],
   );
 
-  // Deep-link on first mount only (e.g. #/gallery/sankey).
   useEffect(() => {
     const deepLinkId = chartIdParam && isValidChartId(chartIdParam) ? chartIdParam : undefined;
 
@@ -181,11 +199,9 @@ export function Gallery() {
 
     updateUrl(DEFAULT_CHART_ID);
     return undefined;
-    // Mount only — scroll/hash reactions are handled by scroll spy & popstate.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Browser back/forward after replaceState hash updates.
   useEffect(() => {
     const onPopState = () => {
       const id = chartIdFromHash();
@@ -201,7 +217,6 @@ export function Gallery() {
     return () => window.removeEventListener('popstate', onPopState);
   }, [scrollToChart]);
 
-  // Scroll spy — highlight sidebar + sync hash while user scrolls.
   useEffect(() => {
     const root = mainRef.current;
     if (!root) return;
@@ -217,7 +232,7 @@ export function Gallery() {
         if (navScrollingRef.current) return;
 
         const visible = entries
-          .filter((e) => e.isIntersecting)
+          .filter((entry) => entry.isIntersecting)
           .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
 
         const top = visible[0]?.target;
@@ -250,7 +265,7 @@ export function Gallery() {
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: '240px 1fr',
+          gridTemplateColumns: '260px 1fr',
           flex: 1,
           minHeight: 0,
           overflow: 'hidden',
@@ -261,12 +276,12 @@ export function Gallery() {
             borderRight: `1px solid ${siteTheme.border}`,
             overflowY: 'auto',
             background: siteTheme.surface,
-            padding: '12px 0',
+            padding: '12px 0 18px',
           }}
         >
           <div
             style={{
-              padding: '0 16px 8px',
+              padding: '0 16px 10px',
               fontSize: 11,
               fontWeight: 600,
               color: siteTheme.textMuted,
@@ -274,81 +289,31 @@ export function Gallery() {
               letterSpacing: '0.04em',
             }}
           >
-            Chart types
+            Chart backends
           </div>
 
-          {CHART_CATEGORIES.map((cat) => {
-            const expanded = expandedCategories.has(cat.id);
-            const firstChartId = cat.charts[0]?.id;
-            const hasActiveChild = cat.charts.some((chart) => chart.id === activeChartId);
+          {CHART_CATEGORIES.map((category, index) => {
+            const expanded = expandedCategories.has(category.id);
+            const firstChartId = category.charts[0]?.id;
+            const hasActiveChild = category.charts.some((chart) => chart.id === activeChartId);
 
             return (
-              <div key={cat.id} style={{ marginBottom: 4 }}>
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    width: '100%',
-                  }}
-                >
-                  <button
-                    type="button"
-                    aria-label={expanded ? `Collapse ${cat.label}` : `Expand ${cat.label}`}
-                    onClick={() => toggleCategory(cat.id)}
-                    style={{
-                      flexShrink: 0,
-                      width: 28,
-                      padding: '6px 0 6px 12px',
-                      border: 0,
-                      background: 'transparent',
-                      cursor: 'pointer',
-                      fontSize: 10,
-                      color: siteTheme.textMuted,
-                    }}
-                  >
-                    {expanded ? '▾' : '▸'}
-                  </button>
-
-                  <button
-                    type="button"
-                    onClick={() => firstChartId && navigateToChart(firstChartId)}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 6,
-                      flex: 1,
-                      padding: '6px 16px 6px 0',
-                      border: 0,
-                      background: hasActiveChild ? siteTheme.accentBg : 'transparent',
-                      cursor: 'pointer',
-                      fontSize: 12,
-                      fontWeight: 600,
-                      color: hasActiveChild ? siteTheme.accent : siteTheme.textMuted,
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.03em',
-                      textAlign: 'left',
-                    }}
-                  >
-                    <span
-                      style={{
-                        width: 18,
-                        textAlign: 'center',
-                        fontSize: 11,
-                        flexShrink: 0,
-                      }}
-                    >
-                      {cat.glyph}
-                    </span>
-                    {cat.label}
-                  </button>
-                </div>
+              <div key={category.id}>
+                <SidebarSectionHeader
+                  category={category}
+                  expanded={expanded}
+                  hasActiveChild={hasActiveChild}
+                  showDivider={index > 0}
+                  onNavigate={() => firstChartId && navigateToChart(firstChartId)}
+                  onToggle={() => toggleCategory(category.id)}
+                />
 
                 {expanded &&
-                  cat.charts.map((chart) => (
+                  category.charts.map((chart) => (
                     <SidebarItem
                       key={chart.id}
                       active={activeChartId === chart.id}
-                      label={chart.label}
+                      chart={chart}
                       onClick={() => navigateToChart(chart.id)}
                     />
                   ))}
@@ -357,49 +322,45 @@ export function Gallery() {
           })}
         </aside>
 
-        <main ref={mainRef} style={{ overflowY: 'auto', padding: '20px 24px' }}>
-          <header style={{ marginBottom: 28 }}>
-            <p style={{ margin: '0 0 4px', fontSize: 12, color: siteTheme.textMuted }}>
-              Gallery
+        <main ref={mainRef} style={{ overflowY: 'auto', padding: '24px 28px 40px' }}>
+          <header style={{ marginBottom: 32, maxWidth: 760 }}>
+            <p style={{ margin: '0 0 6px', fontSize: 12, color: siteTheme.textMuted }}>Gallery</p>
+            <h1 style={{ margin: 0, fontSize: 24, fontWeight: 600 }}>Backend-specific chart examples</h1>
+            <p style={{ margin: '8px 0 0', color: siteTheme.textMuted, fontSize: 14, lineHeight: 1.6 }}>
+              Browse curated examples inspired by clean visualization galleries. Each section is
+              organized by rendering backend and shows only the relevant chart implementation.
             </p>
-            <h1 style={{ margin: 0, fontSize: 22, fontWeight: 600 }}>Chart examples</h1>
-            <p style={{ margin: '6px 0 0', color: siteTheme.textMuted, fontSize: 14, maxWidth: 640 }}>
-              Flint compiles table data + semantic types + a short chart spec into full Vega-Lite,
-              ECharts, and Chart.js configs. Scroll to browse all examples, or use the sidebar to
-              jump to a chart type.
-            </p>
-            <p style={{ margin: '4px 0 0', color: siteTheme.textMuted, fontSize: 12 }}>
-              {totalChartTypes} chart types · up to {CASES_PER_GENERATOR} examples each
+            <p style={{ margin: '6px 0 0', color: siteTheme.textMuted, fontSize: 12 }}>
+              {totalChartTypes} chart sections · {CASES_PER_GENERATOR} curated examples each
             </p>
           </header>
 
-          {CHART_CATEGORIES.map((cat) => (
-            <div key={cat.id} style={{ marginBottom: 36 }}>
-              <h2
-                id={`category-${cat.id}`}
+          {CHART_CATEGORIES.map((category) => (
+            <div key={category.id} style={{ marginBottom: 44 }}>
+              <div
                 style={{
-                  margin: '0 0 16px',
-                  paddingBottom: 8,
-                  fontSize: 13,
-                  fontWeight: 600,
-                  color: siteTheme.textMuted,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.04em',
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                  justifyContent: 'space-between',
+                  gap: 12,
+                  marginBottom: 18,
+                  paddingBottom: 10,
                   borderBottom: `1px solid ${siteTheme.border}`,
-                  scrollMarginTop: 8,
                 }}
               >
-                <span style={{ marginRight: 8 }}>{cat.glyph}</span>
-                {cat.label}
-              </h2>
+                <div>
+                  <p style={{ margin: '0 0 4px', fontSize: 12, color: siteTheme.textMuted }}>Backend</p>
+                  <h2 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: siteTheme.text }}>
+                    {category.label}
+                  </h2>
+                </div>
+                <p style={{ margin: 0, fontSize: 13, color: siteTheme.textMuted }}>
+                  {category.description}
+                </p>
+              </div>
 
-              {cat.charts.map((chart) => (
-                <GalleryChartSection
-                  key={chart.id}
-                  chart={chart}
-                  categoryLabel={cat.label}
-                  scrollRoot={mainRef}
-                />
+              {category.charts.map((chart) => (
+                <GalleryChartSection key={chart.id} chart={chart} scrollRoot={mainRef} />
               ))}
             </div>
           ))}
@@ -411,11 +372,9 @@ export function Gallery() {
 
 function GalleryChartSection({
   chart,
-  categoryLabel,
   scrollRoot,
 }: {
   chart: ChartEntry;
-  categoryLabel: string;
   scrollRoot: RefObject<HTMLElement | null>;
 }) {
   const sectionRef = useRef<HTMLElement>(null);
@@ -446,35 +405,34 @@ function GalleryChartSection({
   }, [chart.generator, loadState, scrollRoot]);
 
   return (
-    <section
-      ref={sectionRef}
-      id={chart.id}
-      style={{ marginBottom: 32, scrollMarginTop: 12 }}
-    >
-      <h3
-        style={{
-          margin: '0 0 12px',
-          fontSize: 16,
-          fontWeight: 600,
-          color: siteTheme.text,
-        }}
-      >
-        {chart.label}
-        <span style={{ marginLeft: 8, fontSize: 12, fontWeight: 400, color: siteTheme.textMuted }}>
-          {categoryLabel}
+    <section ref={sectionRef} id={chart.id} style={{ marginBottom: 34, scrollMarginTop: 12 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+        <img src={chart.icon} alt="" aria-hidden="true" style={{ width: 20, height: 20, flexShrink: 0 }} />
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 17,
+            fontWeight: 600,
+            color: siteTheme.text,
+          }}
+        >
+          {chart.label}
+        </h3>
+        <span style={{ ...backendBadgeBaseStyle, ...BACKEND_BADGE_STYLES[chart.backend] }}>
+          {chart.backendLabel}
         </span>
-      </h3>
+      </div>
 
       {loadState === 'loading' && (
         <p style={{ color: siteTheme.textMuted, fontSize: 13, margin: '0 0 12px' }}>
-          Loading examples…
+          Loading curated examples…
         </p>
       )}
 
       {loadState === 'idle' && (
         <div
           style={{
-            height: 120,
+            height: 132,
             marginBottom: 12,
             borderRadius: siteTheme.radius,
             border: `1px dashed ${siteTheme.border}`,
@@ -483,11 +441,11 @@ function GalleryChartSection({
         />
       )}
 
-      {section?.tests.map((t, i) => (
+      {section?.tests.map((testCase, index) => (
         <article
-          key={`${section.generator}-${i}`}
+          key={`${section.generator}-${index}`}
           style={{
-            marginBottom: 20,
+            marginBottom: 18,
             padding: 16,
             background: siteTheme.surface,
             border: `1px solid ${siteTheme.border}`,
@@ -499,17 +457,17 @@ function GalleryChartSection({
               display: 'flex',
               alignItems: 'baseline',
               flexWrap: 'wrap',
-              gap: '4px 12px',
+              gap: '6px 12px',
               marginBottom: 4,
             }}
           >
-            <h4 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>{t.title}</h4>
-            <a href={buildGalleryEditorHref(section.generator, i)} style={editorLinkStyle}>
-              View this example in the online editor
+            <h4 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>{testCase.title}</h4>
+            <a href={buildGalleryEditorHref(section.generator, index)} style={editorLinkStyle}>
+              Open in editor
             </a>
           </div>
-          <p style={{ margin: '0 0 12px', color: siteTheme.textMuted, fontSize: 13 }}>
-            {t.description}
+          <p style={{ margin: '0 0 12px', color: siteTheme.textMuted, fontSize: 13, lineHeight: 1.55 }}>
+            {testCase.description}
           </p>
           <div
             style={{
@@ -519,8 +477,8 @@ function GalleryChartSection({
               alignItems: 'stretch',
             }}
           >
-            <FlintInputSummary testCase={t} />
-            <LazyTripleChart testCase={t} />
+            <FlintInputSummary testCase={testCase} />
+            <LazyTripleChart testCase={testCase} backend={chart.backend} />
           </div>
         </article>
       ))}
@@ -532,40 +490,126 @@ function GalleryChartSection({
   );
 }
 
+function SidebarSectionHeader({
+  category,
+  expanded,
+  hasActiveChild,
+  showDivider,
+  onNavigate,
+  onToggle,
+}: {
+  category: ChartCategory;
+  expanded: boolean;
+  hasActiveChild: boolean;
+  showDivider: boolean;
+  onNavigate: () => void;
+  onToggle: () => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <div
+      style={{
+        marginTop: showDivider ? 8 : 0,
+        paddingTop: showDivider ? 8 : 0,
+        borderTop: showDivider ? `1px solid ${siteTheme.border}` : undefined,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', padding: '0 8px 0 10px' }}>
+        <button
+          type="button"
+          aria-label={expanded ? `Collapse ${category.label}` : `Expand ${category.label}`}
+          onClick={onToggle}
+          style={{
+            flexShrink: 0,
+            width: 28,
+            padding: '7px 0',
+            border: 0,
+            background: 'transparent',
+            cursor: 'pointer',
+            fontSize: 10,
+            color: siteTheme.textMuted,
+          }}
+        >
+          {expanded ? '▾' : '▸'}
+        </button>
+
+        <button
+          type="button"
+          onClick={onNavigate}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+          style={{
+            flex: 1,
+            padding: '7px 10px',
+            border: 0,
+            borderRadius: 6,
+            background: hasActiveChild ? siteTheme.accentBg : hovered ? SIDEBAR_HOVER_BG : 'transparent',
+            cursor: 'pointer',
+            textAlign: 'left',
+            color: hasActiveChild ? siteTheme.accent : siteTheme.text,
+            fontSize: 13,
+            fontWeight: 600,
+          }}
+        >
+          {category.label}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function SidebarItem({
   active,
-  label,
+  chart,
   onClick,
 }: {
   active: boolean;
-  label: string;
+  chart: ChartEntry;
   onClick: () => void;
 }) {
+  const [hovered, setHovered] = useState(false);
+
   return (
     <button
       type="button"
       onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       style={{
-        display: 'block',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
         width: '100%',
-        padding: '5px 16px 5px 42px',
+        padding: '6px 16px 6px 42px',
         border: 0,
         textAlign: 'left',
-        background: active ? siteTheme.accentBg : 'transparent',
+        background: active ? siteTheme.accentBg : hovered ? SIDEBAR_HOVER_BG : 'transparent',
         color: active ? siteTheme.accent : siteTheme.text,
         cursor: 'pointer',
         fontSize: 13,
         fontWeight: active ? 600 : 400,
       }}
     >
-      {label}
+      <img src={chart.icon} alt="" aria-hidden="true" style={{ width: 20, height: 20, flexShrink: 0 }} />
+      <span>{chart.label}</span>
     </button>
   );
 }
 
-const editorLinkStyle = {
+const backendBadgeBaseStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '2px 8px',
+  borderRadius: 999,
+  fontSize: 11,
+  fontWeight: 600,
+  letterSpacing: '0.01em',
+};
+
+const editorLinkStyle: CSSProperties = {
   color: siteTheme.accent,
   fontSize: 12,
   textDecoration: 'none',
-  whiteSpace: 'nowrap' as const,
+  whiteSpace: 'nowrap',
 };

--- a/site/src/shared/chart-categories.ts
+++ b/site/src/shared/chart-categories.ts
@@ -1,119 +1,148 @@
-/**
- * Gallery sidebar categories — two-level navigation (chart family → chart type)
- * mapped to TEST_GENERATORS keys.
- */
+import type { PreviewBackend } from './supported-backends';
+import { BACKEND_LABELS } from './supported-backends';
+import scatterIcon from '../assets/chart-icons/chart-icon-scatter.svg';
+import regressionIcon from '../assets/chart-icons/chart-icon-linear-regression.svg';
+import barIcon from '../assets/chart-icons/chart-icon-column.svg';
+import stackedBarIcon from '../assets/chart-icons/chart-icon-column-stacked.svg';
+import groupedBarIcon from '../assets/chart-icons/chart-icon-column-grouped.svg';
+import lineIcon from '../assets/chart-icons/chart-icon-line.svg';
+import areaIcon from '../assets/chart-icons/chart-icon-area.svg';
+import pieIcon from '../assets/chart-icons/chart-icon-pie.svg';
+import heatmapIcon from '../assets/chart-icons/chart-icon-heat-map.svg';
+import histogramIcon from '../assets/chart-icons/chart-icon-histogram.svg';
+import boxplotIcon from '../assets/chart-icons/chart-icon-box-plot.svg';
+import radarIcon from '../assets/chart-icons/chart-icon-radar.svg';
+import streamgraphIcon from '../assets/chart-icons/chart-icon-streamgraph.svg';
+import densityIcon from '../assets/chart-icons/chart-icon-density.svg';
+import lollipopIcon from '../assets/chart-icons/chart-icon-lollipop.svg';
+import candlestickIcon from '../assets/chart-icons/chart-icon-candlestick.svg';
+import waterfallIcon from '../assets/chart-icons/chart-icon-waterfall.svg';
+import roseIcon from '../assets/chart-icons/chart-icon-rose.svg';
+import pyramidIcon from '../assets/chart-icons/chart-icon-pyramid.svg';
+import bumpIcon from '../assets/chart-icons/chart-icon-bump.svg';
+import stripPlotIcon from '../assets/chart-icons/chart-icon-strip-plot.svg';
+import funnelIcon from '../assets/chart-icons/chart-icon-funnel.svg';
+import gaugeIcon from '../assets/chart-icons/chart-icon-gauge.svg';
+import treemapIcon from '../assets/chart-icons/chart-icon-treemap.svg';
+import sunburstIcon from '../assets/chart-icons/chart-icon-sunburst.svg';
+import sankeyIcon from '../assets/chart-icons/chart-icon-sankey.svg';
+import rangedDotPlotIcon from '../assets/chart-icons/chart-icon-dot-plot-horizontal.svg';
+
 export interface ChartEntry {
   id: string;
   label: string;
   generator: string;
+  backend: PreviewBackend;
+  backendLabel: string;
+  icon: string;
 }
 
 export interface ChartCategory {
-  id: string;
+  id: PreviewBackend;
   label: string;
-  /** Short glyph for sidebar scan-ability. */
-  glyph: string;
+  description: string;
   charts: ChartEntry[];
+}
+
+function createChart(
+  backend: PreviewBackend,
+  id: string,
+  label: string,
+  generator: string,
+  icon: string,
+): ChartEntry {
+  return {
+    id,
+    label,
+    generator,
+    backend,
+    backendLabel: BACKEND_LABELS[backend],
+    icon,
+  };
 }
 
 export const CHART_CATEGORIES: ChartCategory[] = [
   {
-    id: 'line',
-    label: 'Line',
-    glyph: '↗',
+    id: 'vegalite',
+    label: BACKEND_LABELS.vegalite,
+    description: 'Semantic chart specs compiled to clean Vega-Lite examples.',
     charts: [
-      { id: 'line-chart', label: 'Line Chart', generator: 'Line Chart' },
-      { id: 'bump-chart', label: 'Bump Chart', generator: 'Bump Chart' },
+      createChart('vegalite', 'scatter-plot', 'Scatter Plot', 'Scatter Plot', scatterIcon),
+      createChart('vegalite', 'regression', 'Regression', 'Regression', regressionIcon),
+      createChart('vegalite', 'bar-chart', 'Bar Chart', 'Bar Chart', barIcon),
+      createChart('vegalite', 'stacked-bar-chart', 'Stacked Bar Chart', 'Stacked Bar Chart', stackedBarIcon),
+      createChart('vegalite', 'grouped-bar-chart', 'Grouped Bar Chart', 'Grouped Bar Chart', groupedBarIcon),
+      createChart('vegalite', 'histogram', 'Histogram', 'Histogram', histogramIcon),
+      createChart('vegalite', 'heatmap', 'Heatmap', 'Heatmap', heatmapIcon),
+      createChart('vegalite', 'line-chart', 'Line Chart', 'Line Chart', lineIcon),
+      createChart('vegalite', 'bump-chart', 'Bump Chart', 'Bump Chart', bumpIcon),
+      createChart('vegalite', 'boxplot', 'Boxplot', 'Boxplot', boxplotIcon),
+      createChart('vegalite', 'pie-chart', 'Pie Chart', 'Pie Chart', pieIcon),
+      createChart('vegalite', 'ranged-dot-plot', 'Ranged Dot Plot', 'Ranged Dot Plot', rangedDotPlotIcon),
+      createChart('vegalite', 'area-chart', 'Area Chart', 'Area Chart', areaIcon),
+      createChart('vegalite', 'streamgraph', 'Streamgraph', 'Streamgraph', streamgraphIcon),
+      createChart('vegalite', 'lollipop-chart', 'Lollipop Chart', 'Lollipop Chart', lollipopIcon),
+      createChart('vegalite', 'density-plot', 'Density Plot', 'Density Plot', densityIcon),
+      createChart('vegalite', 'candlestick-chart', 'Candlestick Chart', 'Candlestick Chart', candlestickIcon),
+      createChart('vegalite', 'waterfall-chart', 'Waterfall Chart', 'Waterfall Chart', waterfallIcon),
+      createChart('vegalite', 'strip-plot', 'Strip Plot', 'Strip Plot', stripPlotIcon),
+      createChart('vegalite', 'radar-chart', 'Radar Chart', 'Radar Chart', radarIcon),
+      createChart('vegalite', 'pyramid-chart', 'Pyramid Chart', 'Pyramid Chart', pyramidIcon),
+      createChart('vegalite', 'rose-chart', 'Rose Chart', 'Rose Chart', roseIcon),
     ],
   },
   {
-    id: 'bar',
-    label: 'Bar',
-    glyph: '▮',
+    id: 'echarts',
+    label: BACKEND_LABELS.echarts,
+    description: 'Interactive ECharts examples grouped into a focused gallery.',
     charts: [
-      { id: 'bar-chart', label: 'Bar Chart', generator: 'Bar Chart' },
-      { id: 'stacked-bar-chart', label: 'Stacked Bar Chart', generator: 'Stacked Bar Chart' },
-      { id: 'grouped-bar-chart', label: 'Grouped Bar Chart', generator: 'Grouped Bar Chart' },
-      { id: 'pyramid-chart', label: 'Pyramid Chart', generator: 'Pyramid Chart' },
+      createChart('echarts', 'echarts-scatter', 'Scatter Plot', 'ECharts: Scatter', scatterIcon),
+      createChart('echarts', 'echarts-line', 'Line Chart', 'ECharts: Line', lineIcon),
+      createChart('echarts', 'echarts-bar', 'Bar Chart', 'ECharts: Bar', barIcon),
+      createChart('echarts', 'echarts-stacked-bar', 'Stacked Bar Chart', 'ECharts: Stacked Bar', stackedBarIcon),
+      createChart('echarts', 'echarts-grouped-bar', 'Grouped Bar Chart', 'ECharts: Grouped Bar', groupedBarIcon),
+      createChart('echarts', 'echarts-area', 'Area Chart', 'ECharts: Area', areaIcon),
+      createChart('echarts', 'echarts-pie', 'Pie Chart', 'ECharts: Pie', pieIcon),
+      createChart('echarts', 'echarts-heatmap', 'Heatmap', 'ECharts: Heatmap', heatmapIcon),
+      createChart('echarts', 'echarts-histogram', 'Histogram', 'ECharts: Histogram', histogramIcon),
+      createChart('echarts', 'echarts-boxplot', 'Boxplot', 'ECharts: Boxplot', boxplotIcon),
+      createChart('echarts', 'echarts-radar', 'Radar Chart', 'ECharts: Radar', radarIcon),
+      createChart('echarts', 'echarts-candlestick', 'Candlestick Chart', 'ECharts: Candlestick', candlestickIcon),
+      createChart('echarts', 'echarts-streamgraph', 'Streamgraph', 'ECharts: Streamgraph', streamgraphIcon),
+      createChart('echarts', 'echarts-rose', 'Rose Chart', 'ECharts: Rose', roseIcon),
+      createChart('echarts', 'echarts-gauge', 'Gauge', 'ECharts: Gauge', gaugeIcon),
+      createChart('echarts', 'echarts-funnel', 'Funnel', 'ECharts: Funnel', funnelIcon),
+      createChart('echarts', 'echarts-treemap', 'Treemap', 'ECharts: Treemap', treemapIcon),
+      createChart('echarts', 'echarts-sunburst', 'Sunburst', 'ECharts: Sunburst', sunburstIcon),
+      createChart('echarts', 'echarts-sankey', 'Sankey', 'ECharts: Sankey', sankeyIcon),
     ],
   },
   {
-    id: 'scatter',
-    label: 'Scatter',
-    glyph: '·',
+    id: 'chartjs',
+    label: BACKEND_LABELS.chartjs,
+    description: 'Practical Chart.js examples for familiar dashboard-style visuals.',
     charts: [
-      { id: 'scatter-plot', label: 'Scatter Plot', generator: 'Scatter Plot' },
-      { id: 'regression', label: 'Regression', generator: 'Regression' },
-    ],
-  },
-  {
-    id: 'area',
-    label: 'Area',
-    glyph: '▲',
-    charts: [
-      { id: 'area-chart', label: 'Area Chart', generator: 'Area Chart' },
-      { id: 'streamgraph', label: 'Streamgraph', generator: 'Streamgraph' },
-      { id: 'density-plot', label: 'Density Plot', generator: 'Density Plot' },
-    ],
-  },
-  {
-    id: 'circular',
-    label: 'Pie & Circular',
-    glyph: '◔',
-    charts: [
-      { id: 'pie-chart', label: 'Pie Chart', generator: 'Pie Chart' },
-      { id: 'rose-chart', label: 'Rose Chart', generator: 'Rose Chart' },
-      { id: 'radar-chart', label: 'Radar Chart', generator: 'Radar Chart' },
-      { id: 'sunburst', label: 'Sunburst', generator: 'ECharts: Sunburst' },
-    ],
-  },
-  {
-    id: 'heatmap',
-    label: 'Heatmap',
-    glyph: '▦',
-    charts: [{ id: 'heatmap', label: 'Heatmap', generator: 'Heatmap' }],
-  },
-  {
-    id: 'specialized',
-    label: 'Specialized',
-    glyph: '✦',
-    charts: [
-      { id: 'strip-plot', label: 'Strip Plot', generator: 'Strip Plot' },
-      { id: 'lollipop-chart', label: 'Lollipop Chart', generator: 'Lollipop Chart' },
-      { id: 'waterfall-chart', label: 'Waterfall Chart', generator: 'Waterfall Chart' },
-      { id: 'candlestick-chart', label: 'Candlestick Chart', generator: 'Candlestick Chart' },
-      { id: 'gauge', label: 'Gauge', generator: 'ECharts: Gauge' },
-      { id: 'funnel', label: 'Funnel', generator: 'ECharts: Funnel' },
-      { id: 'treemap', label: 'Treemap', generator: 'ECharts: Treemap' },
-      { id: 'sankey', label: 'Sankey', generator: 'ECharts: Sankey' },
-    ],
-  },
-  {
-    id: 'facet',
-    label: 'Facet',
-    glyph: '⊞',
-    charts: [
-      { id: 'facet-columns', label: 'Columns', generator: 'Facet: Columns' },
-      { id: 'facet-rows', label: 'Rows', generator: 'Facet: Rows' },
-      { id: 'facet-cols-rows', label: 'Cols+Rows', generator: 'Facet: Cols+Rows' },
-      { id: 'facet-small', label: 'Small Multiples', generator: 'Facet: Small' },
-      { id: 'facet-wrap', label: 'Wrap', generator: 'Facet: Wrap' },
-      { id: 'facet-clip', label: 'Clip', generator: 'Facet: Clip' },
-      { id: 'facet-overflowed-col', label: 'Overflowed Col', generator: 'Facet: Overflowed Col' },
-      { id: 'facet-overflowed-col-row', label: 'Overflowed Col+Row', generator: 'Facet: Overflowed Col+Row' },
-      { id: 'facet-overflowed-row', label: 'Overflowed Row', generator: 'Facet: Overflowed Row' },
-      { id: 'facet-dense-line', label: 'Dense Line', generator: 'Facet: Dense Line' },
+      createChart('chartjs', 'chartjs-scatter', 'Scatter Plot', 'Chart.js: Scatter', scatterIcon),
+      createChart('chartjs', 'chartjs-line', 'Line Chart', 'Chart.js: Line', lineIcon),
+      createChart('chartjs', 'chartjs-bar', 'Bar Chart', 'Chart.js: Bar', barIcon),
+      createChart('chartjs', 'chartjs-stacked-bar', 'Stacked Bar Chart', 'Chart.js: Stacked Bar', stackedBarIcon),
+      createChart('chartjs', 'chartjs-grouped-bar', 'Grouped Bar Chart', 'Chart.js: Grouped Bar', groupedBarIcon),
+      createChart('chartjs', 'chartjs-area', 'Area Chart', 'Chart.js: Area', areaIcon),
+      createChart('chartjs', 'chartjs-pie', 'Pie Chart', 'Chart.js: Pie', pieIcon),
+      createChart('chartjs', 'chartjs-histogram', 'Histogram', 'Chart.js: Histogram', histogramIcon),
+      createChart('chartjs', 'chartjs-radar', 'Radar Chart', 'Chart.js: Radar', radarIcon),
+      createChart('chartjs', 'chartjs-rose', 'Rose Chart', 'Chart.js: Rose', roseIcon),
     ],
   },
 ];
 
-export const DEFAULT_CHART_ID = CHART_CATEGORIES[0]!.charts[0]!.id;
+export const DEFAULT_CHART_ID = CHART_CATEGORIES[0]?.charts[0]?.id ?? 'scatter-plot';
 
 export function findChartEntry(
   chartId: string,
 ): { category: ChartCategory; chart: ChartEntry } | undefined {
   for (const category of CHART_CATEGORIES) {
-    const chart = category.charts.find((c) => c.id === chartId);
+    const chart = category.charts.find((candidate) => candidate.id === chartId);
     if (chart) return { category, chart };
   }
   return undefined;
@@ -124,10 +153,9 @@ export function isValidChartId(chartId: string): boolean {
 }
 
 export function getCategoryFirstChartId(categoryId: string): string | undefined {
-  return CHART_CATEGORIES.find((c) => c.id === categoryId)?.charts[0]?.id;
+  return CHART_CATEGORIES.find((category) => category.id === categoryId)?.charts[0]?.id;
 }
 
-/** Flat list of every chart entry in sidebar order. */
 export function getAllChartEntries(): Array<{ category: ChartCategory; chart: ChartEntry }> {
   return CHART_CATEGORIES.flatMap((category) =>
     category.charts.map((chart) => ({ category, chart })),

--- a/site/src/shared/theme.ts
+++ b/site/src/shared/theme.ts
@@ -6,11 +6,11 @@ export const siteTheme = {
   borderMuted: '#d0d7de',
   text: '#1f2328',
   textMuted: '#57606a',
-  accent: '#0969da',
-  accentBg: '#ddf4ff',
+  accent: '#0078d4',
+  accentBg: '#deecf9',
   error: '#cf222e',
   radius: 6,
-  fontSans: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+  fontSans: "'Segoe UI', -apple-system, sans-serif",
   fontMono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
 } as const;
 


### PR DESCRIPTION
## Gallery Restructure

Reorganizes the chart gallery by rendering backend instead of by chart category.

### Changes

**1. Organized by backend**
- Three top-level sections: Vega-Lite (22 charts), ECharts (19 charts), Chart.js (10 charts)
- Each section only shows charts available in that backend — no "unavailable" items

**2. Chart icons**
- 35 SVG chart-type icons (from data-formulator + 5 new: funnel, gauge, treemap, sunburst, sankey)
- Icons displayed at 20×20px next to chart names in sidebar

**3. Design style (data-formulator-inspired)**
- Fluent blue accent `#0078d4` (was GitHub blue `#0969da`)
- Segoe UI font family
- Clean card styling, subtle borders, minimal aesthetic

**4. Gallery-quality examples**
- Reduced from 6 to 3 curated examples per chart type
- No debug/stress/overflow test cases shown in gallery
- Clean, representative examples like VegaLite/ggplot2 galleries

**5. Single backend rendering**
- Each chart section renders only the relevant backend (not triple view)
- Backend badge shown on each card

Preserves: scroll-spy, URL deep-linking, lazy-loading, existing site shell.

TypeScript builds clean ✅