### PR TITLE
Restore AI-era title and simplify MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flint: A Semantic Visualization Language for AI Agents and Humans
+# Flint: A Visualization Language for the AI Era
 
 [![npm: flint-chart](https://img.shields.io/npm/v/flint-chart.svg?label=npm%3A%20flint-chart)](https://www.npmjs.com/package/flint-chart)
 [![npm: flint-chart-mcp](https://img.shields.io/npm/v/flint-chart-mcp.svg?label=npm%3A%20flint-chart-mcp)](https://www.npmjs.com/package/flint-chart-mcp)

--- a/site/index.html
+++ b/site/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Flint: A Semantic Visualization Language for AI Agents and Humans</title>
+    <title>Flint: A Visualization Language for the AI Era</title>
     <link rel="icon" href="data:," />
     <style>
       html, body, #root { margin: 0; padding: 0; height: 100%; }

--- a/site/src/routes/Landing.tsx
+++ b/site/src/routes/Landing.tsx
@@ -32,7 +32,7 @@ export function Landing() {
       <main style={mainStyle}>
         {/* ---- Hero ------------------------------------------------------ */}
         <section style={{ ...sectionStyle, paddingTop: 88, paddingBottom: 36 }}>
-          <h1 style={heroTitleStyle}>Flint: A Semantic Visualization Language for AI Agents and Humans</h1>
+          <h1 style={heroTitleStyle}>Flint: A Visualization Language for the AI Era</h1>
           <div style={heroAttributionStyle}>A Microsoft Research project</div>
 
           <div className="landing-lead-columns" style={leadColumnsStyle}>


### PR DESCRIPTION
## Summary
- Restore the public Flint title to `Flint: A Visualization Language for the AI Era`.
- Apply the title consistently in the README, landing hero, and browser tab title.
- Keep the original MCP intro, then add a TL;DR setup request users can paste into their agent.
- Add a top-right copy control for the TL;DR setup prompt.
- Place install/GitHub links inline with the TL;DR text, without arrows; the install link scrolls to the page section directly.

## Validation
- `npm run build -w site`
- `git diff --check`
- VS Code diagnostics on touched files

## Notes
- This is site/docs copy only. It does not bump package versions or create a release patch.