### PR TITLE
Prepare 0.1.2 patch release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: Use npm 11 for trusted publishing
         run: npm install -g npm@11
@@ -76,6 +75,21 @@ jobs:
 
       - name: Publish flint-chart-mcp
         run: npm publish --workspace packages/flint-mcp --access public
+
+      - name: Wait for flint-chart-mcp to resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in {1..30}; do
+            if npm view "flint-chart-mcp@${mcp_version}" version >/dev/null 2>&1; then
+              npm view "flint-chart-mcp@${mcp_version}" version
+              exit 0
+            fi
+            echo "Waiting for flint-chart-mcp@${mcp_version} to be visible on npm (${attempt}/30)..."
+            sleep 10
+          done
+          echo "::error::flint-chart-mcp@${mcp_version} did not become visible on npm in time."
+          exit 1
 
       - name: Verify published packages
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9911,7 +9911,7 @@
     },
     "packages/flint-js": {
       "name": "flint-chart",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.14.10",
@@ -9952,7 +9952,7 @@
     },
     "packages/flint-mcp": {
       "name": "flint-chart-mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.4",
@@ -9962,7 +9962,7 @@
         "canvas": "^3.2.3",
         "chart.js": "^4.4.0",
         "echarts": "^6.0.0",
-        "flint-chart": "^0.1.1",
+        "flint-chart": "^0.1.2",
         "vega": "^6.0.0",
         "vega-interpreter": "^2.2.1",
         "vega-lite": "^6.0.0",

--- a/packages/flint-js/package.json
+++ b/packages/flint-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flint-chart",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Semantic-level visualization library that compiles data + semantic types into chart specs for Vega-Lite, ECharts, and Chart.js.",
   "keywords": [
     "visualization",

--- a/packages/flint-mcp/package.json
+++ b/packages/flint-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flint-chart-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Model Context Protocol server for Flint — compile, validate, and render semantic chart specs to Vega-Lite, ECharts, or Chart.js artifacts (PNG/SVG) in-process.",
   "keywords": [
     "mcp",
@@ -69,7 +69,7 @@
     "canvas": "^3.2.3",
     "chart.js": "^4.4.0",
     "echarts": "^6.0.0",
-    "flint-chart": "^0.1.1",
+    "flint-chart": "^0.1.2",
     "vega": "^6.0.0",
     "vega-interpreter": "^2.2.1",
     "vega-lite": "^6.0.0",

--- a/packages/flint-mcp/src/render/assemble.ts
+++ b/packages/flint-mcp/src/render/assemble.ts
@@ -6,7 +6,12 @@ import {
   assembleECharts,
   assembleChartjs,
   type ChartAssemblyInput,
+  type ChartEncoding,
+  type ChartTemplateDef,
   type ChartWarning,
+  vlGetTemplateDef,
+  ecGetTemplateDef,
+  cjsGetTemplateDef,
 } from 'flint-chart';
 import {
   resolveDataSource,
@@ -27,6 +32,12 @@ const ASSEMBLERS: Record<
   vegalite: assembleVegaLite,
   echarts: assembleECharts,
   chartjs: assembleChartjs,
+};
+
+const TEMPLATE_LOOKUP: Record<RenderBackend, (chartType: string) => ChartTemplateDef | undefined> = {
+  vegalite: vlGetTemplateDef,
+  echarts: ecGetTemplateDef,
+  chartjs: cjsGetTemplateDef,
 };
 
 export interface AssembleResult {
@@ -56,6 +67,7 @@ export function validateInput(
 export function prepareInput(
   input: ChartAssemblyInput,
   options: DataSourceOptions = {},
+  backend?: RenderBackend,
 ): ChartAssemblyInput {
   if (input == null || typeof input !== 'object') {
     throw new Error('input must be a ChartAssemblyInput object');
@@ -82,6 +94,10 @@ export function prepareInput(
   if (cs == null || typeof cs !== 'object' || typeof cs.chartType !== 'string') {
     throw new Error('input.chart_spec.chartType is required');
   }
+  if (resolvedData.values.length === 0) {
+    throw new Error('input.data.values must contain at least one row');
+  }
+  validateChartSpec(cs, resolvedData.values, backend);
   for (const field of ['baseSize', 'canvasSize'] as const) {
     const size = cs[field];
     if (size) {
@@ -98,6 +114,77 @@ export function prepareInput(
   return resolvedInput;
 }
 
+function validateChartSpec(cs: any, rows: Record<string, unknown>[], backend?: RenderBackend): void {
+  const encodings = cs.encodings;
+  if (encodings == null || typeof encodings !== 'object' || Array.isArray(encodings)) {
+    throw new Error('input.chart_spec.encodings must be a channel-to-encoding object');
+  }
+
+  const entries = Object.entries(encodings);
+  if (entries.length === 0) {
+    throw new Error('input.chart_spec.encodings must bind at least one channel');
+  }
+
+  const template = backend ? TEMPLATE_LOOKUP[backend]?.(cs.chartType) : undefined;
+  if (backend && !template) return;
+
+  if (template) {
+    const allowed = new Set(template.channels ?? []);
+    for (const [channel] of entries) {
+      if (!allowed.has(channel)) {
+        throw new Error(
+          `chart_spec.encodings.${channel} is not supported by ${cs.chartType} for ${backend}`,
+        );
+      }
+    }
+
+    for (const channel of requiredChannels(template)) {
+      if (!hasEncodingBinding(encodings[channel])) {
+        throw new Error(`chart_spec.encodings.${channel} is required for ${cs.chartType}`);
+      }
+    }
+  }
+
+  const dataFields = new Set(rows.flatMap((row) => Object.keys(row)));
+  for (const [channel, encoding] of entries) {
+    for (const field of encodingFields(encoding)) {
+      if (!dataFields.has(field)) {
+        throw new Error(`chart_spec.encodings.${channel}.field "${field}" does not exist in data.values`);
+      }
+    }
+  }
+}
+
+function requiredChannels(template: ChartTemplateDef): string[] {
+  const channels = template.channels ?? [];
+  if (channels.includes('x') && channels.includes('y')) return ['x', 'y'];
+  if (template.chart === 'KPI Card') return ['metric', 'value'];
+  return [];
+}
+
+function hasEncodingBinding(value: unknown): boolean {
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.some(hasEncodingBinding);
+  if (value && typeof value === 'object') {
+    const encoding = value as ChartEncoding;
+    return (
+      (typeof encoding.field === 'string' && encoding.field.trim().length > 0) ||
+      encoding.aggregate === 'count'
+    );
+  }
+  return false;
+}
+
+function encodingFields(value: unknown): string[] {
+  if (typeof value === 'string') return value.trim() ? [value] : [];
+  if (Array.isArray(value)) return value.flatMap(encodingFields);
+  if (value && typeof value === 'object') {
+    const field = (value as ChartEncoding).field;
+    return typeof field === 'string' && field.trim() ? [field] : [];
+  }
+  return [];
+}
+
 /**
  * Assemble a Flint spec for one backend and split out Flint's private metadata
  * (`_warnings`, `_width`, `_height`). The returned `spec` is left untouched so
@@ -112,7 +199,7 @@ export function assembleForBackend(
   if (!assemble) {
     throw new Error(`unknown backend: ${backend}`);
   }
-  const resolvedInput = prepareInput(input, options);
+  const resolvedInput = prepareInput(input, options, backend);
   const spec = assemble(resolvedInput);
   const warnings: ChartWarning[] = Array.isArray(spec?._warnings)
     ? spec._warnings

--- a/packages/flint-mcp/src/render/vegalite.ts
+++ b/packages/flint-mcp/src/render/vegalite.ts
@@ -8,6 +8,13 @@ import type { RenderResult, RenderFormat } from './types.js';
 const DEFAULT_W = 400;
 const DEFAULT_H = 320;
 
+function readSvgDimension(svg: string, attr: 'width' | 'height'): number | undefined {
+  const match = svg.match(new RegExp(`<svg[^>]*\\s${attr}="([^\"]+)"`, 'i'));
+  if (!match) return undefined;
+  const value = Number.parseFloat(match[1]);
+  return Number.isFinite(value) && value > 0 ? Math.round(value) : undefined;
+}
+
 export interface VegaLiteRenderArgs {
   format: RenderFormat;
   scale: number;
@@ -49,9 +56,10 @@ export async function renderVegaLite(
   const svg = await view.toSVG();
   view.finalize();
 
-  // Vega reports the rendered content box; fall back to the assembler size.
-  const width = Math.round((view.width?.() as number) || args.width || DEFAULT_W);
-  const height = Math.round((view.height?.() as number) || args.height || DEFAULT_H);
+  // Vega's View width/height report the content box, excluding axes/legends.
+  // The root SVG dimensions are the actual artifact dimensions used by resvg.
+  const width = readSvgDimension(svg, 'width') ?? args.width ?? DEFAULT_W;
+  const height = readSvgDimension(svg, 'height') ?? args.height ?? DEFAULT_H;
 
   return svgToResult(svg, {
     backend: 'vegalite',

--- a/packages/flint-mcp/src/server.ts
+++ b/packages/flint-mcp/src/server.ts
@@ -24,7 +24,9 @@ import {
 } from './tools/schemas.js';
 
 /** Package version, kept in lockstep with the npm release. */
-export const VERSION = '0.1.0';
+export const VERSION = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+).version as string;
 
 export const AGENT_SKILL_RESOURCE_URI = 'flint://agent-skill';
 const AGENT_SKILL_ASSET = new URL('../assets/flint-chart-author.SKILL.md', import.meta.url);

--- a/packages/flint-mcp/tests/render.test.ts
+++ b/packages/flint-mcp/tests/render.test.ts
@@ -24,6 +24,10 @@ const sales: ChartAssemblyInput = {
 
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
 
+function pngDimensions(buffer: Buffer): { width: number; height: number } {
+  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+}
+
 describe('renderChart → PNG', () => {
   for (const backend of ['vegalite', 'echarts', 'chartjs'] as const) {
     it(`renders a ${backend} bar chart to a non-trivial PNG`, async () => {
@@ -33,6 +37,7 @@ describe('renderChart → PNG', () => {
       expect(res.buffer).toBeInstanceOf(Buffer);
       expect(res.buffer!.length).toBeGreaterThan(1000);
       expect(res.buffer!.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+      expect(pngDimensions(res.buffer!)).toEqual({ width: res.width, height: res.height });
       expect(res.base64).toBeTruthy();
       expect(Array.isArray(res.warnings)).toBe(true);
     });

--- a/packages/flint-mcp/tests/server.test.ts
+++ b/packages/flint-mcp/tests/server.test.ts
@@ -116,6 +116,25 @@ describe('MCP server', () => {
     expect(payload.valid).toBe(true);
   });
 
+  it('validate_chart rejects malformed specs before assembly', async () => {
+    for (const chart_spec of [
+      { ...barChart.chart_spec, encodings: {} },
+      { ...barChart.chart_spec, encodings: { x: { field: 'missing' }, y: { field: 'revenue' } } },
+      {
+        ...barChart.chart_spec,
+        encodings: { x: { field: 'region' }, y: { field: 'revenue' }, banana: { field: 'region' } },
+      },
+    ]) {
+      const res: any = await client.callTool({
+        name: 'validate_chart',
+        arguments: { ...barChart, chart_spec, backend: 'vegalite' },
+      });
+      const payload = JSON.parse(res.content[0].text);
+      expect(payload.valid).toBe(false);
+      expect(payload.errors.length).toBeGreaterThan(0);
+    }
+  });
+
   it('list_chart_types enumerates chart types per backend', async () => {
     const res: any = await client.callTool({
       name: 'list_chart_types',

--- a/packages/flint-mcp/ui/src/FlintApp.tsx
+++ b/packages/flint-mcp/ui/src/FlintApp.tsx
@@ -23,6 +23,8 @@ import {
   type ResolvedAction,
 } from './options';
 
+declare const __FLINT_MCP_VERSION__: string;
+
 /** Control descriptor shared by chart properties and encoding actions. */
 type ControlSpec =
   | { type: 'continuous'; min: number; max: number; step?: number }
@@ -384,7 +386,7 @@ export function FlintApp() {
   const [hostContext, setHostContext] = useState<McpUiHostContext | undefined>();
 
   const { app, error } = useApp({
-    appInfo: { name: 'Flint Chart', version: '0.1.0' },
+    appInfo: { name: 'Flint Chart', version: __FLINT_MCP_VERSION__ },
     capabilities: {},
     autoResize: true,
     onAppCreated: (app) => {

--- a/packages/flint-mcp/ui/vite.config.ts
+++ b/packages/flint-mcp/ui/vite.config.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
@@ -8,12 +9,18 @@ import react from '@vitejs/plugin-react';
 import { viteSingleFile } from 'vite-plugin-singlefile';
 
 const root = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(readFileSync(resolve(root, '../package.json'), 'utf8')) as {
+  version: string;
+};
 
 // Bundle the entire app (React + Flint + Vega) into one self-contained HTML so
 // the MCP App resource needs no network access and renders fully client-side.
 export default defineConfig({
   root,
   plugins: [react(), viteSingleFile()],
+  define: {
+    __FLINT_MCP_VERSION__: JSON.stringify(packageJson.version),
+  },
   // The ext-apps React hooks (useApp) and the app share one React instance.
   // Without deduping, the bundle pulls in a second React copy whose hook
   // dispatcher is never set, so useState() throws at runtime.

--- a/site/src/components/ResizeSplit.tsx
+++ b/site/src/components/ResizeSplit.tsx
@@ -5,6 +5,7 @@ type SplitDirection = 'horizontal' | 'vertical';
 
 interface ResizeSplitProps {
   direction: SplitDirection;
+  className?: string;
   /** Initial size of the first pane, as a percentage (0–100). */
   initialRatio?: number;
   minFirst?: number;
@@ -35,6 +36,7 @@ function clampRatio(value: number, minFirst: number, minSecond: number) {
  */
 export function ResizeSplit({
   direction,
+  className,
   initialRatio = 50,
   minFirst = 15,
   minSecond = 15,
@@ -104,6 +106,7 @@ export function ResizeSplit({
   return (
     <div
       ref={containerRef}
+      className={className}
       style={{
         display: 'flex',
         flexDirection: isHorizontal ? 'row' : 'column',

--- a/site/src/components/SiteShell.tsx
+++ b/site/src/components/SiteShell.tsx
@@ -30,11 +30,13 @@ export function SiteNavBar(_props: { flush?: boolean } = {}) {
 
   return (
     <header
+      className="site-nav-bar"
       style={{
         display: 'flex',
         alignItems: 'center',
         gap: 20,
         width: '100%',
+        boxSizing: 'border-box',
         maxWidth: CONTENT_MAX_WIDTH,
         margin: '0 auto',
         padding: '0 20px',
@@ -45,7 +47,7 @@ export function SiteNavBar(_props: { flush?: boolean } = {}) {
     >
       <BrandLink />
 
-      <nav style={{ display: 'flex', alignItems: 'center', gap: 16, flex: 1 }}>
+      <nav className="site-nav-scroll" style={{ display: 'flex', alignItems: 'center', gap: 16, flex: 1, minWidth: 0 }}>
         <NavLink to="/" active={pathname === '/'}>
           About
         </NavLink>
@@ -70,7 +72,7 @@ export function SiteNavBar(_props: { flush?: boolean } = {}) {
         <NavLinkExternal href={`${GITHUB_REPO}#ecosystem`} label="Ecosystem" /> */}
       </nav>
 
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <div className="site-nav-actions" style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
         <GitHubLink />
       </div>
     </header>

--- a/site/src/components/SpecPipelineFigure.tsx
+++ b/site/src/components/SpecPipelineFigure.tsx
@@ -11,47 +11,53 @@ const HAIRLINE = 'rgba(0, 0, 0, 0.12)';
 export const FIGURE_CANVAS = { width: 720, height: 500 } as const;
 const OMITTED = '__omitted__';
 const MAX_COMPILED_SPEC_LINES = 38;
+const MAX_MOBILE_COMPILED_SPEC_LINES = 24;
+type FigureOrientation = 'horizontal' | 'vertical';
 
 /**
  * Static three-panel pipeline figure: compact Flint spec → compiled
  * backend-native (Vega-Lite) spec → rendered chart. Rendered at its designed
  * size; callers can wrap it in {@link ScaleToFit} to fit a narrower column.
  */
-export function SpecPipelineFigure() {
+export function SpecPipelineFigure({ orientation = 'horizontal' }: { orientation?: FigureOrientation }) {
+  const vertical = orientation === 'vertical';
   const testCase = useMemo(() => TEST_GENERATORS['Omni: Heatmap']()[0], []);
   const specText = useMemo(() => {
     const summary = testCaseToFlintSummary(testCase);
     const body = JSON.stringify({ data: '{...}', ...summary }, null, 2);
     return body.replace('"{...}"', '{...}');
   }, [testCase]);
-  const compiledSpecText = useMemo(() => buildCompiledSpecExcerpt(testCase), [testCase]);
+  const compiledSpecText = useMemo(
+    () => buildCompiledSpecExcerpt(testCase, vertical ? MAX_MOBILE_COMPILED_SPEC_LINES : MAX_COMPILED_SPEC_LINES),
+    [testCase, vertical],
+  );
 
   return (
-    <section className="dev-playground-spec-figure" style={figureStyle}>
-      <div style={paneStyle}>
-        <div style={paneHeaderStyle}>
-          <span style={paneTitleStyle}>Flint spec</span>
+    <section className={`dev-playground-spec-figure dev-playground-spec-figure--${orientation}`} style={vertical ? verticalFigureStyle : figureStyle}>
+      <div style={vertical ? verticalPaneStyle : paneStyle}>
+        <div style={vertical ? verticalPaneHeaderStyle : paneHeaderStyle}>
+          <span style={vertical ? verticalPaneTitleStyle : paneTitleStyle}>Flint spec</span>
         </div>
-        <pre style={specPreStyle}>{specText}</pre>
+        <pre style={vertical ? verticalSpecPreStyle : specPreStyle}>{specText}</pre>
       </div>
 
-      <ArrowColumn />
+      <ArrowColumn orientation={orientation} />
 
-      <div style={borderedPaneStyle}>
-        <div style={chartHeaderStyle}>
-          <span style={paneTitleStyle}>Compiled spec <span style={backendLabelStyle}>(Vega-Lite)</span></span>
+      <div style={vertical ? verticalBorderedPaneStyle : borderedPaneStyle}>
+        <div style={vertical ? verticalChartHeaderStyle : chartHeaderStyle}>
+          <span style={vertical ? verticalPaneTitleStyle : paneTitleStyle}>Compiled spec <span style={backendLabelStyle}>(Vega-Lite)</span></span>
         </div>
-        <pre style={compiledPreStyle}>{compiledSpecText}</pre>
+        <pre style={vertical ? verticalCompiledPreStyle : compiledPreStyle}>{compiledSpecText}</pre>
       </div>
 
-      <ArrowColumn />
+      <ArrowColumn orientation={orientation} />
 
-      <div style={borderedVisualPaneStyle}>
-        <div style={paneHeaderStyle}>
-          <span style={paneTitleStyle}>Visualization</span>
+      <div style={vertical ? verticalBorderedVisualPaneStyle : borderedVisualPaneStyle}>
+        <div style={vertical ? verticalPaneHeaderStyle : paneHeaderStyle}>
+          <span style={vertical ? verticalPaneTitleStyle : paneTitleStyle}>Visualization</span>
         </div>
-        <div style={chartBodyStyle}>
-          <ScaleToFit height={560} minHeight={520} padding={0} adaptiveHeight>
+        <div style={vertical ? verticalChartBodyStyle : chartBodyStyle}>
+          <ScaleToFit height={vertical ? 360 : 560} minHeight={vertical ? 260 : 520} padding={0} adaptiveHeight>
             <WallChart testCase={testCase} backend="vegalite" canvasSize={FIGURE_CANVAS} />
           </ScaleToFit>
         </div>
@@ -60,7 +66,7 @@ export function SpecPipelineFigure() {
   );
 }
 
-function buildCompiledSpecExcerpt(testCase: TestCase): string {
+function buildCompiledSpecExcerpt(testCase: TestCase, maxLines: number): string {
   const spec = assembleVegaLite(testCaseToAssemblyInput(testCase, FIGURE_CANVAS));
   const excerpt = {
     data: spec.data ? OMITTED : undefined,
@@ -71,13 +77,13 @@ function buildCompiledSpecExcerpt(testCase: TestCase): string {
     ...(spec.config ? { config: compactConfig(spec.config) } : {}),
   };
   const text = JSON.stringify(excerpt, null, 2).split(`"${OMITTED}"`).join('{...}');
-  return cropCompiledSpec(text);
+  return cropCompiledSpec(text, maxLines);
 }
 
-function cropCompiledSpec(text: string): string {
+function cropCompiledSpec(text: string, maxLines: number): string {
   const lines = text.split('\n');
-  if (lines.length <= MAX_COMPILED_SPEC_LINES) return text;
-  const visibleLineCount = MAX_COMPILED_SPEC_LINES - 1;
+  if (lines.length <= maxLines) return text;
+  const visibleLineCount = maxLines - 1;
   const hiddenLines = lines.slice(visibleLineCount);
   return [
     ...lines.slice(0, visibleLineCount),
@@ -93,10 +99,10 @@ function compactConfig(config: Record<string, unknown>): Record<string, unknown>
   return compact;
 }
 
-function ArrowColumn() {
+function ArrowColumn({ orientation }: { orientation: FigureOrientation }) {
   return (
-    <div style={arrowColumnStyle} aria-hidden="true">
-      <svg width="30" height="20" viewBox="0 0 30 20" fill="none">
+    <div style={orientation === 'vertical' ? verticalArrowColumnStyle : arrowColumnStyle} aria-hidden="true">
+      <svg width="30" height="20" viewBox="0 0 30 20" fill="none" style={orientation === 'vertical' ? verticalArrowSvgStyle : undefined}>
         <path d="M1 10H27" stroke={siteTheme.accent} strokeWidth="2.4" strokeLinecap="round" />
         <path d="M20 3L27 10L20 17" stroke={siteTheme.accent} strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
@@ -197,4 +203,71 @@ const chartBodyStyle: React.CSSProperties = {
   padding: '2px 6px 18px',
   boxSizing: 'border-box',
   background: PAPER,
+};
+
+const verticalFigureStyle: React.CSSProperties = {
+  ...figureStyle,
+  width: '100%',
+  minHeight: 0,
+  gridTemplateColumns: 'minmax(0, 1fr)',
+  columnGap: 0,
+  padding: 0,
+};
+
+const verticalPaneStyle: React.CSSProperties = {
+  ...paneStyle,
+};
+
+const verticalBorderedPaneStyle: React.CSSProperties = {
+  ...verticalPaneStyle,
+  borderTop: `1px solid ${HAIRLINE}`,
+};
+
+const verticalBorderedVisualPaneStyle: React.CSSProperties = {
+  ...visualPaneStyle,
+  borderTop: `1px solid ${HAIRLINE}`,
+};
+
+const verticalArrowColumnStyle: React.CSSProperties = {
+  ...arrowColumnStyle,
+  minHeight: 44,
+};
+
+const verticalArrowSvgStyle: React.CSSProperties = {
+  transform: 'rotate(90deg)',
+};
+
+const verticalPaneHeaderStyle: React.CSSProperties = {
+  ...paneHeaderStyle,
+  minHeight: 44,
+  padding: '0 12px',
+};
+
+const verticalChartHeaderStyle: React.CSSProperties = {
+  ...verticalPaneHeaderStyle,
+  gap: 6,
+};
+
+const verticalPaneTitleStyle: React.CSSProperties = {
+  ...paneTitleStyle,
+  fontSize: 10.5,
+  letterSpacing: '0.07em',
+};
+
+const verticalSpecPreStyle: React.CSSProperties = {
+  ...specPreStyle,
+  padding: '0 12px 14px',
+  fontSize: 11.2,
+  lineHeight: 1.36,
+};
+
+const verticalCompiledPreStyle: React.CSSProperties = {
+  ...verticalSpecPreStyle,
+  fontSize: 9.8,
+  lineHeight: 1.22,
+};
+
+const verticalChartBodyStyle: React.CSSProperties = {
+  ...chartBodyStyle,
+  padding: '0 8px 12px',
 };

--- a/site/src/global.css
+++ b/site/src/global.css
@@ -21,3 +21,36 @@
   text-decoration-line: underline !important;
   text-decoration-color: currentColor !important;
 }
+
+@media (max-width: 640px) {
+  .site-nav-bar {
+    gap: 14px !important;
+    padding: 0 16px !important;
+    height: auto !important;
+    min-height: 48px;
+    flex-wrap: wrap;
+    padding-top: 8px !important;
+    padding-bottom: 8px !important;
+    overflow: hidden;
+  }
+
+  .site-nav-scroll {
+    order: 3;
+    flex: 0 0 100% !important;
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+    scrollbar-width: none;
+  }
+
+  .site-nav-scroll::-webkit-scrollbar {
+    display: none;
+  }
+
+  .site-nav-actions {
+    order: 2;
+    margin-left: auto;
+    flex-shrink: 0;
+  }
+}

--- a/site/src/routes/ChartWall.tsx
+++ b/site/src/routes/ChartWall.tsx
@@ -254,8 +254,10 @@ export function ChartWall() {
 
   return (
     <SiteShell>
+      <style>{galleryResponsiveStyles}</style>
       <div
         ref={mainRef}
+        className="gallery-scroll-root"
         style={{
           flex: 1,
           minHeight: 0,
@@ -264,6 +266,7 @@ export function ChartWall() {
         }}
       >
         <div
+          className="gallery-layout"
           style={{
             display: 'flex',
             alignItems: 'flex-start',
@@ -282,11 +285,12 @@ export function ChartWall() {
           />
 
           <main style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ maxWidth: 1100, margin: '0 auto', padding: '36px 40px 96px' }}>
-              <header style={{ marginBottom: 18 }}>
-                <h1 style={{ margin: 0, fontSize: 28, fontWeight: 600, letterSpacing: -0.4 }}>
-                  Example Gallery ({category.label} backend)
+            <div className="gallery-content" style={{ maxWidth: 1100, margin: '0 auto', padding: '36px 40px 96px' }}>
+              <header className="gallery-header" style={{ marginBottom: 18 }}>
+                <h1 className="gallery-title" style={{ margin: 0, fontSize: 28, fontWeight: 600, letterSpacing: -0.4 }}>
+                  Example Gallery<span className="gallery-title-backend"> ({category.label} backend)</span>
                 </h1>
+                <MobileBackendTabs category={category} onSelectBackend={scrollToGallery} />
               </header>
 
               <BackendIntro
@@ -324,6 +328,8 @@ export function ChartWall() {
                     </div>
 
                     <div
+                      className="gallery-card-grid"
+                      data-gallery-grid=""
                       style={{
                         display: 'grid',
                         gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
@@ -476,6 +482,38 @@ function BackendNavItem({
   );
 }
 
+function MobileBackendTabs({
+  category,
+  onSelectBackend,
+}: {
+  category: ChartCategory;
+  onSelectBackend: (id: PreviewBackend) => void;
+}) {
+  return (
+    <div className="gallery-mobile-backends" aria-label="Choose gallery backend">
+      {CHART_CATEGORIES.map((candidate) => {
+        const active = candidate.id === category.id;
+        return (
+          <button
+            key={candidate.id}
+            type="button"
+            onClick={() => onSelectBackend(candidate.id)}
+            aria-pressed={active}
+            style={{
+              ...mobileBackendTabStyle,
+              background: active ? siteTheme.text : siteTheme.surface,
+              color: active ? '#fff' : siteTheme.text,
+              borderColor: active ? siteTheme.text : siteTheme.border,
+            }}
+          >
+            {candidate.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 function BackendIntro({
   category,
   groups,
@@ -511,8 +549,9 @@ function BackendIntro({
 const ${resultNames[category.id]} = ${category.fn}(input);`;
 
   return (
-    <div style={{ marginTop: 22 }}>
+    <div className="gallery-intro" data-gallery-intro="" style={{ marginTop: 22 }}>
       <p
+        className="gallery-intro-copy"
         style={{
           margin: 0,
           maxWidth: 720,
@@ -525,11 +564,14 @@ const ${resultNames[category.id]} = ${category.fn}(input);`;
         semantic types, and a chart spec) to <code style={inlineCodeStyle}>{category.fn}()</code>.
       </p>
 
-      <CodeBlock customStyle={{ marginTop: 12, maxWidth: 560, fontSize: 12.5 }}>
-        {snippet}
-      </CodeBlock>
+      <div className="gallery-intro-code">
+        <CodeBlock customStyle={{ marginTop: 12, maxWidth: 560, fontSize: 12.5 }}>
+          {snippet}
+        </CodeBlock>
+      </div>
 
       <p
+        className="gallery-intro-link"
         style={{
           margin: '10px 0 0',
           maxWidth: 720,
@@ -550,8 +592,8 @@ const ${resultNames[category.id]} = ${category.fn}(input);`;
         .
       </p>
 
-      <div style={{ margin: '12px 0 0', maxWidth: 760 }}>
-        <div style={chartNameChipListStyle}>
+      <div className="gallery-chip-panel" style={{ margin: '12px 0 0', maxWidth: 760 }}>
+        <div data-gallery-chip-list="" style={chartNameChipListStyle}>
           {chartLinks.map((link) => (
             <ChartChip key={link.id} link={link} onNavigate={onNavigate} />
           ))}
@@ -616,6 +658,8 @@ function VariantCard({ tile, onOpen }: { tile: Tile; onOpen: () => void }) {
   return (
     <button
       ref={ref}
+      className="gallery-card"
+      data-gallery-card=""
       type="button"
       onClick={onOpen}
       onMouseEnter={() => setHovered(true)}
@@ -720,3 +764,92 @@ const chartNameChipIconStyle: CSSProperties = {
   height: 13,
   flexShrink: 0,
 };
+
+const mobileBackendTabStyle: CSSProperties = {
+  flex: '0 0 auto',
+  border: `1px solid ${siteTheme.border}`,
+  borderRadius: 999,
+  padding: '6px 12px',
+  font: 'inherit',
+  fontSize: 13,
+  lineHeight: 1.2,
+  cursor: 'pointer',
+};
+
+const galleryResponsiveStyles = `
+  .gallery-mobile-backends {
+    display: none;
+  }
+
+  @media (max-width: 640px) {
+    .gallery-scroll-root {
+      overflow-x: hidden !important;
+    }
+
+    .gallery-layout {
+      display: block !important;
+      max-width: none !important;
+    }
+
+    .gallery-layout .app-sidebar {
+      display: none !important;
+    }
+
+    .gallery-content {
+      max-width: none !important;
+      padding: 24px 20px 72px !important;
+    }
+
+    .gallery-header {
+      margin-bottom: 14px !important;
+    }
+
+    .gallery-title {
+      font-size: 26px !important;
+      line-height: 1.16 !important;
+      letter-spacing: 0 !important;
+    }
+
+    .gallery-title-backend {
+      display: none;
+    }
+
+    .gallery-mobile-backends {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 14px 0 2px;
+      scrollbar-width: none;
+    }
+
+    .gallery-mobile-backends::-webkit-scrollbar {
+      display: none;
+    }
+
+    .gallery-intro {
+      margin-top: 10px !important;
+      margin-bottom: 30px;
+    }
+
+    .gallery-intro-copy {
+      font-size: 15.5px !important;
+      line-height: 1.6 !important;
+      max-width: none !important;
+    }
+
+    .gallery-intro-code,
+    .gallery-intro-link,
+    .gallery-chip-panel {
+      display: none !important;
+    }
+
+    .gallery-card-grid {
+      grid-template-columns: minmax(0, 1fr) !important;
+      gap: 22px !important;
+    }
+
+    .gallery-card {
+      text-align: left !important;
+    }
+  }
+`;

--- a/site/src/routes/DocSectionPage.tsx
+++ b/site/src/routes/DocSectionPage.tsx
@@ -69,8 +69,10 @@ export function DocSectionPage({ section }: { section: DocSection }) {
 
   return (
     <SiteShell>
+      <style>{docResponsiveStyles}</style>
       <div
         ref={mainRef}
+        className="doc-scroll-root"
         style={{
           flex: 1,
           minHeight: 0,
@@ -78,6 +80,8 @@ export function DocSectionPage({ section }: { section: DocSection }) {
         }}
       >
         <div
+          className="doc-layout"
+          data-doc-layout=""
           style={{
             display: 'grid',
             gridTemplateColumns: `${SIDEBAR_NAV_WIDTH}px 1fr`,
@@ -109,7 +113,16 @@ export function DocSectionPage({ section }: { section: DocSection }) {
             ))}
           </SidebarNav>
 
-          <main style={{ minWidth: 0, padding: '24px 32px 48px' }}>
+          <main className="doc-main" data-doc-main="" style={{ minWidth: 0, padding: '24px 32px 48px' }}>
+            <MobileDocPicker
+              section={section}
+              groups={groups}
+              activeSlug={activeSlug}
+              onNavigate={(nextSlug) => {
+                mainRef.current?.scrollTo({ top: 0 });
+                navigate(`/${section}/${nextSlug}`);
+              }}
+            />
             {!entry || !markdown ? (
               <p style={{ color: siteTheme.textMuted }}>Document not found.</p>
             ) : (
@@ -121,3 +134,114 @@ export function DocSectionPage({ section }: { section: DocSection }) {
     </SiteShell>
   );
 }
+
+function MobileDocPicker({
+  section,
+  groups,
+  activeSlug,
+  onNavigate,
+}: {
+  section: DocSection;
+  groups: ReturnType<typeof getDocGroups>;
+  activeSlug?: string;
+  onNavigate: (slug: string) => void;
+}) {
+  return (
+    <label className="doc-mobile-picker" style={docMobilePickerStyle}>
+      <span style={docMobilePickerLabelStyle}>Documentation</span>
+      <select
+        value={activeSlug ?? ''}
+        onChange={(event) => onNavigate(event.currentTarget.value)}
+        style={docMobileSelectStyle}
+        aria-label="Choose documentation page"
+      >
+        {groups.map((group) => (
+          <optgroup key={group.id} label={group.label}>
+            {group.docs.map((doc) => (
+              <option key={doc.slug} value={doc.slug}>
+                {doc.title}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+      <span style={docMobilePathStyle}>/{section}</span>
+    </label>
+  );
+}
+
+const docMobilePickerStyle: React.CSSProperties = {
+  display: 'none',
+};
+
+const docMobilePickerLabelStyle: React.CSSProperties = {
+  display: 'block',
+  marginBottom: 6,
+  color: siteTheme.textMuted,
+  fontSize: 12,
+  fontWeight: 600,
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase',
+};
+
+const docMobileSelectStyle: React.CSSProperties = {
+  display: 'block',
+  width: '100%',
+  minHeight: 40,
+  padding: '7px 12px',
+  border: `1px solid ${siteTheme.border}`,
+  borderRadius: 8,
+  background: siteTheme.surface,
+  color: siteTheme.text,
+  font: 'inherit',
+  fontSize: 15,
+};
+
+const docMobilePathStyle: React.CSSProperties = {
+  display: 'block',
+  marginTop: 6,
+  color: siteTheme.textMuted,
+  fontSize: 12,
+};
+
+const docResponsiveStyles = `
+  @media (max-width: 640px) {
+    .doc-scroll-root {
+      overflow-x: hidden !important;
+    }
+
+    .doc-layout {
+      display: block !important;
+      max-width: none !important;
+    }
+
+    .doc-layout .app-sidebar {
+      display: none !important;
+    }
+
+    .doc-main {
+      padding: 22px 20px 56px !important;
+    }
+
+    .doc-mobile-picker {
+      display: block !important;
+      margin-bottom: 22px;
+    }
+
+    .doc-markdown {
+      max-width: none !important;
+      font-size: 15.5px !important;
+      line-height: 1.68 !important;
+    }
+
+    .doc-markdown h1 {
+      font-size: 26px !important;
+      line-height: 1.16 !important;
+    }
+
+    .doc-markdown h2 {
+      font-size: 19px !important;
+      line-height: 1.25 !important;
+    }
+  }
+`;

--- a/site/src/routes/Editor.tsx
+++ b/site/src/routes/Editor.tsx
@@ -140,12 +140,14 @@ export function Editor() {
 
   return (
     <SiteShell>
+      <style>{editorResponsiveStyles}</style>
       <ResizeSplit
+        className="editor-main-split"
         direction="horizontal"
         initialRatio={32}
         storageKey="flint-editor-split-h"
       >
-        <section style={{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1 }}>
+        <section className="editor-code-pane" style={{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1 }}>
           <InputPane
             label="Flint spec"
             loadedFromGallery={loadedFromGallery}
@@ -163,6 +165,7 @@ export function Editor() {
         </section>
 
         <ResizeSplit
+          className="editor-preview-split"
           direction="vertical"
           initialRatio={52}
           storageKey="flint-editor-split-v"
@@ -213,7 +216,7 @@ function InputPane({
   foldKey: number;
 }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1 }}>
+    <div className="editor-input-pane" style={{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1 }}>
       <PaneHeader label={label}>
         {loadedFromGallery ? (
           <span style={galleryBadgeStyle}>loaded from Gallery</span>
@@ -269,7 +272,7 @@ function PreviewPane({
   compiled: CompileResult<unknown> | null;
 }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1 }}>
+    <div className="editor-preview-pane" style={{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1 }}>
       <header style={paneHeaderStyle}>
         <span style={paneTitleStyle}>Preview</span>
         <div style={backendToggleStyle} role="tablist" aria-label="Rendering backend">
@@ -289,7 +292,7 @@ function PreviewPane({
         <div style={{ flex: 1 }} />
       </header>
 
-      <div style={{ flex: 1, overflow: 'auto', padding: 16, background: siteTheme.surface }}>
+      <div className="editor-preview-body" style={{ flex: 1, overflow: 'auto', padding: 16, background: siteTheme.surface }}>
         {!parsed.ok ? (
           <pre style={{ color: siteTheme.error, fontSize: 13, whiteSpace: 'pre-wrap', margin: 0 }}>
             JSON error: {String((parsed.err as Error).message)}
@@ -426,7 +429,7 @@ function OutputPane({
 }) {
   const spec = compiled?.ok ? compiled.value : null;
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1 }}>
+    <div className="editor-output-pane" style={{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1 }}>
       <PaneHeader label={label} hint={`${OUTPUT_LANG[backend]} · read-only`}>
         {spec != null && <OutputActions backend={backend} spec={spec} text={text} />}
         {compileError && (
@@ -538,3 +541,76 @@ const outputBtnStyle: React.CSSProperties = {
   cursor: 'pointer',
   whiteSpace: 'nowrap',
 };
+
+const editorResponsiveStyles = `
+  @media (max-width: 640px) {
+    .editor-main-split {
+      flex-direction: column !important;
+      overflow-y: auto !important;
+      overflow-x: hidden !important;
+    }
+
+    .editor-main-split > [role="separator"],
+    .editor-preview-split > [role="separator"] {
+      display: none !important;
+    }
+
+    .editor-main-split > div:not([role="separator"]),
+    .editor-preview-split > div:not([role="separator"]) {
+      flex: 0 0 auto !important;
+      min-height: 0 !important;
+    }
+
+    .editor-main-split > div:not([role="separator"]):first-child {
+      flex-basis: 430px !important;
+      height: 430px !important;
+      overflow: hidden !important;
+    }
+
+    .editor-code-pane,
+    .editor-input-pane {
+      height: 430px !important;
+      min-height: 0 !important;
+      overflow: hidden !important;
+    }
+
+    .editor-preview-split {
+      display: block !important;
+      flex: 0 0 auto !important;
+      min-height: 360px !important;
+      overflow: visible !important;
+    }
+
+    .editor-preview-pane {
+      min-height: 360px !important;
+      border-top: 1px solid ${siteTheme.border};
+    }
+
+    .editor-preview-body {
+      min-height: 320px;
+      padding: 12px !important;
+    }
+
+    .editor-output-pane {
+      display: none !important;
+    }
+
+    .editor-input-pane header,
+    .editor-preview-pane header {
+      flex-wrap: wrap;
+      align-items: center !important;
+      min-height: 42px !important;
+      gap: 6px !important;
+    }
+
+    .editor-preview-pane [role="tablist"] {
+      max-width: 100%;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }
+
+    .editor-preview-pane [role="tablist"]::-webkit-scrollbar {
+      display: none;
+    }
+  }
+`;

--- a/site/src/routes/Landing.tsx
+++ b/site/src/routes/Landing.tsx
@@ -7,6 +7,7 @@ import { ScaleToFit } from '../components/ScaleToFit';
 import { SpecPipelineFigure } from '../components/SpecPipelineFigure';
 import { testCaseToFlintSummary, testCaseToAssemblyInput } from '../shared/test-case-utils';
 import { buildGalleryEditorHref, openEditorWithPayload } from '../shared/editor-payload';
+import { CHART_CATEGORIES } from '../shared/chart-categories';
 import { MOVIE_RATINGS } from './movie-ratings-data';
 import {
   ALL_BACKENDS,
@@ -34,7 +35,7 @@ export function Landing() {
           <h1 style={heroTitleStyle}>Flint: A Visualization Language for the AI Era</h1>
           <div style={heroAttributionStyle}>A Microsoft Research project</div>
 
-          <div style={leadColumnsStyle}>
+          <div className="landing-lead-columns" style={leadColumnsStyle}>
             <div style={leadTextColStyle}>
               <p style={leadStyle}>{LEAD_INTRO}</p>
 
@@ -61,12 +62,21 @@ export function Landing() {
                   </Link>
                   .
                 </div>
+                <div style={installLineStyle}>
+                  <span style={promptMarkStyle}>&gt;</span> Explore {CHART_FAMILY_COUNT} chart types and{' '}
+                  {CHART_GALLERY_ENTRY_COUNT} examples in the{' '}
+                  <Link to="/gallery" className="landing-skill-link" style={installLineLinkStyle}>
+                    gallery
+                  </Link>
+                  .
+                </div>
               </div>
             </div>
-            <div style={leadButtonsColStyle}>
+            <div className="landing-hero-actions" style={leadButtonsColStyle}>
               <div style={actionBoxStyle}>
-                <HeroCTA href={GITHUB_REPO} label="Visit GitHub" variant="primary" />
+                <HeroCTA to="/gallery" label="Explore Gallery" variant="primary" />
                 <HeroCTA to="/mcp" label="Get MCP Server" variant="secondary" />
+                <HeroCTA href={GITHUB_REPO} label="Visit GitHub" variant="secondary" />
               </div>
             </div>
           </div>
@@ -106,9 +116,9 @@ export function Landing() {
                 and the chart spec. From there, the compiler produces a complete backend-native spec (shown
                 here in Vega-Lite) filling with the necessary low-level details and renders a good-looking chart. 
               </p>
-              <div style={showcaseIntroCtaColStyle}>
+              <div className="landing-docs-actions" style={showcaseIntroCtaColStyle}>
                 <div style={actionBoxStyle}>
-                  <HeroCTA to="/documentation/overview" label="Read the docs" variant="secondary" />
+                  <HeroCTA className="landing-docs-cta" to="/documentation/overview" label="Read the docs" variant="secondary" />
                 </div>
               </div>
             </div>
@@ -316,11 +326,13 @@ function HeroCTA({
   to,
   href,
   variant,
+  className,
 }: {
   label: string;
   to?: string;
   href?: string;
   variant: 'primary' | 'secondary';
+  className?: string;
 }) {
   const [active, setActive] = useState(false);
   const handlers = {
@@ -332,14 +344,14 @@ function HeroCTA({
 
   if (href) {
     return (
-      <a href={href} style={heroCtaStyle(variant, active)} target="_blank" rel="noreferrer" {...handlers}>
+      <a className={className} href={href} style={heroCtaStyle(variant, active)} target="_blank" rel="noreferrer" {...handlers}>
         {label}
       </a>
     );
   }
 
   return (
-    <Link to={to ?? '/'} style={heroCtaStyle(variant, active)} {...handlers}>
+    <Link className={className} to={to ?? '/'} style={heroCtaStyle(variant, active)} {...handlers}>
       {label}
     </Link>
   );
@@ -370,6 +382,7 @@ function HeroShowcase() {
     <section style={heroShowcaseSectionStyle}>
       <div className="landing-showcase-row" style={carouselRowStyle}>
         <button
+          className="landing-carousel-arrow"
           type="button"
           onClick={goPrev}
           aria-label="Previous example"
@@ -379,7 +392,7 @@ function HeroShowcase() {
           <ChevronIcon dir="left" />
         </button>
 
-        <div style={{ ...showcaseCardStyle, flex: 1, minWidth: 0 }}>
+        <div className="landing-showcase-card" style={{ ...showcaseCardStyle, flex: 1, minWidth: 0 }}>
           <div style={showcasePaneStyle}>
             <div style={paneHeaderRowStyle}>
               <span style={paneLabelStyle}>Flint spec</span>
@@ -399,10 +412,10 @@ function HeroShowcase() {
             <FlintSpecCode testCase={testCase} canvasSize={example.canvasSize} />
           </div>
 
-          <div style={{ ...showcasePaneStyle, ...chartPaneStyle, borderLeft: `1px solid ${HAIRLINE}` }}>
-            <div style={paneHeaderRowStyle}>
+          <div className="landing-chart-pane" style={{ ...showcasePaneStyle, ...chartPaneStyle, borderLeft: `1px solid ${HAIRLINE}` }}>
+            <div className="landing-pane-header" style={paneHeaderRowStyle}>
               <span style={paneLabelStyle}>Compiled chart</span>
-              <div style={backendToggleStyle} role="tablist" aria-label="Rendering backend">
+              <div className="landing-backend-toggle" style={backendToggleStyle} role="tablist" aria-label="Rendering backend">
                 {ALL_BACKENDS.map((b) => {
                   const isSupported = supported.includes(b);
                   const active = b === backend;
@@ -430,8 +443,9 @@ function HeroShowcase() {
             </div>
           </div>
         </div>
-                
+
         <button
+          className="landing-carousel-arrow"
           type="button"
           onClick={goNext}
           aria-label="Next example"
@@ -531,11 +545,16 @@ function FlintSpecCode({ testCase, canvasSize }: { testCase: TestCase; canvasSiz
 
 function PipelineDiagram() {
   return (
-    <figure style={pipelineFigureStyle}>
-      <ScaleToFit height={520} minHeight={260} padding={0} adaptiveHeight>
-        <SpecPipelineFigure />
-      </ScaleToFit>
-    </figure>
+    <>
+      <figure className="landing-pipeline-figure--desktop" style={pipelineFigureStyle}>
+        <ScaleToFit height={520} minHeight={260} padding={0} adaptiveHeight>
+          <SpecPipelineFigure />
+        </ScaleToFit>
+      </figure>
+      <figure className="landing-pipeline-figure--mobile" style={pipelineFigureStyle}>
+        <SpecPipelineFigure orientation="vertical" />
+      </figure>
+    </>
   );
 }
 
@@ -549,6 +568,16 @@ function LeadHighlight({ children }: { children: string }) {
   return <span style={leadHighlightStyle}>{children}</span>;
 }
 
+const CHART_FAMILY_COUNT = new Set(
+  CHART_CATEGORIES.flatMap((category) =>
+    category.charts.map((chart) => chart.label.replace(/\s+\*$/u, '')),
+  ),
+).size;
+const CHART_GALLERY_ENTRY_COUNT = CHART_CATEGORIES.reduce(
+  (count, category) => count + category.charts.length,
+  0,
+);
+
 // Lead paragraph shown in the hero (the single intro to Flint).
 const LEAD_INTRO = (
   <>
@@ -556,7 +585,7 @@ const LEAD_INTRO = (
     <LeadHighlight>AI agents reliably create expressive, good-looking charts from simple, human-editable chart specs</LeadHighlight>. Instead of requiring verbose
     low-level parameters such as scales, axes, spacing, and layout, the Flint compiler derives
     optimized chart settings from the data, semantic types, chart type, and encodings. {' '}
-    <LeadHighlight>Flint specs can be rendered in different backends (Vega-Lite, ECharts, Chart.js)</LeadHighlight>.
+    <LeadHighlight>{`Flint supports ${CHART_FAMILY_COUNT} chart types, and it supports rendering in Vega-Lite, ECharts, and Chart.js`}</LeadHighlight>.
   </>
 );
 
@@ -602,8 +631,8 @@ const FEATURES: Feature[] = [
   {
     title: 'Render with different backends',
     body:
-      'Flint specs can be compiled to 34 different chart types in different backends (Vega-Lite, ECharts, and Chart.js). Despite their different APIs and ' +
-      'programming models, Flint hides them behind a unified interface. The user can easily switch to different backends and leverage their unique features.',
+      `Flint supports ${CHART_FAMILY_COUNT} chart types across Vega-Lite, ECharts, and Chart.js, with ${CHART_GALLERY_ENTRY_COUNT} backend-specific examples in the gallery. ` +
+      'Despite their different APIs and programming models, Flint hides them behind a unified interface. The user can easily switch to different backends and leverage their unique features.',
     example:
       'Vega-Lite has no native sunburst, but the user can easily switch to ECharts. The sunburst chart is a better alternative than the grouped bar chart for visualizing the hierarchy of region \u00d7 gameType \u00d7 game.',
     demo: demoBackends,
@@ -1039,11 +1068,97 @@ const landingInteractiveStyles = `
     margin-right: -48px;
   }
 
+  .landing-pipeline-figure--mobile {
+    display: none;
+  }
+
   @media (max-width: 900px) {
     .landing-showcase-row {
       width: 100%;
       margin-left: 0;
       margin-right: 0;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .landing-lead-columns {
+      gap: 24px !important;
+    }
+
+    .landing-hero-actions {
+      width: 100% !important;
+      border-left: 0 !important;
+      border-top: 1px solid ${HAIRLINE} !important;
+      padding-left: 0 !important;
+      padding-top: 18px !important;
+    }
+
+    .landing-docs-actions {
+      width: 100% !important;
+      max-width: 220px;
+      border-left: 0 !important;
+      padding-left: 0 !important;
+      justify-content: flex-start !important;
+    }
+
+    .landing-docs-cta {
+      padding-top: 7px !important;
+      padding-bottom: 7px !important;
+      line-height: 1.1 !important;
+    }
+
+    .landing-showcase-row {
+      align-items: stretch !important;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 10px 12px !important;
+    }
+
+    .landing-showcase-card {
+      order: 1;
+      flex: 0 0 100% !important;
+      width: 100%;
+      max-width: 100%;
+      box-sizing: border-box;
+    }
+
+    .landing-carousel-arrow {
+      order: 2;
+    }
+
+    .landing-chart-pane {
+      border-left: 0 !important;
+      border-top: 1px solid ${HAIRLINE} !important;
+    }
+
+    .landing-pane-header {
+      flex-direction: column;
+      flex-wrap: wrap;
+      align-items: flex-start !important;
+      justify-content: flex-start !important;
+      gap: 4px;
+    }
+
+    .landing-backend-toggle {
+      max-width: calc(100vw - 72px);
+      margin-left: 14px;
+      margin-top: 0 !important;
+      margin-bottom: 8px;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }
+
+    .landing-backend-toggle::-webkit-scrollbar {
+      display: none;
+    }
+
+    .landing-pipeline-figure--desktop {
+      display: none;
+    }
+
+    .landing-pipeline-figure--mobile {
+      display: block;
+      margin-bottom: 42px !important;
     }
   }
 `;


### PR DESCRIPTION
## Summary
- Bump `flint-chart` and `flint-chart-mcp` to `0.1.2`, with MCP depending on `flint-chart ^0.1.2`.
- Keep the public Flint title as `Flint: A Visualization Language for the AI Era`, with surrounding copy explaining the semantic chart-spec layer.
- Harden MCP `validate_chart` preflight validation for malformed semantic specs before assembly.
- Fix Vega-Lite render dimension reporting to match root SVG/PNG artifact dimensions.
- Polish the public site mobile experience across landing, gallery, docs, and editor routes.

## Validation
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run test`
- `npm run build`
- `npm run site:build`
- `npm run build -w site` after the title update
- `git diff --check`
- VS Code diagnostics on touched TS/CSS files

## Release Notes
- `0.1.2` is for the MCP/runtime fixes and site polish, not for a title-only change.
- Verified `flint-chart@0.1.2` and `flint-chart-mcp@0.1.2` are not yet published on npm.
- Untracked paper/blog artifacts are intentionally excluded from this PR.