### PR TITLE
0.2.2 fixes and adding dodge options for grouped charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-07-15
+
+### Added
+
+- Grouped violin plots in Vega-Lite: a genuine colour sub-group now renders as a
+  split violin for two groups and as a category × sub-group grid of independent
+  violins for three or more, instead of an overlapping mirror.
+- Local (compact) and global (aligned) dodge modes for grouped bar charts
+  (Vega-Lite, ECharts, Chart.js) and boxplots (Vega-Lite, ECharts), selectable
+  through the `dodge` chart property so sparse category × group data reads
+  cleanly.
+
+### Changed
+
+- The `dodge` chart property now offers `auto`, `local`, and `global` only.
+  One-per-band collapsing happens automatically when a colour/group is redundant
+  with the axis, so the manual `none` option was removed.
+- The Vega-Lite Rose Chart no longer exposes an inner-radius control; a rose has
+  no donut hole (Chart.js and ECharts already omitted it).
+
+### Fixed
+
+- Vega-Lite Rose Chart "Sort slices" now reliably reorders the wedges and their
+  legend by value.
+- Chart.js Rose Chart alignment (Left / Center) now rotates the wedges; the
+  rotation was previously set on an option Chart.js ignores for polar charts.
+
 ## [0.2.1] - 2026-07-13
 
 ### Added
@@ -34,5 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Treated only lowercase `start` and `end` Waterfall Type values as total
   anchors in Vega-Lite; other values now remain floating deltas colored by sign.
 
-[Unreleased]: https://github.com/microsoft/flint-chart/compare/0.2.1...HEAD
+[Unreleased]: https://github.com/microsoft/flint-chart/compare/0.2.2...HEAD
+[0.2.2]: https://github.com/microsoft/flint-chart/compare/0.2.1...0.2.2
 [0.2.1]: https://github.com/microsoft/flint-chart/compare/c8e20b052ad9ddad29ba3ecfc825948c424e5ba5...0.2.1

--- a/docs/reference-chartjs.md
+++ b/docs/reference-chartjs.md
@@ -75,7 +75,9 @@ _No template-specific parameters._
 
 **Encoding channels:** `x`, `y`, `group`, `color`, `column`, `row`
 
-_No template-specific parameters._
+| Parameter | Control | Domain | Default | Availability | Description |
+|---|---|---|---|---|---|
+| `dodge` | choice | `auto` (Auto), `local` (Local (compact)), `global` (Global (aligned)) | `auto` | conditional | Dodge |
 
 ### ![](chart-icon-column-stacked.svg) Stacked Bar Chart
 

--- a/docs/reference-echarts.md
+++ b/docs/reference-echarts.md
@@ -66,7 +66,7 @@ _No template-specific parameters._
 |---|---|---|---|---|---|
 | `whiskerMethod` | choice | `iqr` (Tukey (1.5 × IQR)), `minmax` (Min–Max) | `iqr` | always | Whiskers |
 | `showOutliers` | toggle | on / off | `true` | conditional | Outliers |
-| `colorLayout` | choice | `auto` (Auto), `dodge` (Side by side), `nested` (One per band) | `auto` | conditional | Color layout |
+| `dodge` | choice | `auto` (Auto), `local` (Local (compact)), `global` (Global (aligned)) | `auto` | conditional | Dodge |
 
 ### ![](chart-icon-strip-plot.svg) Strip Plot
 
@@ -88,7 +88,9 @@ _No template-specific parameters._
 
 **Encoding channels:** `x`, `y`, `group`, `color`, `column`, `row`
 
-_No template-specific parameters._
+| Parameter | Control | Domain | Default | Availability | Description |
+|---|---|---|---|---|---|
+| `dodge` | choice | `auto` (Auto), `local` (Local (compact)), `global` (Global (aligned)) | `auto` | conditional | Dodge |
 
 ### ![](chart-icon-column-stacked.svg) Stacked Bar Chart
 

--- a/docs/reference-echarts.md
+++ b/docs/reference-echarts.md
@@ -66,6 +66,7 @@ _No template-specific parameters._
 |---|---|---|---|---|---|
 | `whiskerMethod` | choice | `iqr` (Tukey (1.5 × IQR)), `minmax` (Min–Max) | `iqr` | always | Whiskers |
 | `showOutliers` | toggle | on / off | `true` | conditional | Outliers |
+| `colorLayout` | choice | `auto` (Auto), `dodge` (Side by side), `nested` (One per band) | `auto` | conditional | Color layout |
 
 ### ![](chart-icon-strip-plot.svg) Strip Plot
 

--- a/docs/reference-vegalite.md
+++ b/docs/reference-vegalite.md
@@ -349,7 +349,6 @@ _No template-specific parameters._
 
 | Parameter | Control | Domain | Default | Availability | Description |
 |---|---|---|---|---|---|
-| `innerRadius` | number | 0 – 100 (step 5) | `0` | always | Inner radius as a percentage of the outer radius. |
 | `padAngle` | number | 0 – 0.1 (step 0.005) | `0` | always | Angular gap between radial segments. |
 | `alignment` | choice | `left` (Left (default)), `center` (Center) | — | always | Segment alignment for radial charts. |
 | `sortSlices` | choice | `none` (Data order), `descending` (Largest first), `ascending` (Smallest first) | `none` | always | Sort slices |

--- a/docs/reference-vegalite.md
+++ b/docs/reference-vegalite.md
@@ -216,6 +216,7 @@ The **Availability** column shows whether a parameter is `always` available or `
 |---|---|---|---|---|---|
 | `whiskerMethod` | choice | `iqr` (Tukey (1.5 × IQR)), `minmax` (Min–Max) | `iqr` | always | Whiskers |
 | `showOutliers` | toggle | on / off | `true` | conditional | Outliers |
+| `colorLayout` | choice | `auto` (Auto), `dodge` (Side by side), `nested` (One per band) | `auto` | conditional | Color layout |
 | `independentYAxis` | toggle | on / off | `false` | conditional | Use independent y-scales for facets. |
 | `logScale_x` | toggle | on / off | `false` | conditional | Use a log/symlog scale on the x-axis. |
 | `logScale_y` | toggle | on / off | `false` | conditional | Use a log/symlog scale on the y-axis. |

--- a/docs/reference-vegalite.md
+++ b/docs/reference-vegalite.md
@@ -113,6 +113,7 @@ The **Availability** column shows whether a parameter is `always` available or `
 
 | Parameter | Control | Domain | Default | Availability | Description |
 |---|---|---|---|---|---|
+| `dodge` | choice | `auto` (Auto), `local` (Local (compact)), `global` (Global (aligned)) | `auto` | conditional | Dodge |
 | `independentYAxis` | toggle | on / off | `false` | conditional | Use independent y-scales for facets. |
 
 ### ![](chart-icon-column-stacked.svg) Stacked Bar Chart
@@ -216,7 +217,7 @@ The **Availability** column shows whether a parameter is `always` available or `
 |---|---|---|---|---|---|
 | `whiskerMethod` | choice | `iqr` (Tukey (1.5 × IQR)), `minmax` (Min–Max) | `iqr` | always | Whiskers |
 | `showOutliers` | toggle | on / off | `true` | conditional | Outliers |
-| `colorLayout` | choice | `auto` (Auto), `dodge` (Side by side), `nested` (One per band) | `auto` | conditional | Color layout |
+| `dodge` | choice | `auto` (Auto), `local` (Local (compact)), `global` (Global (aligned)) | `auto` | conditional | Dodge |
 | `independentYAxis` | toggle | on / off | `false` | conditional | Use independent y-scales for facets. |
 | `logScale_x` | toggle | on / off | `false` | conditional | Use a log/symlog scale on the x-axis. |
 | `logScale_y` | toggle | on / off | `false` | conditional | Use a log/symlog scale on the y-axis. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9511,7 +9511,7 @@
     },
     "packages/flint-js": {
       "name": "flint-chart",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.14.10",
@@ -9552,7 +9552,7 @@
     },
     "packages/flint-mcp": {
       "name": "flint-chart-mcp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.4",
@@ -9561,7 +9561,7 @@
         "@resvg/resvg-js": "^2.6.2",
         "chart.js": "^4.4.0",
         "echarts": "^6.0.0",
-        "flint-chart": "^0.2.1",
+        "flint-chart": "^0.2.2",
         "vega": "^6.0.0",
         "vega-interpreter": "^2.2.1",
         "vega-lite": "^6.0.0",

--- a/packages/flint-js/package.json
+++ b/packages/flint-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flint-chart",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Semantic-level visualization library that compiles data + semantic types into chart specs for Vega-Lite, ECharts, and Chart.js.",
   "keywords": [
     "visualization",

--- a/packages/flint-js/src/chartjs/templates/bar.ts
+++ b/packages/flint-js/src/chartjs/templates/bar.ts
@@ -22,6 +22,7 @@ import {
 import {
     detectBandedAxisFromSemantics, detectBandedAxisForceDiscrete,
 } from '../../core/axis-detection';
+import { planBandDodge, resolveDodge } from '../../core/band-dodge';
 import { makeCartesianPivot } from '../../core/pivot';
 
 // ---------------------------------------------------------------------------
@@ -236,13 +237,21 @@ export const cjsGroupedBarChartDef: ChartTemplateDef = {
     template: { mark: 'bar', encoding: {} },
     channels: ['x', 'y', 'group', 'color', 'column', 'row'],
     markCognitiveChannel: 'length',
-    declareLayoutMode: (cs, table) => {
+    declareLayoutMode: (cs, table, chartProperties) => {
         const result = detectBandedAxisForceDiscrete(cs, table, { preferAxis: 'x' });
-        return {
+        const decl: any = {
             axisFlags: result ? { [result.axis]: { banded: true } } : { x: { banded: true } },
             resolvedTypes: result?.resolvedTypes,
             paramOverrides: { continuousMarkCrossSection: { x: 20, y: 20, seriesCountAxis: 'auto' } },
         };
+        const groupField = cs.group?.field || cs.color?.field;
+        const axisField = result?.axis ? cs[result.axis]?.field : (isDiscrete(cs.x?.type) ? cs.x?.field : cs.y?.field);
+        if (groupField && axisField) {
+            const plan = planBandDodge(table, axisField, groupField);
+            const { mode } = resolveDodge(plan, chartProperties?.dodge);
+            if (mode === 'local') decl.groupLaneCount = Math.max(1, plan.maxPerBand);
+        }
+        return decl;
     },
     instantiate: (spec, ctx) => {
         const { channelSemantics, table, chartProperties } = ctx;
@@ -258,6 +267,10 @@ export const cjsGroupedBarChartDef: ChartTemplateDef = {
         const isHorizontal = categoryAxis === 'y';
 
         const palette = getChartJsPalette(ctx, 'group');
+
+        // Decide compact (local) vs fixed-lane (global) dodge.
+        const dodgePlan = groupField ? planBandDodge(table, catField, groupField) : null;
+        const dodgeMode = dodgePlan ? resolveDodge(dodgePlan, chartProperties?.dodge).mode : 'none';
 
         const config: any = {
             type: 'bar',
@@ -284,7 +297,69 @@ export const cjsGroupedBarChartDef: ChartTemplateDef = {
             },
         };
 
-        if (groupField) {
+        if (groupField && dodgeMode === 'local') {
+            // Local (compact) dodge: pack only `maxPerBand` lanes per band,
+            // left-aligned. Each lane is a dataset; a band with fewer present
+            // groups leaves trailing lanes null. Bars are colored per-datum by
+            // their group value, and a custom legend maps group → swatch (lane
+            // dataset labels are synthetic).
+            const globalGroups: string[] = [...new Set(table.map((r) => String(r[groupField] ?? '')))].filter(Boolean).sort();
+            const colorFor = (g: string) => getSeriesBackgroundColor(palette, Math.max(0, globalGroups.indexOf(g)));
+            const borderFor = (g: string) => getSeriesBorderColor(palette, Math.max(0, globalGroups.indexOf(g)));
+
+            // Per-band ordered present groups → lane index.
+            const perBand = new Map<string, string[]>();
+            for (const cat of categories) perBand.set(cat, []);
+            for (const r of table) {
+                const cat = String(r[catField] ?? '');
+                const g = String(r[groupField] ?? '');
+                if (!perBand.has(cat) || !g) continue;
+                const arr = perBand.get(cat)!;
+                if (!arr.includes(g)) arr.push(g);
+            }
+            for (const arr of perBand.values()) arr.sort();
+            const maxPerBand = Math.max(1, ...[...perBand.values()].map((a) => a.length));
+
+            const valAt = new Map<string, number>();
+            for (const r of table) {
+                const v = Number(r[valField]);
+                if (isFinite(v)) valAt.set(`${r[catField]}\u0000${r[groupField]}`, v);
+            }
+
+            for (let lane = 0; lane < maxPerBand; lane++) {
+                const data: (number | null)[] = [];
+                const bg: string[] = [];
+                const bd: string[] = [];
+                for (const cat of categories) {
+                    const g = perBand.get(cat)?.[lane];
+                    if (g === undefined) { data.push(null); bg.push('transparent'); bd.push('transparent'); continue; }
+                    const v = valAt.get(`${cat}\u0000${g}`);
+                    data.push(v === undefined ? null : v);
+                    bg.push(colorFor(g));
+                    bd.push(borderFor(g));
+                }
+                config.data.datasets.push({
+                    label: `__lane${lane}`,
+                    data,
+                    backgroundColor: bg,
+                    borderColor: bd,
+                    borderWidth: 1,
+                });
+            }
+
+            // Custom legend: one swatch per group value (not per lane).
+            config.options.plugins.legend = {
+                display: true,
+                labels: {
+                    generateLabels: () => globalGroups.map((g) => ({
+                        text: g,
+                        fillStyle: colorFor(g),
+                        strokeStyle: borderFor(g),
+                        lineWidth: 1,
+                    })),
+                },
+            };
+        } else if (groupField) {
             const groups = groupBy(table, groupField);
             let colorIdx = 0;
             for (const [name, rows] of groups) {
@@ -322,6 +397,31 @@ export const cjsGroupedBarChartDef: ChartTemplateDef = {
         delete spec.mark;
         delete spec.encoding;
     },
+    properties: [
+        {
+            key: 'dodge', label: 'Dodge', type: 'discrete',
+            options: [
+                { value: 'auto',   label: 'Auto' },
+                { value: 'local',  label: 'Local (compact)' },
+                { value: 'global', label: 'Global (aligned)' },
+            ],
+            defaultValue: 'auto',
+            check: (ctx) => {
+                const isDisc = (t: string | undefined) => t === 'nominal' || t === 'ordinal';
+                const groupField = ctx.channelSemantics?.group?.field
+                    ?? ctx.channelSemantics?.color?.field
+                    ?? ctx.encodings?.group?.field
+                    ?? ctx.encodings?.color?.field;
+                const axisField = isDisc(ctx.channelSemantics?.x?.type)
+                    ? ctx.channelSemantics?.x?.field
+                    : ctx.channelSemantics?.y?.field;
+                const rows = ctx.data;
+                if (!groupField || !axisField || !rows) return { applicable: false };
+                const plan = planBandDodge(rows, axisField, groupField);
+                return { applicable: plan.ambiguous, recommendedValue: plan.mode === 'none' ? 'auto' : plan.mode };
+            },
+        },
+    ] as ChartPropertyDef[],
     pivot: makeCartesianPivot({
         transpose: [['x', 'y']],
         permute: [['x', 'y', 'color']],

--- a/packages/flint-js/src/chartjs/templates/rose.ts
+++ b/packages/flint-js/src/chartjs/templates/rose.ts
@@ -107,9 +107,12 @@ export const cjsRoseChartDef: ChartTemplateDef = {
 
         const alignment = ctx.chartProperties?.alignment ?? 'left';
         const n = categories.length;
-        // Chart.js polarArea: startAngle 0 = 12 o'clock, CW.
-        // Default (startAngle=0) is left alignment.
-        // For center: offset by -halfSlice degrees.
+        // Chart.js polarArea rotation lives on the RADIAL SCALE
+        // (`scales.r.startAngle`, in degrees, 0 = 12 o'clock, CW) — the
+        // top-level `options.startAngle` is NOT read for polarArea and has no
+        // effect. Default (0) is left alignment (first wedge's left edge at 12
+        // o'clock); center rotates back by half a slice so the first wedge is
+        // centred on 12 o'clock.
         const startAngle = alignment === 'center' && n > 0
             ? -(180 / n)
             : 0;
@@ -128,10 +131,10 @@ export const cjsRoseChartDef: ChartTemplateDef = {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
-                startAngle,
                 scales: {
                     r: {
                         beginAtZero: true,
+                        startAngle,
                         // Radii are sqrt(value); the raw tick numbers would
                         // misrepresent the scale, so hide them (true values are
                         // surfaced in the tooltip).

--- a/packages/flint-js/src/core/band-dodge.ts
+++ b/packages/flint-js/src/core/band-dodge.ts
@@ -24,29 +24,57 @@
  *     cross-products.
  */
 
-/** Default fraction of bands that must be single-valued for `auto` to snap to
- *  `nested` in the ambiguous zone. Tunable via `planBandDodge` options. */
+/** Default fraction of single-valued bands above which `auto` snaps to `none`
+ *  (mostly-1:1 / dirty near-1:1 data). Tunable via `planBandDodge` options. */
 export const DEFAULT_NESTED_SNAP_THRESHOLD = 0.9;
 
+/** Resolved dodge mode (what actually renders). */
+export type DodgeMode = 'none' | 'local' | 'global';
+
+/** User-facing `dodge` chart-property values (`auto` defers to the compiler). */
+export type DodgeOption = 'auto' | DodgeMode;
+
 export interface BandDodgePlan {
-    /** `auto` recommendation: subdivide the band into sub-lanes? */
+    /** Compiler's recommended default mode. */
+    mode: DodgeMode;
+    /** Back-compat: does the recommendation subdivide the band? (`mode !== 'none'`). */
     dodge: boolean;
-    /** Sub-lanes a global offset scale reserves per band = global distinct
-     *  sub-values. Meaningful whenever the caller decides to dodge. */
+    /** Lanes a *global* offset scale reserves per band = global distinct
+     *  sub-values (the `global` mode lane count). */
     laneCount: number;
-    /** True in the uncertain regime (`1 < maxPerBand < global`) where a
-     *  user-facing toggle should be surfaced instead of trusting `auto`. */
+    /** True when a user override is worth surfacing (any real dodge choice,
+     *  i.e. `maxPerBand > 1`). */
     ambiguous: boolean;
     /** Most distinct sub-values co-occurring within any single band. */
     maxPerBand: number;
-    /** Global distinct sub-values (== `laneCount`). */
+    /** Global distinct sub-values. */
     global: number;
+    /** Number of distinct axis bands. */
+    bandCount: number;
 }
 
 export interface PlanBandDodgeOptions {
-    /** Fraction of single-valued bands above which `auto` snaps to `nested` in
-     *  the ambiguous zone. Defaults to {@link DEFAULT_NESTED_SNAP_THRESHOLD}. */
+    /** Fraction of single-valued bands above which `auto` snaps to `none`.
+     *  Defaults to {@link DEFAULT_NESTED_SNAP_THRESHOLD}. */
     nestedSnapThreshold?: number;
+}
+
+/** Pure recommendation from the per-band statistics. */
+function recommendMode(
+    maxPerBand: number,
+    globalCount: number,
+    nestedFraction: number,
+    threshold: number,
+): DodgeMode {
+    // Nothing subdivides any band → full-width.
+    if (maxPerBand <= 1) return 'none';
+    // Mostly single-valued (a few dirty/outlier multi-color bands) → snap to
+    // full-width rather than dodge the whole chart for a couple of rows.
+    if (nestedFraction >= threshold) return 'none';
+    // Every occupied band spans the full sub-domain → uniform global grid.
+    if (maxPerBand >= globalCount) return 'global';
+    // Sparse / spiky → compact, centered per-band lanes.
+    return 'local';
 }
 
 /**
@@ -86,35 +114,63 @@ export function planBandDodge(
         if (bandSet.size <= 1) singleValuedBands++;
     }
 
-    // Confident: no band holds more than one sub-value → nested.
-    if (maxPerBand <= 1) {
-        return { dodge: false, laneCount: globalCount, ambiguous: false, maxPerBand, global: globalCount };
-    }
-    // Confident: every occupied band spans the full sub-domain → real 2nd dim.
-    if (maxPerBand === globalCount) {
-        return { dodge: true, laneCount: globalCount, ambiguous: false, maxPerBand, global: globalCount };
-    }
-
-    // Ambiguous: resolve the `auto` lean via the snap threshold.
     const threshold = options?.nestedSnapThreshold ?? DEFAULT_NESTED_SNAP_THRESHOLD;
     const nestedFraction = bandCount > 0 ? singleValuedBands / bandCount : 1;
-    const dodge = nestedFraction < threshold;
-    return { dodge, laneCount: globalCount, ambiguous: true, maxPerBand, global: globalCount };
+    const mode = recommendMode(maxPerBand, globalCount, nestedFraction, threshold);
+
+    return {
+        mode,
+        dodge: mode !== 'none',
+        laneCount: globalCount,
+        ambiguous: maxPerBand > 1,
+        maxPerBand,
+        global: globalCount,
+        bandCount,
+    };
 }
 
-/** User-facing `colorLayout` chart-property values. */
-export type ColorLayoutMode = 'auto' | 'dodge' | 'nested';
+/** Number of sub-lanes a resolved mode reserves per band. */
+export function laneCountForMode(plan: BandDodgePlan, mode: DodgeMode): number {
+    if (mode === 'global') return plan.global;
+    if (mode === 'local') return Math.max(1, plan.maxPerBand);
+    return 1;
+}
 
 /**
- * Apply a user `colorLayout` override on top of a plan. `dodge`/`nested` are hard
- * overrides; `auto` (or anything else) follows the plan's recommendation. The
- * lane count is always the plan's global-derived value.
+ * Apply a user `dodge` override on top of a plan. `none`/`local`/`global` are
+ * hard overrides; `auto` (or unset) follows the compiler recommendation. A dodge
+ * mode is downgraded to `none` when nothing actually subdivides a band
+ * (`maxPerBand <= 1`), so forcing dodge on redundant color can't collapse it.
  */
+export function resolveDodge(
+    plan: BandDodgePlan,
+    override?: string,
+): { mode: DodgeMode; laneCount: number } {
+    let mode: DodgeMode =
+        override === 'none' || override === 'local' || override === 'global'
+            ? override
+            : plan.mode;
+    if (mode !== 'none' && plan.maxPerBand <= 1) mode = 'none';
+    return { mode, laneCount: laneCountForMode(plan, mode) };
+}
+
+// ---------------------------------------------------------------------------
+// Back-compat shim (pre-`local` callers that only need a dodge boolean).
+// `local` currently renders via the global offset path, so its lane count is
+// the global one until the per-backend `local` renderer lands (Stage 2).
+// ---------------------------------------------------------------------------
+
+/** @deprecated user-facing values; prefer {@link DodgeOption}. */
+export type ColorLayoutMode = DodgeOption;
+
+/** @deprecated prefer {@link resolveDodge}. Maps the mode to a dodge boolean and
+ *  the global lane count (the only lane count the current renderers support). */
 export function resolveBandDodge(
     plan: BandDodgePlan,
     override?: string,
 ): { dodge: boolean; laneCount: number } {
-    if (override === 'dodge') return { dodge: true, laneCount: plan.laneCount };
-    if (override === 'nested') return { dodge: false, laneCount: plan.laneCount };
-    return { dodge: plan.dodge, laneCount: plan.laneCount };
+    // Legacy override spellings → new modes.
+    const normalized = override === 'dodge' ? 'global' : override === 'nested' ? 'none' : override;
+    const { mode } = resolveDodge(plan, normalized);
+    return { dodge: mode !== 'none', laneCount: plan.laneCount };
 }

--- a/packages/flint-js/src/core/band-dodge.ts
+++ b/packages/flint-js/src/core/band-dodge.ts
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Band-dodge decision: does a secondary discrete channel (`color`, or an explicit
+ * `group` field) subdivide a categorical axis band into side-by-side sub-lanes
+ * ("dodge"), or is it redundant/nested with the axis (render one full-width glyph
+ * per band, "nested")?
+ *
+ * This is the single source of truth shared by the layout engine
+ * (`compute-layout.ts`) and every backend template that dodges by color/group
+ * (VL boxplot/violin/grouped-bar, ECharts, Chart.js). Keeping the decision here
+ * prevents the layout and the templates from drifting apart (the class of bug
+ * where the band is budgeted for a different lane count than the glyph is sized
+ * for). See `design-docs/boxplot-color-dodge-heuristic.md`.
+ *
+ * Two independent quantities, deliberately NOT the same number:
+ *   - the **gate** (`dodge`): keyed off the max per-band sub-cardinality — "does
+ *     any single band actually contain more than one sub-value?"
+ *   - the **lane count** (`laneCount`): the *global* distinct sub-value count,
+ *     because that is what a global band-offset scale (VL `xOffset`, an ECharts
+ *     series-per-group, a Chart.js dataset-per-group) physically reserves per
+ *     band. Sizing a glyph by the max-per-band instead would overlap in sparse
+ *     cross-products.
+ */
+
+/** Default fraction of bands that must be single-valued for `auto` to snap to
+ *  `nested` in the ambiguous zone. Tunable via `planBandDodge` options. */
+export const DEFAULT_NESTED_SNAP_THRESHOLD = 0.9;
+
+export interface BandDodgePlan {
+    /** `auto` recommendation: subdivide the band into sub-lanes? */
+    dodge: boolean;
+    /** Sub-lanes a global offset scale reserves per band = global distinct
+     *  sub-values. Meaningful whenever the caller decides to dodge. */
+    laneCount: number;
+    /** True in the uncertain regime (`1 < maxPerBand < global`) where a
+     *  user-facing toggle should be surfaced instead of trusting `auto`. */
+    ambiguous: boolean;
+    /** Most distinct sub-values co-occurring within any single band. */
+    maxPerBand: number;
+    /** Global distinct sub-values (== `laneCount`). */
+    global: number;
+}
+
+export interface PlanBandDodgeOptions {
+    /** Fraction of single-valued bands above which `auto` snaps to `nested` in
+     *  the ambiguous zone. Defaults to {@link DEFAULT_NESTED_SNAP_THRESHOLD}. */
+    nestedSnapThreshold?: number;
+}
+
+/**
+ * Decide whether `subField` dodges `axisField` for the given data.
+ *
+ * Confident zones (never ambiguous):
+ *   - `maxPerBand <= 1`  → nested (redundant/nested with the axis; `color == x`
+ *     or a 1:1 different-field pair).
+ *   - `maxPerBand === global` → dodge (clean full cross-product).
+ * Ambiguous zone (`1 < maxPerBand < global`, e.g. sparse cross-products or dirty
+ * near-1:1 data): the `auto` lean is resolved by a configurable threshold on the
+ * fraction of single-valued bands, and `ambiguous` is set so a host can surface
+ * the toggle.
+ */
+export function planBandDodge(
+    table: ReadonlyArray<Record<string, unknown>>,
+    axisField: string,
+    subField: string,
+    options?: PlanBandDodgeOptions,
+): BandDodgePlan {
+    const perBand = new Map<unknown, Set<unknown>>();
+    const global = new Set<unknown>();
+    for (const row of table) {
+        global.add(row[subField]);
+        const key = row[axisField];
+        let bandSet = perBand.get(key);
+        if (!bandSet) perBand.set(key, (bandSet = new Set()));
+        bandSet.add(row[subField]);
+    }
+
+    const globalCount = Math.max(1, global.size);
+    const bandCount = perBand.size;
+    let maxPerBand = 0;
+    let singleValuedBands = 0;
+    for (const bandSet of perBand.values()) {
+        if (bandSet.size > maxPerBand) maxPerBand = bandSet.size;
+        if (bandSet.size <= 1) singleValuedBands++;
+    }
+
+    // Confident: no band holds more than one sub-value → nested.
+    if (maxPerBand <= 1) {
+        return { dodge: false, laneCount: globalCount, ambiguous: false, maxPerBand, global: globalCount };
+    }
+    // Confident: every occupied band spans the full sub-domain → real 2nd dim.
+    if (maxPerBand === globalCount) {
+        return { dodge: true, laneCount: globalCount, ambiguous: false, maxPerBand, global: globalCount };
+    }
+
+    // Ambiguous: resolve the `auto` lean via the snap threshold.
+    const threshold = options?.nestedSnapThreshold ?? DEFAULT_NESTED_SNAP_THRESHOLD;
+    const nestedFraction = bandCount > 0 ? singleValuedBands / bandCount : 1;
+    const dodge = nestedFraction < threshold;
+    return { dodge, laneCount: globalCount, ambiguous: true, maxPerBand, global: globalCount };
+}
+
+/** User-facing `colorLayout` chart-property values. */
+export type ColorLayoutMode = 'auto' | 'dodge' | 'nested';
+
+/**
+ * Apply a user `colorLayout` override on top of a plan. `dodge`/`nested` are hard
+ * overrides; `auto` (or anything else) follows the plan's recommendation. The
+ * lane count is always the plan's global-derived value.
+ */
+export function resolveBandDodge(
+    plan: BandDodgePlan,
+    override?: string,
+): { dodge: boolean; laneCount: number } {
+    if (override === 'dodge') return { dodge: true, laneCount: plan.laneCount };
+    if (override === 'nested') return { dodge: false, laneCount: plan.laneCount };
+    return { dodge: plan.dodge, laneCount: plan.laneCount };
+}

--- a/packages/flint-js/src/core/compute-layout.ts
+++ b/packages/flint-js/src/core/compute-layout.ts
@@ -342,7 +342,10 @@ export function computeLayout(
     }
     let groupAxis: 'x' | 'y' | undefined;
     if (groupField) {
-        nominalCount.group = new Set(table.map((r: any) => r[groupField])).size;
+        // `local` dodge budgets only `maxPerBand` lanes (declaration.groupLaneCount);
+        // otherwise reserve one lane per global distinct group value.
+        nominalCount.group = declaration.groupLaneCount
+            ?? new Set(table.map((r: any) => r[groupField])).size;
         if (isDiscreteType(effectiveTypes.x ?? channelSemantics.x?.type)) groupAxis = 'x';
         else if (isDiscreteType(effectiveTypes.y ?? channelSemantics.y?.type)) groupAxis = 'y';
     }

--- a/packages/flint-js/src/core/compute-layout.ts
+++ b/packages/flint-js/src/core/compute-layout.ts
@@ -59,6 +59,7 @@ import {
     type ElasticStretchParams,
     type GasPressureParams,
 } from './decisions';
+import { planBandDodge } from './band-dodge';
 
 // ---------------------------------------------------------------------------
 // Short discrete axis labels (align with echarts/templates/bar.ts)
@@ -308,7 +309,7 @@ export function computeLayout(
     }
 
     // Detect grouping from 'group' channel + discrete axis
-    let groupField = channelSemantics.group?.field;
+    let groupField: string | undefined = channelSemantics.group?.field;
     // Some templates (e.g. boxplot) subdivide a band by the COLOR field via an
     // explicit offset rather than a dedicated 'group' channel. When they opt in,
     // size the band as a group so total width is budgeted across categories and
@@ -321,6 +322,22 @@ export function computeLayout(
             : channelSemantics.y?.field;
         if (colorCS?.field && isDiscreteType(colorType) && colorCS.field !== axisField) {
             groupField = colorCS.field;
+        }
+    }
+    // Guard: a grouping field that is redundant/nested with the categorical axis
+    // (group == x, or a 1:1 field pair) doesn't actually subdivide any band, so
+    // grouping it would collapse each bar/box to ~1/N of its band. When no band
+    // holds more than one distinct group value (confident-nested; threshold-
+    // independent), suppress grouping so glyphs fill their whole band. Genuine
+    // grouped charts (any band with >1 group value) are untouched.
+    if (groupField) {
+        const groupAxisField = isDiscreteType(effectiveTypes.x ?? channelSemantics.x?.type)
+            ? channelSemantics.x?.field
+            : channelSemantics.y?.field;
+        if (groupAxisField === groupField) {
+            groupField = undefined;  // group == axis: nothing to dodge
+        } else if (groupAxisField && planBandDodge(table, groupAxisField, groupField).maxPerBand <= 1) {
+            groupField = undefined;  // 1:1 / nested with the axis
         }
     }
     let groupAxis: 'x' | 'y' | undefined;

--- a/packages/flint-js/src/core/index.ts
+++ b/packages/flint-js/src/core/index.ts
@@ -63,6 +63,16 @@ export {
     detectBandedAxisForceDiscrete,
 } from './axis-detection';
 
+// Band-dodge decision (dodge-by-color/group vs. nested full-width)
+export {
+    planBandDodge,
+    resolveBandDodge,
+    DEFAULT_NESTED_SNAP_THRESHOLD,
+    type BandDodgePlan,
+    type PlanBandDodgeOptions,
+    type ColorLayoutMode,
+} from './band-dodge';
+
 // Semantic type system
 export {
     SemanticTypes,

--- a/packages/flint-js/src/core/index.ts
+++ b/packages/flint-js/src/core/index.ts
@@ -67,9 +67,13 @@ export {
 export {
     planBandDodge,
     resolveBandDodge,
+    resolveDodge,
+    laneCountForMode,
     DEFAULT_NESTED_SNAP_THRESHOLD,
     type BandDodgePlan,
     type PlanBandDodgeOptions,
+    type DodgeMode,
+    type DodgeOption,
     type ColorLayoutMode,
 } from './band-dodge';
 

--- a/packages/flint-js/src/core/types.ts
+++ b/packages/flint-js/src/core/types.ts
@@ -243,6 +243,15 @@ export interface LayoutDeclaration {
     colorActsAsGroup?: boolean;
 
     /**
+     * Override the number of sub-lanes the grouping field reserves per band.
+     * When unset, computeLayout uses the global distinct count of the group
+     * field. Templates that render `local` (compact) dodge set this to the
+     * per-band max cardinality (`maxPerBand`) so the band is budgeted for only
+     * as many lanes as the busiest band actually uses.
+     */
+    groupLaneCount?: number;
+
+    /**
      * Custom overflow strategy for deciding which discrete values to keep
      * when a channel overflows. If not provided, the default strategy is used.
      *

--- a/packages/flint-js/src/echarts/templates/bar.ts
+++ b/packages/flint-js/src/echarts/templates/bar.ts
@@ -18,6 +18,7 @@ import {
 } from './utils';
 import type { ColorDecision } from '../../core/color-decisions';
 import { pickEChartsPalette } from '../colormap';
+import { planBandDodge, resolveDodge } from '../../core/band-dodge';
 import {
     detectBandedAxisFromSemantics, detectBandedAxisForceDiscrete,
 } from '../../core/axis-detection';
@@ -28,6 +29,57 @@ import { makeCartesianPivot } from '../../core/pivot';
 // ---------------------------------------------------------------------------
 
 const isDiscrete = (type: string | undefined) => type === 'nominal' || type === 'ordinal';
+
+/**
+ * `local` dodge for grouped bars: build `maxPerBand` LANE series (native ECharts
+ * grouping = compact, left-anchored) instead of one series per global group.
+ * Each bar is colored per-datum by its actual group value, and a custom legend
+ * maps group → color. Returns the series[] + legend data, or null when the plan
+ * doesn't call for local dodge.
+ */
+function buildLocalLaneSeries(
+    table: any[],
+    categories: string[],
+    catField: string,
+    groupField: string,
+    valField: string,
+    groupColor: (g: string) => string,
+): { series: any[]; legendData: { name: string; itemStyle: { color: string } }[] } | null {
+    const globalGroups: string[] = [...new Set(table.map((r) => String(r[groupField] ?? '')))].filter(Boolean);
+    // Per-band ordered present groups → lane index.
+    const perBand = new Map<string, string[]>();
+    for (const cat of categories) perBand.set(cat, []);
+    for (const r of table) {
+        const cat = String(r[catField] ?? '');
+        const g = String(r[groupField] ?? '');
+        if (!perBand.has(cat) || !g) continue;
+        const arr = perBand.get(cat)!;
+        if (!arr.includes(g)) arr.push(g);
+    }
+    for (const arr of perBand.values()) arr.sort();
+    const maxPerBand = Math.max(1, ...[...perBand.values()].map((a) => a.length));
+    if (maxPerBand <= 1) return null;
+
+    // value lookup per (cat, group)
+    const valAt = new Map<string, number>();
+    for (const r of table) {
+        const v = Number(r[valField]);
+        if (isFinite(v)) valAt.set(`${r[catField]}\u0000${r[groupField]}`, v);
+    }
+
+    const series = Array.from({ length: maxPerBand }, (_, lane) => ({
+        type: 'bar',
+        name: `__lane${lane}`,
+        data: categories.map((cat) => {
+            const g = perBand.get(cat)?.[lane];
+            if (g === undefined) return '-';
+            const v = valAt.get(`${cat}\u0000${g}`);
+            return v === undefined ? '-' : { value: v, itemStyle: { color: groupColor(g) } };
+        }),
+    }));
+    const legendData = globalGroups.map((g) => ({ name: g, itemStyle: { color: groupColor(g) } }));
+    return { series, legendData };
+}
 
 /**
  * For a category-axis bar chart, build an array of values aligned to the
@@ -639,13 +691,22 @@ export const ecGroupedBarChartDef: ChartTemplateDef = {
     template: { mark: 'bar', encoding: {} },
     channels: ['x', 'y', 'group', 'color', 'column', 'row'],
     markCognitiveChannel: 'length',
-    declareLayoutMode: (cs, table) => {
+    declareLayoutMode: (cs, table, chartProperties) => {
         const result = detectBandedAxisForceDiscrete(cs, table, { preferAxis: 'x' });
         const axis = result?.axis || 'x';
-        return {
+        const decl: import('../../core/types').LayoutDeclaration = {
             axisFlags: { [axis]: { banded: true } },
             resolvedTypes: result?.resolvedTypes,
         };
+        // `local` dodge budgets only maxPerBand lanes per band (compact).
+        const groupField = cs.group?.field || cs.color?.field;
+        const axisField = cs[axis]?.field;
+        if (groupField && axisField) {
+            const plan = planBandDodge(table, axisField, groupField);
+            const { mode } = resolveDodge(plan, chartProperties?.dodge);
+            if (mode === 'local') decl.groupLaneCount = Math.max(1, plan.maxPerBand);
+        }
+        return decl;
     },
     instantiate: (spec, ctx) => {
         const { channelSemantics, table } = ctx;
@@ -874,6 +935,24 @@ export const ecGroupedBarChartDef: ChartTemplateDef = {
                     // 颜色由全局 palette 决定。
                 });
             }
+
+            // `local` dodge → rebuild as compact maxPerBand lane-series (native,
+            // left-anchored), colored per-datum by group. Replaces the per-group
+            // series built above. `none`/`global` keep the native series above.
+            const gAxisField = channelSemantics[categoryAxis]?.field;
+            if (gAxisField) {
+                const plan = planBandDodge(ctx.fullTable ?? table, gAxisField, groupField);
+                const { mode } = resolveDodge(plan, ctx.chartProperties?.dodge);
+                if (mode === 'local') {
+                    const palette = pickEChartsPalette(ctx.colorDecisions?.group ?? ctx.colorDecisions?.color);
+                    const colorFor = (g: string) => palette[legendKeys.indexOf(g) % palette.length] ?? palette[0];
+                    const built = buildLocalLaneSeries(table, categories, catField, groupField, valField, colorFor);
+                    if (built) {
+                        option.series = built.series;
+                        option.legend.data = built.legendData;
+                    }
+                }
+            }
         } else {
             // No grouping — single series
             const data = buildCategoryValues(table, catField, valField, categories);
@@ -884,6 +963,27 @@ export const ecGroupedBarChartDef: ChartTemplateDef = {
         delete spec.mark;
         delete spec.encoding;
     },
+    properties: [
+        {
+            key: 'dodge', label: 'Dodge', type: 'discrete',
+            options: [
+                { value: 'auto',   label: 'Auto' },
+                { value: 'local',  label: 'Local (compact)' },
+                { value: 'global', label: 'Global (aligned)' },
+            ],
+            defaultValue: 'auto',
+            check: (ctx) => {
+                const groupField = ctx.channelSemantics?.group?.field ?? ctx.encodings?.group?.field;
+                const axisField = isDiscrete(ctx.channelSemantics?.x?.type)
+                    ? ctx.channelSemantics?.x?.field
+                    : ctx.channelSemantics?.y?.field;
+                const rows = ctx.data;
+                if (!groupField || !axisField || !rows) return { applicable: false };
+                const plan = planBandDodge(rows, axisField, groupField);
+                return { applicable: plan.ambiguous, recommendedValue: plan.mode === 'none' ? 'auto' : plan.mode };
+            },
+        } as ChartPropertyDef,
+    ],
     pivot: makeCartesianPivot({
         transpose: [['x', 'y']],
         permute: [['x', 'y', 'color']],

--- a/packages/flint-js/src/echarts/templates/boxplot.ts
+++ b/packages/flint-js/src/echarts/templates/boxplot.ts
@@ -14,7 +14,8 @@
 import { ChartTemplateDef, ChartPropertyDef } from '../../core/types';
 import { extractCategories, groupBy, getCategoryOrder } from './utils';
 import { detectBandedAxisForceDiscrete } from '../../core/axis-detection';
-import { planBandDodge, resolveBandDodge } from '../../core/band-dodge';
+import { planBandDodge, resolveDodge } from '../../core/band-dodge';
+import { pickEChartsPalette } from '../colormap';
 
 const isDiscrete = (type: string | undefined) => type === 'nominal' || type === 'ordinal';
 
@@ -83,15 +84,23 @@ export const ecBoxplotDef: ChartTemplateDef = {
     template: { mark: 'boxplot', encoding: {} },
     channels: ['x', 'y', 'color', 'opacity', 'column', 'row'],
     markCognitiveChannel: 'position',
-    declareLayoutMode: (cs, table) => {
+    declareLayoutMode: (cs, table, chartProperties) => {
         if (!cs.x?.field || !cs.y?.field) return {};
         const result = detectBandedAxisForceDiscrete(cs, table, { preferAxis: 'x' });
         if (!result) return {};
-        return {
+        const decl: import('../../core/types').LayoutDeclaration = {
             axisFlags: { [result.axis]: { banded: true } },
             resolvedTypes: result.resolvedTypes,
             paramOverrides: { defaultBandSize: 28 },  // box+whisker needs wider bands
         };
+        const colorField = cs.color?.field;
+        const axisField = cs[result.axis]?.field;
+        if (colorField && axisField && isDiscrete(cs.color?.type)) {
+            const plan = planBandDodge(table, axisField, colorField);
+            const { mode } = resolveDodge(plan, chartProperties?.dodge);
+            if (mode === 'local') decl.groupLaneCount = Math.max(1, plan.maxPerBand);
+        }
+        return decl;
     },
     instantiate: (spec, ctx) => {
         const { channelSemantics, table } = ctx;
@@ -133,14 +142,13 @@ export const ecBoxplotDef: ChartTemplateDef = {
         // or a 1:1 field pair) — in which case a single boxplot series is correct.
         // Sharing `planBandDodge` avoids the collapse-to-slivers bug AND the
         // degenerate zero-boxes that a per-color series would draw in empty cells.
-        const dodgeColor = colorIsDiscrete && colorField
-            ? resolveBandDodge(
-                planBandDodge(ctx.fullTable ?? table, catField, colorField, {
-                    nestedSnapThreshold: ctx.chartProperties?.nestedSnapThreshold,
-                }),
-                ctx.chartProperties?.colorLayout,
-            ).dodge
-            : false;
+        const dodgePlan = colorIsDiscrete && colorField
+            ? planBandDodge(ctx.fullTable ?? table, catField, colorField, {
+                nestedSnapThreshold: ctx.chartProperties?.nestedSnapThreshold,
+            })
+            : null;
+        const dodgeMode = dodgePlan ? resolveDodge(dodgePlan, ctx.chartProperties?.dodge).mode : 'none';
+        const dodgeColor = dodgeMode !== 'none';
 
         // 颜色由 ecApplyLayoutToSpec 根据 colorDecisions 统一分配（不在此处硬编码）
         const isHorizontal = catAxis === 'y';
@@ -167,7 +175,57 @@ export const ecBoxplotDef: ChartTemplateDef = {
             series: [],
         };
 
-        if (colorIsDiscrete && colorField && dodgeColor) {
+        if (colorIsDiscrete && colorField && dodgeMode === 'local') {
+            // Local (compact) dodge: only `maxPerBand` lanes, packed left-aligned
+            // per band. Each lane is a boxplot series; a band that has fewer than
+            // `maxPerBand` present colors simply leaves trailing lanes null. Boxes
+            // are colored per-datum by their color value (a custom legend maps the
+            // color value → swatch, since lane-series names are synthetic).
+            const globalColors = [...new Set(
+                (ctx.fullTable ?? table).map((r: any) => String(r[colorField] ?? '')),
+            )].filter(Boolean).sort();
+            const palette = pickEChartsPalette(ctx.colorDecisions?.color);
+            const colorFor = (g: string) => palette[Math.max(0, globalColors.indexOf(g)) % palette.length];
+
+            // Per-band ordered present colors → lane index.
+            const perBand = new Map<string, string[]>();
+            for (const cat of categories) perBand.set(cat, []);
+            for (const r of table) {
+                const cat = String(r[catField] ?? '');
+                const g = String(r[colorField] ?? '');
+                if (!perBand.has(cat) || !g) continue;
+                const arr = perBand.get(cat)!;
+                if (!arr.includes(g)) arr.push(g);
+            }
+            for (const arr of perBand.values()) arr.sort();
+            const maxPerBand = Math.max(1, ...[...perBand.values()].map((a) => a.length));
+
+            // value lookup per (cat, color)
+            const catGroups = groupBy(table, catField);
+            for (let lane = 0; lane < maxPerBand; lane++) {
+                const boxData: ({ value: [number, number, number, number, number]; itemStyle: any } | null)[] = [];
+                const outlierData: any[] = [];
+                for (let i = 0; i < categories.length; i++) {
+                    const cat = categories[i];
+                    const g = perBand.get(cat)?.[lane];
+                    if (g === undefined) { boxData.push(null); continue; }
+                    const rows = (catGroups.get(cat) || []).filter((r: any) => String(r[colorField] ?? '') === g);
+                    const values = rows.map((r: any) => Number(r[valField])).filter((v: number) => isFinite(v));
+                    if (!values.length) { boxData.push(null); continue; }
+                    const c = colorFor(g);
+                    boxData.push({ value: fiveNumberSummary(values, whiskerMethod), itemStyle: { color: c, borderColor: c } });
+                    if (showOutliers) {
+                        for (const o of findOutliers(values)) outlierData.push({ value: [i, o], itemStyle: { color: c } });
+                    }
+                }
+                option.series.push({ name: `__lane${lane}`, type: 'boxplot', data: boxData });
+                if (outlierData.length > 0) {
+                    option.series.push({ name: `__lane${lane} (outliers)`, type: 'scatter', data: outlierData, symbolSize: 4 });
+                }
+            }
+            option.legend = { data: globalColors.map((g) => ({ name: g, itemStyle: { color: colorFor(g) } })) };
+            option._legendTitle = colorField;
+        } else if (colorIsDiscrete && colorField && dodgeColor) {
             // Grouped boxplot: one series per color value (e.g. Male, Female)
             const colorCategories = extractCategories(table, colorField, getCategoryOrder(ctx, 'color'));
             const catGroups = groupBy(table, catField);
@@ -268,11 +326,11 @@ export const ecBoxplotDef: ChartTemplateDef = {
             check: (ctx) => ({ applicable: ctx.chartProperties?.whiskerMethod !== 'minmax' }),
         } as ChartPropertyDef,
         {
-            key: 'colorLayout', label: 'Color layout', type: 'discrete',
+            key: 'dodge', label: 'Dodge', type: 'discrete',
             options: [
                 { value: 'auto',   label: 'Auto' },
-                { value: 'dodge',  label: 'Side by side' },
-                { value: 'nested', label: 'One per band' },
+                { value: 'local',  label: 'Local (compact)' },
+                { value: 'global', label: 'Global (aligned)' },
             ],
             defaultValue: 'auto',
             check: (ctx) => {
@@ -288,7 +346,7 @@ export const ecBoxplotDef: ChartTemplateDef = {
                 const plan = planBandDodge(rows, axisField, colorField, {
                     nestedSnapThreshold: ctx.chartProperties?.nestedSnapThreshold,
                 });
-                return { applicable: plan.ambiguous, recommendedValue: plan.dodge ? 'dodge' : 'nested' };
+                return { applicable: plan.ambiguous, recommendedValue: plan.mode === 'none' ? 'auto' : plan.mode };
             },
         } as ChartPropertyDef,
     ],

--- a/packages/flint-js/src/echarts/templates/boxplot.ts
+++ b/packages/flint-js/src/echarts/templates/boxplot.ts
@@ -14,6 +14,7 @@
 import { ChartTemplateDef, ChartPropertyDef } from '../../core/types';
 import { extractCategories, groupBy, getCategoryOrder } from './utils';
 import { detectBandedAxisForceDiscrete } from '../../core/axis-detection';
+import { planBandDodge, resolveBandDodge } from '../../core/band-dodge';
 
 const isDiscrete = (type: string | undefined) => type === 'nominal' || type === 'ordinal';
 
@@ -127,6 +128,20 @@ export const ecBoxplotDef: ChartTemplateDef = {
         const catCS = channelSemantics[catAxis];
         const categories = extractCategories(table, catField, catCS?.ordinalSortOrder);
 
+        // Decide whether `color` genuinely subdivides a category band (dodge into
+        // one series per color) or is redundant/nested with the axis (`color == x`
+        // or a 1:1 field pair) — in which case a single boxplot series is correct.
+        // Sharing `planBandDodge` avoids the collapse-to-slivers bug AND the
+        // degenerate zero-boxes that a per-color series would draw in empty cells.
+        const dodgeColor = colorIsDiscrete && colorField
+            ? resolveBandDodge(
+                planBandDodge(ctx.fullTable ?? table, catField, colorField, {
+                    nestedSnapThreshold: ctx.chartProperties?.nestedSnapThreshold,
+                }),
+                ctx.chartProperties?.colorLayout,
+            ).dodge
+            : false;
+
         // 颜色由 ecApplyLayoutToSpec 根据 colorDecisions 统一分配（不在此处硬编码）
         const isHorizontal = catAxis === 'y';
 
@@ -152,14 +167,14 @@ export const ecBoxplotDef: ChartTemplateDef = {
             series: [],
         };
 
-        if (colorIsDiscrete && colorField) {
+        if (colorIsDiscrete && colorField && dodgeColor) {
             // Grouped boxplot: one series per color value (e.g. Male, Female)
             const colorCategories = extractCategories(table, colorField, getCategoryOrder(ctx, 'color'));
             const catGroups = groupBy(table, catField);
 
             for (let cIdx = 0; cIdx < colorCategories.length; cIdx++) {
                 const colorName = colorCategories[cIdx];
-                const boxData: [number, number, number, number, number][] = [];
+                const boxData: ([number, number, number, number, number] | null)[] = [];
                 const outlierData: [number, number][] = [];
 
                 for (let i = 0; i < categories.length; i++) {
@@ -168,7 +183,11 @@ export const ecBoxplotDef: ChartTemplateDef = {
                         (r: any) => String(r[colorField] ?? '') === colorName,
                     );
                     const values = rows.map((r: any) => Number(r[valField])).filter(v => isFinite(v));
-                    boxData.push(fiveNumberSummary(values, whiskerMethod));
+                    // Empty (category, color) cells must draw NO box. Pushing a
+                    // five-number summary of [] yields [0,0,0,0,0] — a degenerate
+                    // flat box at 0 in every unoccupied lane (the sparse-dodge
+                    // zero-box bug). `null` leaves the lane blank.
+                    boxData.push(values.length ? fiveNumberSummary(values, whiskerMethod) : null);
 
                     if (showOutliers) {
                         for (const o of findOutliers(values)) {
@@ -247,6 +266,30 @@ export const ecBoxplotDef: ChartTemplateDef = {
         {
             key: 'showOutliers', label: 'Outliers', type: 'binary', defaultValue: true,
             check: (ctx) => ({ applicable: ctx.chartProperties?.whiskerMethod !== 'minmax' }),
+        } as ChartPropertyDef,
+        {
+            key: 'colorLayout', label: 'Color layout', type: 'discrete',
+            options: [
+                { value: 'auto',   label: 'Auto' },
+                { value: 'dodge',  label: 'Side by side' },
+                { value: 'nested', label: 'One per band' },
+            ],
+            defaultValue: 'auto',
+            check: (ctx) => {
+                const colorField = ctx.channelSemantics?.color?.field;
+                const colorType = ctx.channelSemantics?.color?.type;
+                const axisField = isDiscrete(ctx.channelSemantics?.x?.type)
+                    ? ctx.channelSemantics?.x?.field
+                    : ctx.channelSemantics?.y?.field;
+                const rows = ctx.data;
+                if (!colorField || !axisField || !isDiscrete(colorType) || !rows) {
+                    return { applicable: false };
+                }
+                const plan = planBandDodge(rows, axisField, colorField, {
+                    nestedSnapThreshold: ctx.chartProperties?.nestedSnapThreshold,
+                });
+                return { applicable: plan.ambiguous, recommendedValue: plan.dodge ? 'dodge' : 'nested' };
+            },
         } as ChartPropertyDef,
     ],
 };

--- a/packages/flint-js/src/test-data/bar-tests.ts
+++ b/packages/flint-js/src/test-data/bar-tests.ts
@@ -495,5 +495,40 @@ export function genGroupedBarTests(): TestCase[] {
         });
     }
 
+    // Explicit global vs local dodge demo (sparse region × channel).
+    {
+        const regions = ['North', 'South', 'East', 'West', 'Central', 'Coast'];
+        const channels = ['Retail', 'Online', 'Wholesale', 'Direct'];
+        const subset: Record<string, string[]> = {
+            North: ['Retail', 'Online'], South: ['Online', 'Wholesale', 'Direct'], East: ['Wholesale', 'Direct'],
+            West: ['Retail', 'Direct'], Central: ['Retail', 'Online', 'Wholesale'], Coast: ['Online', 'Direct'],
+        };
+        const mkData = () => {
+            const d: any[] = [];
+            regions.forEach((r, ri) => subset[r].forEach((ch, ci) => d.push({ Region: r, Channel: ch, Sales: Math.round(300 + ri * 40 + ci * 30) })));
+            return d;
+        };
+        const meta = {
+            Region: { type: Type.String, semanticType: 'Category', levels: regions },
+            Sales: { type: Type.Number, semanticType: 'Quantity', levels: [] },
+            Channel: { type: Type.String, semanticType: 'Category', levels: channels },
+        };
+        for (const mode of ['global', 'local'] as const) {
+            tests.push({
+                title: mode === 'global' ? 'Dodge = Global (aligned)' : 'Dodge = Local (compact)',
+                description: mode === 'global'
+                    ? 'fixed lane per channel across regions — gaps where a channel is absent'
+                    : 'compact maxPerBand lanes per region (VL centered; EC left-aligned)',
+                tags: ['grouped-bar', 'sparse', `dodge-${mode}`, 'gallery-pin'],
+                chartType: 'Grouped Bar Chart',
+                data: mkData(),
+                fields: [makeField('Region'), makeField('Sales'), makeField('Channel')],
+                metadata: meta,
+                chartProperties: { dodge: mode },
+                encodingMap: { x: makeEncodingItem('Region'), y: makeEncodingItem('Sales'), group: makeEncodingItem('Channel') },
+            });
+        }
+    }
+
     return tests;
 }

--- a/packages/flint-js/src/test-data/bar-tests.ts
+++ b/packages/flint-js/src/test-data/bar-tests.ts
@@ -95,9 +95,8 @@ const STACKED_BAR_MATRIX: BarMatrixEntry[] = [
     { x: 'Q', y: 'N', n: 24,  yCard: 8,  color: 'N', colorCard: 3, desc: 'Horizontal stack — 8 cats × 3' },
     { x: 'Q', y: 'T', n: 45,  color: 'N', colorCard: 3, desc: 'Horizontal temporal stack — 15 dates × 3' },
 
-    // ── Edge combos (2 tests) ───────────────────────────────────────
+    // ── Edge combos (1 test) ─────────────────────────────────
     { x: 'N', y: 'N', n: 0,  xCard: 5, yCard: 5, color: 'N', colorCard: 3, desc: 'Cat × cat stacked (degenerate)', extraTags: ['edge-case'] },
-    { x: 'T', y: 'N', n: 20, yCard: 5,  color: 'N', colorCard: 4, desc: 'Temporal × cat stacked' },
 ];
 
 const GROUPED_BAR_MATRIX: BarMatrixEntry[] = [
@@ -121,9 +120,8 @@ const GROUPED_BAR_MATRIX: BarMatrixEntry[] = [
     { x: 'N', y: 'Q', n: 400, xCard: 8,  color: 'Q', colorCard: 50, desc: 'Numeric group (1–50) — large' },
     { x: 'N', y: 'Q', n: 50,  xCard: 5,  color: 'Q', desc: 'Continuous float on group — gradient' },
 
-    // ── Edge combos (2 tests) ───────────────────────────────────────
+    // ── Edge combos (1 test) ─────────────────────────────────
     { x: 'N', y: 'N', n: 0,  xCard: 5, yCard: 5, color: 'N', colorCard: 3, desc: 'Cat × cat grouped (degenerate)', extraTags: ['edge-case'] },
-    { x: 'T', y: 'N', n: 20, yCard: 5,  color: 'N', colorCard: 4, desc: 'Temporal × cat grouped' },
 ];
 
 // ============================================================================
@@ -427,5 +425,75 @@ export function genStackedBarTests(): TestCase[] {
 
 export function genGroupedBarTests(): TestCase[] {
     const rand = seededRandom(300);
-    return GROUPED_BAR_MATRIX.map(entry => barMatrixToTestCase(entry, 'Grouped Bar Chart', 'group', rand));
+    const tests = GROUPED_BAR_MATRIX.map(entry => barMatrixToTestCase(entry, 'Grouped Bar Chart', 'group', rand));
+
+    // Group redundant with the x axis (group == x): must render full-width bars,
+    // NOT ~1/N slivers. Grouping a bar chart by its own category is degenerate,
+    // so the dodge is suppressed and each band shows one bar.
+    {
+        const cats = genCategories('Region', 5);
+        const data = cats.map((c, i) => ({ Region: c, Sales: Math.round(200 + rand() * 800) + i }));
+        tests.push({
+            title: 'Group == X (redundant group)',
+            description: 'group re-encodes the x category — one full-width bar per band, no dodge',
+            tags: ['grouped-bar', 'redundant-group', 'nominal', 'gallery-pin'],
+            chartType: 'Grouped Bar Chart',
+            data,
+            fields: [makeField('Region'), makeField('Sales')],
+            metadata: {
+                Region: { type: Type.String, semanticType: 'Category', levels: cats },
+                Sales: { type: Type.Number, semanticType: 'Quantity', levels: [] },
+            },
+            encodingMap: {
+                x: makeEncodingItem('Region'),
+                y: makeEncodingItem('Sales'),
+                group: makeEncodingItem('Region'),
+            },
+        });
+    }
+
+    // Sparse / MIDDLE case: neither a perfect cross-product nor all-single-item.
+    // Each region carries a SUBSET of the 4 global channels (maxPerBand 2–3,
+    // global 4), so the ambiguous-zone heuristic (nestedSnapThreshold) leans to
+    // dodge — bars sized by the GLOBAL lane count (4), with gaps where a
+    // (region, channel) pair is missing rather than overlapping bars.
+    {
+        const regions = ['North', 'South', 'East', 'West', 'Central', 'Coast'];
+        const channels = ['Retail', 'Online', 'Wholesale', 'Direct'];
+        // Each region has 2–3 of the 4 channels (rotating subsets).
+        const subset: Record<string, string[]> = {
+            North:   ['Retail', 'Online'],
+            South:   ['Online', 'Wholesale', 'Direct'],
+            East:    ['Wholesale', 'Direct'],
+            West:    ['Retail', 'Direct'],
+            Central: ['Retail', 'Online', 'Wholesale'],
+            Coast:   ['Online', 'Direct'],
+        };
+        const data: any[] = [];
+        regions.forEach((r, ri) => {
+            subset[r].forEach((ch, ci) => {
+                data.push({ Region: r, Channel: ch, Sales: Math.round(300 + rand() * 700) + ri * 10 + ci });
+            });
+        });
+        tests.push({
+            title: 'Sparse groups (region × channel subset)',
+            description: 'each region has 2–3 of 4 channels — dodges, bars sized by global lane count (no overlap)',
+            tags: ['grouped-bar', 'sparse', 'ambiguous', 'nominal', 'gallery-pin'],
+            chartType: 'Grouped Bar Chart',
+            data,
+            fields: [makeField('Region'), makeField('Sales'), makeField('Channel')],
+            metadata: {
+                Region:  { type: Type.String, semanticType: 'Category', levels: regions },
+                Sales:   { type: Type.Number, semanticType: 'Quantity', levels: [] },
+                Channel: { type: Type.String, semanticType: 'Category', levels: channels },
+            },
+            encodingMap: {
+                x: makeEncodingItem('Region'),
+                y: makeEncodingItem('Sales'),
+                group: makeEncodingItem('Channel'),
+            },
+        });
+    }
+
+    return tests;
 }

--- a/packages/flint-js/src/test-data/chartjs-tests.ts
+++ b/packages/flint-js/src/test-data/chartjs-tests.ts
@@ -465,6 +465,35 @@ export function genChartJsAreaTests(): TestCase[] {
         });
     }
 
+    // Global vs local dodge (sparse region × channel).
+    {
+        const regions = ['North', 'South', 'East', 'West', 'Central', 'Coast'];
+        const channels = ['Retail', 'Online', 'Wholesale', 'Direct'];
+        const subset: Record<string, string[]> = {
+            North: ['Retail', 'Online'], South: ['Online', 'Wholesale', 'Direct'], East: ['Wholesale', 'Direct'],
+            West: ['Retail', 'Direct'], Central: ['Retail', 'Online', 'Wholesale'], Coast: ['Online', 'Direct'],
+        };
+        for (const mode of ['global', 'local'] as const) {
+            const data: any[] = [];
+            regions.forEach((r, ri) => subset[r].forEach((ch, ci) => data.push({ Region: r, Channel: ch, Sales: Math.round(300 + ri * 40 + ci * 30) })));
+            tests.push({
+                title: mode === 'global' ? 'CJS: Grouped Bar — Dodge Global' : 'CJS: Grouped Bar — Dodge Local',
+                description: mode === 'global' ? 'fixed lane per channel (gaps where absent)' : 'compact maxPerBand lanes, left-aligned',
+                tags: ['chartjs', 'grouped-bar', 'sparse', `dodge-${mode}`],
+                chartType: 'Grouped Bar Chart',
+                data,
+                fields: [makeField('Region'), makeField('Sales'), makeField('Channel')],
+                metadata: {
+                    Region: { type: Type.String, semanticType: 'Category', levels: regions },
+                    Sales: { type: Type.Number, semanticType: 'Quantity', levels: [] },
+                    Channel: { type: Type.String, semanticType: 'Category', levels: channels },
+                },
+                chartProperties: { dodge: mode },
+                encodingMap: { x: makeEncodingItem('Region'), y: makeEncodingItem('Sales'), group: makeEncodingItem('Channel') },
+            });
+        }
+    }
+
     return tests;
 }
 

--- a/packages/flint-js/src/test-data/distribution-tests.ts
+++ b/packages/flint-js/src/test-data/distribution-tests.ts
@@ -272,6 +272,42 @@ export function genBoxplotTests(): TestCase[] {
         });
     }
 
+    // Explicit global vs local dodge demo (sparse dept × level).
+    {
+        const depts = ['Eng', 'Sales', 'HR', 'Ops', 'Legal', 'Finance'];
+        const levels = ['L1', 'L2', 'L3', 'L4', 'L5'];
+        const subset: Record<string, string[]> = {
+            Eng: ['L1', 'L2'], Sales: ['L2', 'L3'], HR: ['L3', 'L4'], Ops: ['L4', 'L5'], Legal: ['L5', 'L1'], Finance: ['L1', 'L3'],
+        };
+        const mkData = () => {
+            const d: any[] = [];
+            for (const dp of depts) for (const l of subset[dp]) for (let i = 0; i < 18; i++) {
+                d.push({ Department: dp, Level: l, Comp: Math.round(30000 + (l.charCodeAt(1) % 5) * 15000 + rand() * 90000) });
+            }
+            return d;
+        };
+        const meta = {
+            Department: { type: Type.String, semanticType: 'Department', levels: depts },
+            Comp: { type: Type.Number, semanticType: 'Amount', levels: [] },
+            Level: { type: Type.String, semanticType: 'Category', levels: levels },
+        };
+        for (const mode of ['global', 'local'] as const) {
+            tests.push({
+                title: mode === 'global' ? 'Dodge = Global (aligned)' : 'Dodge = Local (compact)',
+                description: mode === 'global'
+                    ? 'fixed lane per level across depts — gaps where a level is absent'
+                    : 'compact maxPerBand lanes per dept, centered (VL)',
+                tags: ['nominal', 'quantitative', 'color', 'sparse', `dodge-${mode}`, 'gallery-pin'],
+                chartType: 'Boxplot',
+                data: mkData(),
+                fields: [makeField('Department'), makeField('Comp'), makeField('Level')],
+                metadata: meta,
+                chartProperties: { dodge: mode },
+                encodingMap: { x: makeEncodingItem('Department'), y: makeEncodingItem('Comp'), color: makeEncodingItem('Level') },
+            });
+        }
+    }
+
     return tests;
 }
 

--- a/packages/flint-js/src/test-data/distribution-tests.ts
+++ b/packages/flint-js/src/test-data/distribution-tests.ts
@@ -219,6 +219,59 @@ export function genBoxplotTests(): TestCase[] {
         });
     }
 
+    // 7. Color redundant with axis (color == x) — must render full-width boxes,
+    //    NOT ~1/N slivers. Colors each category by its own axis value.
+    {
+        const ratings = ['G', 'PG', 'PG-13', 'R', 'NC-17', 'Unrated'];
+        const data: any[] = [];
+        for (const r of ratings) for (let i = 0; i < 30; i++) {
+            data.push({ Rating: r, ROI: Math.round(rand() * 300) });
+        }
+        tests.push({
+            title: 'Color == X (redundant color)',
+            description: 'color re-encodes the x category — one full-width box per band, no dodge',
+            tags: ['nominal', 'quantitative', 'color', 'redundant-color', 'medium', 'gallery-pin'],
+            chartType: 'Boxplot',
+            data,
+            fields: [makeField('Rating'), makeField('ROI')],
+            metadata: {
+                Rating: { type: Type.String, semanticType: 'Category', levels: ratings },
+                ROI: { type: Type.Number, semanticType: 'Quantity', levels: [] },
+            },
+            encodingMap: { x: makeEncodingItem('Rating'), y: makeEncodingItem('ROI'), color: makeEncodingItem('Rating') },
+        });
+    }
+
+    // 8. Sparse cross-product (dept × level, each dept holds only some levels).
+    //    Genuine 2nd dimension → dodges, but sized by the GLOBAL lane count so
+    //    occupied lanes never overlap.
+    {
+        const depts = ['Eng', 'Sales', 'HR', 'Ops', 'Legal', 'Finance'];
+        const levels = ['L1', 'L2', 'L3', 'L4', 'L5'];
+        const subset: Record<string, string[]> = {
+            Eng: ['L1', 'L2'], Sales: ['L2', 'L3'], HR: ['L3', 'L4'],
+            Ops: ['L4', 'L5'], Legal: ['L5', 'L1'], Finance: ['L1', 'L3'],
+        };
+        const data: any[] = [];
+        for (const d of depts) for (const l of subset[d]) for (let i = 0; i < 18; i++) {
+            data.push({ Department: d, Level: l, Comp: Math.round(30000 + rand() * 120000) });
+        }
+        tests.push({
+            title: 'Sparse cross-product (dept × level)',
+            description: 'each dept has 2 of 5 levels — dodges, boxes sized by global lane count',
+            tags: ['nominal', 'quantitative', 'color', 'sparse', 'medium', 'gallery-pin'],
+            chartType: 'Boxplot',
+            data,
+            fields: [makeField('Department'), makeField('Comp'), makeField('Level')],
+            metadata: {
+                Department: { type: Type.String, semanticType: 'Department', levels: depts },
+                Comp: { type: Type.Number, semanticType: 'Amount', levels: [] },
+                Level: { type: Type.String, semanticType: 'Category', levels: levels },
+            },
+            encodingMap: { x: makeEncodingItem('Department'), y: makeEncodingItem('Comp'), color: makeEncodingItem('Level') },
+        });
+    }
+
     return tests;
 }
 

--- a/packages/flint-js/src/test-data/echarts-tests.ts
+++ b/packages/flint-js/src/test-data/echarts-tests.ts
@@ -436,12 +436,38 @@ export function genEChartsGroupedBarTests(): TestCase[] {
         });
     }
 
+    // Global vs local dodge (sparse region × channel). EC local = compact
+    // maxPerBand lane-series (left-aligned).
+    {
+        const regions = ['North', 'South', 'East', 'West', 'Central', 'Coast'];
+        const channels = ['Retail', 'Online', 'Wholesale', 'Direct'];
+        const subset: Record<string, string[]> = {
+            North: ['Retail', 'Online'], South: ['Online', 'Wholesale', 'Direct'], East: ['Wholesale', 'Direct'],
+            West: ['Retail', 'Direct'], Central: ['Retail', 'Online', 'Wholesale'], Coast: ['Online', 'Direct'],
+        };
+        for (const mode of ['global', 'local'] as const) {
+            const data: any[] = [];
+            regions.forEach((r, ri) => subset[r].forEach((ch, ci) => data.push({ Region: r, Channel: ch, Sales: Math.round(300 + ri * 40 + ci * 30) })));
+            tests.push({
+                title: mode === 'global' ? 'EC: Grouped Bar — Dodge Global' : 'EC: Grouped Bar — Dodge Local',
+                description: mode === 'global' ? 'fixed lane per channel (gaps where absent)' : 'compact maxPerBand lanes, left-aligned',
+                tags: ['echarts', 'grouped-bar', 'sparse', `dodge-${mode}`],
+                chartType: 'Grouped Bar Chart',
+                data,
+                fields: [makeField('Region'), makeField('Sales'), makeField('Channel')],
+                metadata: {
+                    Region: { type: Type.String, semanticType: 'Category', levels: regions },
+                    Sales: { type: Type.Number, semanticType: 'Quantity', levels: [] },
+                    Channel: { type: Type.String, semanticType: 'Category', levels: channels },
+                },
+                chartProperties: { dodge: mode },
+                encodingMap: { x: makeEncodingItem('Region'), y: makeEncodingItem('Sales'), group: makeEncodingItem('Channel') },
+            });
+        }
+    }
+
     return tests;
 }
-
-// ---------------------------------------------------------------------------
-// Stress / overflow test cases
-// ---------------------------------------------------------------------------
 
 export function genEChartsStressTests(): TestCase[] {
     const tests: TestCase[] = [];
@@ -920,12 +946,39 @@ export function genEChartsBoxplotTests(): TestCase[] {
         });
     }
 
+    // Global vs local dodge (sparse dept × level).
+    {
+        const depts = ['Eng', 'Sales', 'HR', 'Ops', 'Legal', 'Finance'];
+        const levels = ['L1', 'L2', 'L3', 'L4', 'L5'];
+        const subset: Record<string, string[]> = {
+            Eng: ['L1', 'L2'], Sales: ['L2', 'L3'], HR: ['L3', 'L4'], Ops: ['L4', 'L5'], Legal: ['L5', 'L1'], Finance: ['L1', 'L3'],
+        };
+        const rand = seededRandom(880);
+        for (const mode of ['global', 'local'] as const) {
+            const data: any[] = [];
+            for (const dp of depts) for (const l of subset[dp]) for (let i = 0; i < 18; i++) {
+                data.push({ Department: dp, Level: l, Comp: Math.round(30000 + (l.charCodeAt(1) % 5) * 15000 + rand() * 90000) });
+            }
+            tests.push({
+                title: mode === 'global' ? 'EC: Boxplot — Dodge Global' : 'EC: Boxplot — Dodge Local',
+                description: mode === 'global' ? 'fixed lane per level (gaps where absent)' : 'compact maxPerBand lanes, left-aligned',
+                tags: ['echarts', 'boxplot', 'sparse', `dodge-${mode}`],
+                chartType: 'Boxplot',
+                data,
+                fields: [makeField('Department'), makeField('Comp'), makeField('Level')],
+                metadata: {
+                    Department: { type: Type.String, semanticType: 'Category', levels: depts },
+                    Comp: { type: Type.Number, semanticType: 'Amount', levels: [] },
+                    Level: { type: Type.String, semanticType: 'Category', levels: levels },
+                },
+                chartProperties: { dodge: mode },
+                encodingMap: { x: makeEncodingItem('Department'), y: makeEncodingItem('Comp'), color: makeEncodingItem('Level') },
+            });
+        }
+    }
+
     return tests;
 }
-
-// ===========================================================================
-// Radar Chart tests
-// ===========================================================================
 
 export function genEChartsRadarTests(): TestCase[] {
     const tests: TestCase[] = [];

--- a/packages/flint-js/src/test-data/violin-tests.ts
+++ b/packages/flint-js/src/test-data/violin-tests.ts
@@ -298,5 +298,71 @@ export function genViolinTests(): TestCase[] {
         });
     }
 
+    // 9. SPLIT violin — a genuine 2-value colour sub-group. Each category holds
+    //    two groups (Day / Night), so the mirror seats one on each half: the
+    //    classic split violin for comparing two distributions per category.
+    {
+        const depts = ['Eng', 'Sales', 'Support', 'Ops'];
+        const shifts = ['Day', 'Night'];
+        const data: any[] = [];
+        depts.forEach((d, di) => shifts.forEach((s, si) => {
+            for (let i = 0; i < 70; i++) {
+                const v = normal(rand, 62000 + di * 9000 + si * 7000, 12000);
+                data.push({ Department: d, Shift: s, Salary: Math.round(Math.max(28000, v)) });
+            }
+        }));
+        tests.push({
+            title: 'Salary by department, split by shift (2 groups)',
+            description: 'Split violin — Day vs Night distributions share each department band',
+            tags: ['nominal', 'quantitative', 'distribution', 'color', 'group', 'gallery', 'medium'],
+            chartType: 'Violin Plot',
+            data,
+            fields: [makeField('Department'), makeField('Salary'), makeField('Shift')],
+            metadata: {
+                Department: { type: Type.String, semanticType: 'Category', levels: depts },
+                Salary: { type: Type.Number, semanticType: 'Amount', levels: [] },
+                Shift: { type: Type.String, semanticType: 'Category', levels: shifts },
+            },
+            encodingMap: {
+                x: makeEncodingItem('Department'),
+                y: makeEncodingItem('Salary'),
+                color: makeEncodingItem('Shift'),
+            },
+        });
+    }
+
+    // 10. GRID violin — a 3+ value colour sub-group. A centre stack of three
+    //     densities would misread each layer, so the sub-group is laid out as a
+    //     category × sub-group grid of independent full violins.
+    {
+        const depts = ['Eng', 'Sales', 'Support'];
+        const levels = ['Junior', 'Mid', 'Senior'];
+        const data: any[] = [];
+        depts.forEach((d, di) => levels.forEach((l, li) => {
+            for (let i = 0; i < 60; i++) {
+                const v = normal(rand, 55000 + di * 8000 + li * 22000, 10000 + li * 3000);
+                data.push({ Department: d, Level: l, Salary: Math.round(Math.max(30000, v)) });
+            }
+        }));
+        tests.push({
+            title: 'Salary by department and level (3 groups, grid)',
+            description: 'Grouped violins as a department × level grid, one independent shape per cell',
+            tags: ['nominal', 'quantitative', 'distribution', 'color', 'group', 'grid', 'gallery', 'medium'],
+            chartType: 'Violin Plot',
+            data,
+            fields: [makeField('Department'), makeField('Salary'), makeField('Level')],
+            metadata: {
+                Department: { type: Type.String, semanticType: 'Category', levels: depts },
+                Salary: { type: Type.Number, semanticType: 'Amount', levels: [] },
+                Level: { type: Type.String, semanticType: 'Category', levels: levels },
+            },
+            encodingMap: {
+                x: makeEncodingItem('Department'),
+                y: makeEncodingItem('Salary'),
+                color: makeEncodingItem('Level'),
+            },
+        });
+    }
+
     return tests;
 }

--- a/packages/flint-js/src/vegalite/assemble.ts
+++ b/packages/flint-js/src/vegalite/assemble.ts
@@ -55,6 +55,7 @@ import {
 import type { ChartWarning, ChartOption, OptionEvalContext } from '../core/types';
 import { applyEncodingOverrides } from '../core/encoding-overrides';
 import { applyAggregation } from '../core/aggregate';
+import { planBandDodge } from '../core/band-dodge';
 import { applyPivot, type PivotSurface } from '../core/pivot';
 import { vlGetTemplateDef } from './templates';
 import { inferVisCategory, computeZeroDecision } from '../core/semantic-types';
@@ -970,9 +971,19 @@ function buildVLEncodings(
         }
         delete resolvedEncodings.group;
 
+        // Suppress the dodge offset when the group field is redundant/nested with
+        // the axis (group == x, or a 1:1 pair): otherwise VL subdivides each band
+        // by the global group domain and every bar collapses to ~1/N width. This
+        // mirrors the grouping suppression in computeLayout so the band budget and
+        // the offset agree. Confident-nested only (maxPerBand <= 1).
+        const groupAxisField = channelSemantics[groupAxis]?.field;
+        const groupIsNested = !!groupAxisField
+            && (groupAxisField === groupCS.field
+                || planBandDodge(data, groupAxisField, groupCS.field).maxPerBand <= 1);
+
         // Create offset encoding for position subdivision.
         // Coordinate sort with color so bar order matches legend order.
-        if (!resolvedEncodings[offsetChannel]) {
+        if (!groupIsNested && !resolvedEncodings[offsetChannel]) {
             const offsetEnc: any = { field: groupCS.field, type: 'nominal' };
             if (resolvedEncodings.color?.sort !== undefined) {
                 offsetEnc.sort = resolvedEncodings.color.sort;

--- a/packages/flint-js/src/vegalite/assemble.ts
+++ b/packages/flint-js/src/vegalite/assemble.ts
@@ -55,7 +55,7 @@ import {
 import type { ChartWarning, ChartOption, OptionEvalContext } from '../core/types';
 import { applyEncodingOverrides } from '../core/encoding-overrides';
 import { applyAggregation } from '../core/aggregate';
-import { planBandDodge } from '../core/band-dodge';
+import { planBandDodge, resolveDodge } from '../core/band-dodge';
 import { applyPivot, type PivotSurface } from '../core/pivot';
 import { vlGetTemplateDef } from './templates';
 import { inferVisCategory, computeZeroDecision } from '../core/semantic-types';
@@ -445,7 +445,7 @@ export function assembleVegaLite(input: ChartAssemblyInput): any {
     const resolvedEncodings = buildVLEncodings(
         encodings, channelSemantics, declaration, data,
         canvasSize, semanticTypes, templateMarkType, chartTemplate,
-        fieldDisplayNames,
+        fieldDisplayNames, chartProperties,
     );
 
     // --- Align sort/domain arrays to converted data types ---
@@ -728,6 +728,7 @@ function buildVLEncodings(
     templateMarkType: string | undefined,
     chartTemplate: ChartTemplateDef,
     fieldDisplayNames?: Record<string, string>,
+    chartProperties?: Record<string, any>,
 ): Record<string, any> {
     const resolvedEncodings: Record<string, any> = {};
 
@@ -971,15 +972,18 @@ function buildVLEncodings(
         }
         delete resolvedEncodings.group;
 
-        // Suppress the dodge offset when the group field is redundant/nested with
-        // the axis (group == x, or a 1:1 pair): otherwise VL subdivides each band
-        // by the global group domain and every bar collapses to ~1/N width. This
-        // mirrors the grouping suppression in computeLayout so the band budget and
-        // the offset agree. Confident-nested only (maxPerBand <= 1).
+        // Suppress the dodge offset when the group is redundant/nested with the
+        // axis (group == x, or a 1:1 pair), OR when the user forces `dodge: none`.
+        // Otherwise VL subdivides each band by the global group domain. `local`
+        // and `global` both keep the (global) offset for now — the compact
+        // `local` renderer is a follow-up; the layout budget stays consistent.
         const groupAxisField = channelSemantics[groupAxis]?.field;
+        const groupPlan = groupAxisField
+            ? planBandDodge(data, groupAxisField, groupCS.field)
+            : undefined;
+        const groupMode = groupPlan ? resolveDodge(groupPlan, chartProperties?.dodge).mode : 'global';
         const groupIsNested = !!groupAxisField
-            && (groupAxisField === groupCS.field
-                || planBandDodge(data, groupAxisField, groupCS.field).maxPerBand <= 1);
+            && (groupAxisField === groupCS.field || groupMode === 'none');
 
         // Create offset encoding for position subdivision.
         // Coordinate sort with color so bar order matches legend order.

--- a/packages/flint-js/src/vegalite/templates/bar.ts
+++ b/packages/flint-js/src/vegalite/templates/bar.ts
@@ -4,6 +4,7 @@
 import { ChartTemplateDef, ChartPropertyDef, EncodingActionDef } from '../../core/types';
 import { makeSortAction } from '../../core/encoding-actions';
 import { makeCartesianPivot } from '../../core/pivot';
+import { planBandDodge, resolveDodge } from '../../core/band-dodge';
 import { snapToBoundHeuristic } from '../../core/field-semantics';
 import {
     detectBandedAxisFromSemantics, detectBandedAxisForceDiscrete,
@@ -242,21 +243,89 @@ export const groupedBarChartDef: ChartTemplateDef = {
     template: { mark: "bar", encoding: {} },
     channels: ["x", "y", "group", "column", "row"],
     markCognitiveChannel: 'length',
-    declareLayoutMode: (cs, table) => {
+    declareLayoutMode: (cs, table, chartProperties) => {
         const result = detectBandedAxisForceDiscrete(cs, table, { preferAxis: 'x' });
         const axis = result?.axis || 'x';
 
-        return {
+        const decl: import('../../core/types').LayoutDeclaration = {
             axisFlags: { [axis]: { banded: true } },
             resolvedTypes: result?.resolvedTypes,
         };
+        // `local` dodge budgets only maxPerBand lanes per band (compact), so the
+        // band isn't sized for the full global group domain.
+        const groupField = cs.group?.field;
+        const axisField = cs[axis]?.field;
+        if (groupField && axisField) {
+            const plan = planBandDodge(table, axisField, groupField);
+            const { mode } = resolveDodge(plan, chartProperties?.dodge);
+            if (mode === 'local') decl.groupLaneCount = Math.max(1, plan.maxPerBand);
+        }
+        return decl;
     },
     instantiate: (spec, ctx) => {
         // resolvedEncodings already includes color + xOffset/yOffset from group channel
         defaultBuildEncodings(spec, ctx.resolvedEncodings);
         adjustBarMarks(spec, ctx);
+
+        // `local` dodge: replace the global group offset with a per-band lane
+        // index so each band is subdivided into only maxPerBand lanes (compact),
+        // rather than the full global grid. Native x labels stay centered.
+        const offsetCh = spec.encoding?.xOffset ? 'xOffset' : spec.encoding?.yOffset ? 'yOffset' : undefined;
+        const groupField = ctx.channelSemantics?.group?.field;
+        const xDisc = ctx.channelSemantics?.x?.type === 'nominal' || ctx.channelSemantics?.x?.type === 'ordinal';
+        const axisField = xDisc ? ctx.channelSemantics?.x?.field : ctx.channelSemantics?.y?.field;
+        if (offsetCh && groupField && axisField) {
+            const plan = planBandDodge(ctx.fullTable ?? ctx.table, axisField, groupField);
+            const { mode } = resolveDodge(plan, ctx.chartProperties?.dodge);
+            if (mode === 'local') {
+                const maxPB = Math.max(1, plan.maxPerBand);
+                // Center each band's items with a QUANTITATIVE offset in the
+                // band's [-0.5, 0.5] range: a single-item band sits at the band
+                // centre, a partial cluster is centred (not left-anchored). The
+                // native band x-axis is kept, so group labels stay centred.
+                spec.encoding[offsetCh] = {
+                    field: '__off', type: 'quantitative',
+                    scale: { domain: [-0.5, 0.5] }, axis: null, title: null,
+                };
+                spec.transform = [
+                    ...(spec.transform ?? []),
+                    { window: [{ op: 'dense_rank', as: '__laneIdx' }], groupby: [axisField], sort: [{ field: groupField, order: 'ascending' }] },
+                    { joinaggregate: [{ op: 'distinct', field: groupField, as: '__localCount' }], groupby: [axisField] },
+                    { calculate: `((datum.__laneIdx - 1) - (datum.__localCount - 1) / 2) / ${maxPB}`, as: '__off' },
+                ];
+                // Constant bar width ≈ 85% of a lane. VL's band reserves ~20%
+                // padding, so the usable per-lane pitch is (band·0.8 / maxPerBand).
+                const band = offsetCh === 'xOffset' ? ctx.layout?.xStep : ctx.layout?.yStep;
+                if (band) {
+                    spec.mark = setMarkProp(spec.mark, 'size', Math.max(2, Math.round((band * 0.8 / maxPB) * 0.85)));
+                }
+            }
+        }
     },
     encodingActions: [makeSortAction()] as EncodingActionDef[],
+    properties: [
+        {
+            key: 'dodge', label: 'Dodge', type: 'discrete',
+            options: [
+                { value: 'auto',   label: 'Auto' },
+                { value: 'local',  label: 'Local (compact)' },
+                { value: 'global', label: 'Global (aligned)' },
+            ],
+            defaultValue: 'auto',
+            // The `group` field is what subdivides each category band.
+            check: (ctx) => {
+                const isDisc = (t: string | undefined) => t === 'nominal' || t === 'ordinal';
+                const groupField = ctx.channelSemantics?.group?.field ?? ctx.encodings?.group?.field;
+                const axisField = isDisc(ctx.channelSemantics?.x?.type)
+                    ? ctx.channelSemantics?.x?.field
+                    : ctx.channelSemantics?.y?.field;
+                const rows = ctx.data;
+                if (!groupField || !axisField || !rows) return { applicable: false };
+                const plan = planBandDodge(rows, axisField, groupField);
+                return { applicable: plan.ambiguous, recommendedValue: plan.mode === 'none' ? 'auto' : plan.mode };
+            },
+        },
+    ] as ChartPropertyDef[],
     // Chart-type transition: the dodge series (`group`) becomes a stacked series
     // (`color`), re-rendering as a Stacked Bar Chart. Plus the orientation flip,
     // role swap (banded axis ↔ series), and series routing to column/row facets.

--- a/packages/flint-js/src/vegalite/templates/rose.ts
+++ b/packages/flint-js/src/vegalite/templates/rose.ts
@@ -42,6 +42,27 @@ export const roseChartDef: ChartTemplateDef = {
         const { x, y, color, column, row, ...rest } = ctx.resolvedEncodings;
         const isFaceted = !!(column || row);
 
+        // Slice ordering: 'none' keeps the category/data order; 'descending' /
+        // 'ascending' reorder the angular wedges (and their colours) by each
+        // category's total. We resolve the order to an EXPLICIT array so that
+        // both theta (slice angle) and the colour/legend follow the same order —
+        // a `{field, op}` sort on theta alone does not reliably reorder the
+        // wedges of a stacked arc.
+        const sortSlices = ctx.chartProperties?.sortSlices;
+        let sliceOrder: string[] | undefined;
+        if ((sortSlices === 'descending' || sortSlices === 'ascending') && x?.field && y?.field) {
+            const totals = new Map<string, number>();
+            for (const rr of ctx.table) {
+                const c = String((rr as any)[x.field] ?? '');
+                totals.set(c, (totals.get(c) ?? 0) + (Number((rr as any)[y.field]) || 0));
+            }
+            sliceOrder = [...totals.keys()].sort((a, b) =>
+                sortSlices === 'descending'
+                    ? (totals.get(b) ?? 0) - (totals.get(a) ?? 0)
+                    : (totals.get(a) ?? 0) - (totals.get(b) ?? 0),
+            );
+        }
+
         // ── theta encoding (shared) ──
         if (x) {
             const thetaEnc: any = { ...x };
@@ -68,11 +89,9 @@ export const roseChartDef: ChartTemplateDef = {
                 // 'left': no range offset needed — default [0, 2π] puts left edge at top
             }
 
-            // Slice ordering (design choice): default keeps the category order;
-            // sorting by value reorders the angular wedges by their radius sum.
-            const sortSlices = ctx.chartProperties?.sortSlices;
-            if ((sortSlices === 'descending' || sortSlices === 'ascending') && y?.field) {
-                thetaEnc.sort = { field: y.field, op: 'sum', order: sortSlices };
+            // Reorder the angular wedges by category total when sorting.
+            if (sliceOrder) {
+                thetaEnc.sort = sliceOrder;
             }
 
             spec.encoding.theta = thetaEnc;
@@ -100,7 +119,9 @@ export const roseChartDef: ChartTemplateDef = {
         } else if (x) {
             // No color channel: color by category (like a pie chart)
             colorEnc = { field: x.field, type: x.type || 'nominal' };
-            if (Array.isArray(x.sort)) {
+            if (sliceOrder) {
+                colorEnc.sort = sliceOrder;
+            } else if (Array.isArray(x.sort)) {
                 colorEnc.sort = x.sort;
             }
         }
@@ -205,9 +226,6 @@ export const roseChartDef: ChartTemplateDef = {
         const config = ctx.chartProperties;
         if (config) {
             const markTarget = spec.layer ? spec.layer[0] : spec;
-            if (config.innerRadius > 0) {
-                markTarget.mark = setMarkProp(markTarget.mark, 'innerRadius', config.innerRadius);
-            }
             if (config.padAngle > 0) {
                 markTarget.mark = setMarkProp(markTarget.mark, 'padAngle', config.padAngle);
             }
@@ -215,7 +233,6 @@ export const roseChartDef: ChartTemplateDef = {
     },
 
     properties: [
-        { key: "innerRadius", label: "Inner Radius", type: "continuous", min: 0, max: 100, step: 5, defaultValue: 0 },
         { key: "padAngle", label: "Gap", type: "continuous", min: 0, max: 0.1, step: 0.005, defaultValue: 0 },
         {
             key: 'alignment', label: 'Alignment', type: 'discrete', options: [

--- a/packages/flint-js/src/vegalite/templates/scatter.ts
+++ b/packages/flint-js/src/vegalite/templates/scatter.ts
@@ -3,7 +3,7 @@
 
 import { ChartTemplateDef, ChartPropertyDef } from '../../core/types';
 import { detectBandedAxisForceDiscrete } from '../../core/axis-detection';
-import { planBandDodge, resolveBandDodge } from '../../core/band-dodge';
+import { planBandDodge, resolveDodge } from '../../core/band-dodge';
 import {
     defaultBuildEncodings, applyPointSizeScaling, setMarkProp,
 } from './utils';
@@ -189,21 +189,26 @@ export const boxplotDef: ChartTemplateDef = {
         // Decide whether `color` dodges the banded axis into side-by-side
         // sub-lanes, or is redundant/nested with it (one full-width box per
         // band). Shared with `instantiate` via `planBandDodge` so the band
-        // budget and the box size agree. Honors the `colorLayout` override.
+        // budget and the box size agree. Honors the `dodge` override.
         let colorActsAsGroup = false;
+        let groupLaneCount: number | undefined;
         const colorField = cs.color?.field;
         const axisField = cs[result.axis]?.field;
         if (colorField && axisField && isDiscreteType(cs.color?.type)) {
             const plan = planBandDodge(table, axisField, colorField, {
                 nestedSnapThreshold: chartProperties?.nestedSnapThreshold,
             });
-            colorActsAsGroup = resolveBandDodge(plan, chartProperties?.colorLayout).dodge;
+            const { mode } = resolveDodge(plan, chartProperties?.dodge);
+            colorActsAsGroup = mode !== 'none';
+            // `local` budgets only maxPerBand lanes per band (compact).
+            if (mode === 'local') groupLaneCount = Math.max(1, plan.maxPerBand);
         }
         return {
             axisFlags: { [result.axis]: { banded: true } },
             resolvedTypes: result.resolvedTypes,
             paramOverrides: { defaultBandSize: 28 },  // box+whisker needs wider bands
             colorActsAsGroup,  // dodge-by-color → budget band per category, shrink lanes
+            ...(groupLaneCount ? { groupLaneCount } : {}),
         };
     },
     instantiate: (spec, ctx) => {
@@ -251,29 +256,39 @@ export const boxplotDef: ChartTemplateDef = {
             const plan = planBandDodge(ctx.fullTable ?? ctx.table, axisField, colorField, {
                 nestedSnapThreshold: ctx.chartProperties?.nestedSnapThreshold,
             });
-            const resolved = resolveBandDodge(plan, ctx.chartProperties?.colorLayout);
-            if (resolved.dodge) {
+            const resolved = resolveDodge(plan, ctx.chartProperties?.dodge);
+            if (resolved.mode !== 'none') {
                 const offsetChannel = hasDiscreteX ? 'xOffset' : 'yOffset';
-                const offsetEnc: Record<string, unknown> = { field: colorEnc.field, type: 'nominal' };
-                if (colorEnc.sort !== undefined) offsetEnc.sort = colorEnc.sort;
-                spec.encoding[offsetChannel] = offsetEnc;
-                // Lane count == global distinct colors, which is exactly what the
-                // VL offset scale + the layout band budget both reserve. Sizing by
-                // the max-per-band would overlap in sparse cross-products.
                 subgroups = Math.max(1, resolved.laneCount);
+                if (resolved.mode === 'local') {
+                    // Compact + centered: a quantitative offset over the band's
+                    // [-0.5, 0.5] range places each band's boxes centered, using
+                    // only maxPerBand lanes. Native axis labels stay centered.
+                    const maxPB = Math.max(1, plan.maxPerBand);
+                    spec.encoding[offsetChannel] = {
+                        field: '__off', type: 'quantitative',
+                        scale: { domain: [-0.5, 0.5] }, axis: null,
+                    };
+                    spec.transform = [
+                        ...(spec.transform ?? []),
+                        { window: [{ op: 'dense_rank', as: '__laneIdx' }], groupby: [axisField], sort: [{ field: colorField, order: 'ascending' }] },
+                        { joinaggregate: [{ op: 'distinct', field: colorField, as: '__localCount' }], groupby: [axisField] },
+                        { calculate: `((datum.__laneIdx - 1) - (datum.__localCount - 1) / 2) / ${maxPB}`, as: '__off' },
+                    ];
+                } else {
+                    // Global: a fixed lane per distinct color across all bands.
+                    const offsetEnc: Record<string, unknown> = { field: colorEnc.field, type: 'nominal' };
+                    if (colorEnc.sort !== undefined) offsetEnc.sort = colorEnc.sort;
+                    spec.encoding[offsetChannel] = offsetEnc;
+                }
             }
         }
 
-        // Scale box width to the step size of the discrete axis. With
-        // colorActsAsGroup, computeLayout sizes the axis per *category band*
-        // (xStepUnit 'group') and Vega-Lite gets `width:{step, for:'position'}`,
-        // so each band is subdivided into `subgroups` sub-lanes. Vega-Lite's
-        // position band scale reserves ~20% of every step as inter-band padding,
-        // so only ~80% of the step is actual drawing width — the per-subgroup
-        // pitch is `step * USABLE_BAND_FRACTION / subgroups`. Sizing a box to the
-        // raw `step / subgroups` overshoots that pitch and makes adjacent boxes
-        // in a group overlap; account for the padding, then fill most of the lane
-        // so boxes shrink (and stay separated) as subgroups grow.
+        // Scale box width to the step size of the discrete axis. Each band is
+        // subdivided into `subgroups` sub-lanes. VL's position band reserves ~20%
+        // of the step as inter-band padding (both the nominal `global` offset and
+        // the quantitative `local` offset map into that ~80% usable width), so the
+        // per-lane pitch is `step * USABLE_BAND_FRACTION / subgroups`.
         if (hasDiscreteAxis) {
             const boxStep = hasDiscreteX ? layout.xStep : layout.yStep;
             if (subgroups > 1) {
@@ -302,16 +317,16 @@ export const boxplotDef: ChartTemplateDef = {
             check: (ctx) => ({ applicable: ctx.chartProperties?.whiskerMethod !== 'minmax' }),
         },
         {
-            key: 'colorLayout', label: 'Color layout', type: 'discrete',
+            key: 'dodge', label: 'Dodge', type: 'discrete',
             options: [
                 { value: 'auto',   label: 'Auto' },
-                { value: 'dodge',  label: 'Side by side' },
-                { value: 'nested', label: 'One per band' },
+                { value: 'local',  label: 'Local (compact)' },
+                { value: 'global', label: 'Global (aligned)' },
             ],
             defaultValue: 'auto',
-            // Only surface the control when the dodge decision is genuinely
-            // uncertain (sparse cross-product / dirty near-1:1); when color is
-            // clearly redundant or clearly a second dimension, trust Auto.
+            // Surface whenever color genuinely subdivides a band (maxPerBand > 1),
+            // so the user can pick none / local / global; the compiler default is
+            // reported as `recommendedValue`.
             check: (ctx) => {
                 const colorField = ctx.channelSemantics?.color?.field;
                 const xType = ctx.channelSemantics?.x?.type;
@@ -327,7 +342,7 @@ export const boxplotDef: ChartTemplateDef = {
                 });
                 return {
                     applicable: plan.ambiguous,
-                    recommendedValue: plan.dodge ? 'dodge' : 'nested',
+                    recommendedValue: plan.mode === 'none' ? 'auto' : plan.mode,
                 };
             },
         },

--- a/packages/flint-js/src/vegalite/templates/scatter.ts
+++ b/packages/flint-js/src/vegalite/templates/scatter.ts
@@ -3,10 +3,13 @@
 
 import { ChartTemplateDef, ChartPropertyDef } from '../../core/types';
 import { detectBandedAxisForceDiscrete } from '../../core/axis-detection';
+import { planBandDodge, resolveBandDodge } from '../../core/band-dodge';
 import {
     defaultBuildEncodings, applyPointSizeScaling, setMarkProp,
 } from './utils';
 import { makeCartesianPivot } from '../../core/pivot';
+
+const isDiscreteType = (t: string | undefined) => t === 'nominal' || t === 'ordinal';
 
 // Fraction of the band/lane step a boxplot box should occupy. An ungrouped box
 // fills most of its category band; a grouped (dodged) box fills most of its
@@ -179,15 +182,28 @@ export const boxplotDef: ChartTemplateDef = {
     template: { mark: "boxplot", encoding: {} },
     channels: ["x", "y", "color", "opacity", "column", "row"],
     markCognitiveChannel: 'position',
-    declareLayoutMode: (cs, table) => {
+    declareLayoutMode: (cs, table, chartProperties) => {
         if (!cs.x?.field || !cs.y?.field) return {};
         const result = detectBandedAxisForceDiscrete(cs, table, { preferAxis: 'x' });
         if (!result) return {};
+        // Decide whether `color` dodges the banded axis into side-by-side
+        // sub-lanes, or is redundant/nested with it (one full-width box per
+        // band). Shared with `instantiate` via `planBandDodge` so the band
+        // budget and the box size agree. Honors the `colorLayout` override.
+        let colorActsAsGroup = false;
+        const colorField = cs.color?.field;
+        const axisField = cs[result.axis]?.field;
+        if (colorField && axisField && isDiscreteType(cs.color?.type)) {
+            const plan = planBandDodge(table, axisField, colorField, {
+                nestedSnapThreshold: chartProperties?.nestedSnapThreshold,
+            });
+            colorActsAsGroup = resolveBandDodge(plan, chartProperties?.colorLayout).dodge;
+        }
         return {
             axisFlags: { [result.axis]: { banded: true } },
             resolvedTypes: result.resolvedTypes,
             paramOverrides: { defaultBandSize: 28 },  // box+whisker needs wider bands
-            colorActsAsGroup: true,  // dodge-by-color → budget band per category, shrink lanes
+            colorActsAsGroup,  // dodge-by-color → budget band per category, shrink lanes
         };
     },
     instantiate: (spec, ctx) => {
@@ -217,16 +233,34 @@ export const boxplotDef: ChartTemplateDef = {
         // dodge the boxes side-by-side (xOffset/yOffset), not overlay them at the
         // same position — overlaid boxes hide whichever is drawn underneath.
         // Vega-Lite needs an explicit offset encoding to lay grouped boxes out.
+        // But only dodge when color actually subdivides a band: when it's
+        // redundant/nested with the axis (`color == x`, or a 1:1 field pair),
+        // `planBandDodge` returns `dodge:false` and we fall through to the
+        // single-band branch below (one full-width box per category).
         const colorEnc = spec.encoding?.color;
         let subgroups = 1;
-        if (colorEnc?.field && hasDiscreteAxis && !spec.encoding.xOffset && !spec.encoding.yOffset) {
-            const offsetChannel = hasDiscreteX ? 'xOffset' : 'yOffset';
-            const offsetEnc: Record<string, unknown> = { field: colorEnc.field, type: 'nominal' };
-            if (colorEnc.sort !== undefined) offsetEnc.sort = colorEnc.sort;
-            spec.encoding[offsetChannel] = offsetEnc;
-            const colorField = ctx.channelSemantics?.color?.field;
-            if (colorField) {
-                subgroups = Math.max(1, new Set(ctx.table.map((r) => r[colorField])).size);
+        const colorField = ctx.channelSemantics?.color?.field;
+        const axisField = hasDiscreteX
+            ? ctx.channelSemantics?.x?.field
+            : ctx.channelSemantics?.y?.field;
+        if (
+            colorEnc?.field && colorField && axisField
+            && isDiscreteType(ctx.channelSemantics?.color?.type)
+            && hasDiscreteAxis && !spec.encoding.xOffset && !spec.encoding.yOffset
+        ) {
+            const plan = planBandDodge(ctx.fullTable ?? ctx.table, axisField, colorField, {
+                nestedSnapThreshold: ctx.chartProperties?.nestedSnapThreshold,
+            });
+            const resolved = resolveBandDodge(plan, ctx.chartProperties?.colorLayout);
+            if (resolved.dodge) {
+                const offsetChannel = hasDiscreteX ? 'xOffset' : 'yOffset';
+                const offsetEnc: Record<string, unknown> = { field: colorEnc.field, type: 'nominal' };
+                if (colorEnc.sort !== undefined) offsetEnc.sort = colorEnc.sort;
+                spec.encoding[offsetChannel] = offsetEnc;
+                // Lane count == global distinct colors, which is exactly what the
+                // VL offset scale + the layout band budget both reserve. Sizing by
+                // the max-per-band would overlap in sparse cross-products.
+                subgroups = Math.max(1, resolved.laneCount);
             }
         }
 
@@ -266,6 +300,36 @@ export const boxplotDef: ChartTemplateDef = {
             // Outliers exist only with Tukey whiskers; min–max whiskers absorb
             // every point, so the toggle is irrelevant there.
             check: (ctx) => ({ applicable: ctx.chartProperties?.whiskerMethod !== 'minmax' }),
+        },
+        {
+            key: 'colorLayout', label: 'Color layout', type: 'discrete',
+            options: [
+                { value: 'auto',   label: 'Auto' },
+                { value: 'dodge',  label: 'Side by side' },
+                { value: 'nested', label: 'One per band' },
+            ],
+            defaultValue: 'auto',
+            // Only surface the control when the dodge decision is genuinely
+            // uncertain (sparse cross-product / dirty near-1:1); when color is
+            // clearly redundant or clearly a second dimension, trust Auto.
+            check: (ctx) => {
+                const colorField = ctx.channelSemantics?.color?.field;
+                const xType = ctx.channelSemantics?.x?.type;
+                const axisField = isDiscreteType(xType)
+                    ? ctx.channelSemantics?.x?.field
+                    : ctx.channelSemantics?.y?.field;
+                const rows = ctx.data;
+                if (!colorField || !axisField || !isDiscreteType(ctx.channelSemantics?.color?.type) || !rows) {
+                    return { applicable: false };
+                }
+                const plan = planBandDodge(rows, axisField, colorField, {
+                    nestedSnapThreshold: ctx.chartProperties?.nestedSnapThreshold,
+                });
+                return {
+                    applicable: plan.ambiguous,
+                    recommendedValue: plan.dodge ? 'dodge' : 'nested',
+                };
+            },
         },
     ] as ChartPropertyDef[],
 };

--- a/packages/flint-js/src/vegalite/templates/violin.ts
+++ b/packages/flint-js/src/vegalite/templates/violin.ts
@@ -33,6 +33,7 @@
 
 import { ChartTemplateDef, ChartPropertyDef } from '../../core/types';
 import { detectBandedAxisForceDiscrete } from '../../core/axis-detection';
+import { planBandDodge } from '../../core/band-dodge';
 
 const isDiscrete = (t: string | undefined) => t === 'nominal' || t === 'ordinal';
 
@@ -205,6 +206,7 @@ export const violinPlotDef: ChartTemplateDef = {
 
         // --- Color: default to the category so each violin has its own hue ---
         const catType = isDiscrete(x?.type) ? x.type : 'nominal';
+        const colorType = (color?.type as string) || 'nominal';
         if (colorField) {
             spec.encoding.color = { ...color };
         } else {
@@ -216,7 +218,26 @@ export const violinPlotDef: ChartTemplateDef = {
             spec.encoding.color.legend = null;
         }
 
-        // --- Per-category panels: the category occupies the column/wrap facet ---
+        // --- Grouped sub-distributions (a genuine colour sub-group) ---
+        // A violin cannot dodge full shapes side-by-side inside one panel — the
+        // KDE owns the continuous axis and VL drops an `xOffset` on a continuous
+        // x. So a genuine sub-group is laid out by count:
+        //   • 2 sub-groups  → SPLIT violin (the `stack:'center'` mirror below
+        //     seats one sub-group on each half — the standard split violin).
+        //   • ≥3 sub-groups → a per-(category × sub-group) small-multiples GRID
+        //     so every sub-group keeps its own independent, un-stacked shape (a
+        //     3-way centre stack misreads each layer's width).
+        // `planBandDodge` gates this so a redundant/1:1 colour (maxPerBand ≤ 1)
+        // stays a plain one-violin-per-category chart rather than dodging.
+        const genuineSubgroup =
+            !!colorField && colorField !== catField && !rowField &&
+            planBandDodge(ctx.table, catField, colorField).maxPerBand > 1;
+        const subgroupCount = genuineSubgroup
+            ? new Set(ctx.table.map((r: any) => String(r[colorField]))).size
+            : 0;
+        const useGrid = genuineSubgroup && subgroupCount >= 3;
+
+        // --- Per-category panels ---
         const cats = distinctValues(ctx.table, catField);
         const catCount = Math.max(1, cats.length);
 
@@ -228,12 +249,6 @@ export const violinPlotDef: ChartTemplateDef = {
         const reservedW = 60;   // value axis + its title
         const reservedH = 70;   // facet headers + breathing room
         const minPanelW = 44;
-        const maxPerRow = Math.max(1, Math.floor((canvasW - reservedW) / (minPanelW + spacing)));
-        const columns = Math.min(catCount, maxPerRow);
-        const rows = Math.ceil(catCount / columns);
-        let panelW = Math.round((canvasW - reservedW - (columns - 1) * spacing) / columns);
-        panelW = Math.max(minPanelW, Math.min(panelW, 220));
-        const panelH = Math.max(120, Math.round((canvasH - reservedH) / rows) - (rows > 1 ? 24 : 0));
 
         const facetDef: any = {
             field: catField,
@@ -243,24 +258,50 @@ export const violinPlotDef: ChartTemplateDef = {
             header: { titleOrient: 'bottom', labelOrient: 'bottom', labelPadding: 2 },
         };
 
-        if (row) {
-            // An additional OUTER facet → 2-D grid: category in columns, the
-            // outer field in rows (VL cannot combine a wrap `facet` with `row`).
-            // A non-wrap `column` + `row` pair is left intact by restructureFacets.
+        if (useGrid) {
+            // 2-D grid: category across columns, sub-group down rows. Each cell is
+            // one clean full violin; the row headers label the sub-group, so the
+            // colour legend is redundant.
+            let panelW = Math.round((canvasW - reservedW) / catCount);
+            panelW = Math.max(minPanelW, Math.min(panelW, 220));
+            const panelH = Math.max(70, Math.round((canvasH - reservedH) / subgroupCount) - 10);
             spec.encoding.column = facetDef;
-            spec.encoding.row = row;
+            spec.encoding.row = {
+                field: colorField,
+                type: colorType,
+                ...(color?.sort !== undefined ? { sort: color.sort } : {}),
+                header: { labelAngle: 0 },
+            };
+            if (spec.encoding.color) spec.encoding.color.legend = null;
+            spec.width = panelW;
+            spec.height = panelH;
         } else {
-            // The per-category panels occupy a wrap facet with an EXPLICIT column
-            // count. We set `encoding.facet` directly (not `encoding.column`) so
-            // the assembler's restructureFacets leaves the grid untouched — it
-            // would otherwise collapse an un-tracked column facet to `columns: 1`.
-            spec.encoding.facet = { ...facetDef, columns };
-        }
+            const maxPerRow = Math.max(1, Math.floor((canvasW - reservedW) / (minPanelW + spacing)));
+            const columns = Math.min(catCount, maxPerRow);
+            const gridRows = Math.ceil(catCount / columns);
+            let panelW = Math.round((canvasW - reservedW - (columns - 1) * spacing) / columns);
+            panelW = Math.max(minPanelW, Math.min(panelW, 220));
+            const panelH = Math.max(120, Math.round((canvasH - reservedH) / gridRows) - (gridRows > 1 ? 24 : 0));
 
-        // Explicit per-panel size (numbers) so vlApplyLayoutToSpec keeps them and
-        // the grid is the per-category strip, not a single oversized plot.
-        spec.width = panelW;
-        spec.height = panelH;
+            if (row) {
+                // An additional OUTER facet → 2-D grid: category in columns, the
+                // outer field in rows (VL cannot combine a wrap `facet` with `row`).
+                // A non-wrap `column` + `row` pair is left intact by restructureFacets.
+                spec.encoding.column = facetDef;
+                spec.encoding.row = row;
+            } else {
+                // The per-category panels occupy a wrap facet with an EXPLICIT column
+                // count. We set `encoding.facet` directly (not `encoding.column`) so
+                // the assembler's restructureFacets leaves the grid untouched — it
+                // would otherwise collapse an un-tracked column facet to `columns: 1`.
+                spec.encoding.facet = { ...facetDef, columns };
+            }
+
+            // Explicit per-panel size (numbers) so vlApplyLayoutToSpec keeps them and
+            // the grid is the per-category strip, not a single oversized plot.
+            spec.width = panelW;
+            spec.height = panelH;
+        }
     },
     properties: [
         { key: 'bandwidth', label: 'Bandwidth', type: 'continuous', min: 0.05, max: 2, step: 0.05, defaultValue: 0 },

--- a/packages/flint-js/tests/band-dodge.test.ts
+++ b/packages/flint-js/tests/band-dodge.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from 'vitest';
+import { planBandDodge, resolveDodge, laneCountForMode } from '../src/core/band-dodge';
+
+/** Build rows for a band→sub-values map (each pair repeated a few times). */
+function rows(bands: Record<string, string[]>) {
+  const out: { cat: string; sub: string }[] = [];
+  for (const [cat, subs] of Object.entries(bands)) {
+    for (const sub of subs) for (let i = 0; i < 3; i++) out.push({ cat, sub });
+  }
+  return out;
+}
+
+describe('planBandDodge — mode recommendation', () => {
+  it('color == x (every band 1 value) → none', () => {
+    const plan = planBandDodge(rows({ A: ['A'], B: ['B'], C: ['C'] }), 'cat', 'sub');
+    expect(plan.mode).toBe('none');
+    expect(plan.dodge).toBe(false);
+    expect(plan.maxPerBand).toBe(1);
+  });
+
+  it('1:1 different field (bijection) → none', () => {
+    const plan = planBandDodge(rows({ US: ['United States'], CA: ['Canada'], MX: ['Mexico'] }), 'cat', 'sub');
+    expect(plan.mode).toBe('none');
+  });
+
+  it('full cross-product (every band all values) → global', () => {
+    const plan = planBandDodge(rows({ A: ['M', 'F'], B: ['M', 'F'], C: ['M', 'F'] }), 'cat', 'sub');
+    expect(plan.mode).toBe('global');
+    expect(plan.maxPerBand).toBe(2);
+    expect(plan.global).toBe(2);
+  });
+
+  it('sparse cross-product (1 < maxPerBand < global) → local', () => {
+    const plan = planBandDodge(
+      rows({ Eng: ['L1', 'L2'], Sales: ['L2', 'L3'], HR: ['L3', 'L4'], Ops: ['L4', 'L5'] }),
+      'cat', 'sub',
+    );
+    expect(plan.mode).toBe('local');
+    expect(plan.maxPerBand).toBe(2);
+    expect(plan.global).toBe(5);
+  });
+
+  it('spiky (mostly 1, one band with 2, near-unique colors) → local', () => {
+    const plan = planBandDodge(
+      rows({ Mon: ['a'], Tue: ['b'], Wed: ['c'], Thu: ['d', 'e'], Fri: ['f'], Sat: ['g'] }),
+      'cat', 'sub',
+    );
+    // 5/6 bands single = 0.83 < 0.9 threshold → still dodges; maxPerBand 2 < global 7 → local.
+    expect(plan.mode).toBe('local');
+    expect(plan.maxPerBand).toBe(2);
+    expect(plan.global).toBe(7);
+  });
+
+  it('dirty near-1:1 (≥90% single bands) → none (snap)', () => {
+    // 20 clean 1:1 bands + 1 band with a stray second value → 20/21 ≈ 0.95 ≥ 0.9.
+    const bands: Record<string, string[]> = {};
+    for (let i = 0; i < 20; i++) bands['c' + i] = ['n' + i];
+    bands['dirty'] = ['nA', 'nB'];
+    const plan = planBandDodge(rows(bands), 'cat', 'sub');
+    expect(plan.mode).toBe('none');
+    expect(plan.maxPerBand).toBe(2);
+  });
+
+  it('ambiguous flag is set whenever a real dodge choice exists (maxPerBand > 1)', () => {
+    const sparse = planBandDodge(rows({ A: ['x', 'y'], B: ['y', 'z'] }), 'cat', 'sub');
+    expect(sparse.ambiguous).toBe(true);
+    const none = planBandDodge(rows({ A: ['A'], B: ['B'] }), 'cat', 'sub');
+    expect(none.ambiguous).toBe(false);
+  });
+});
+
+describe('resolveDodge — user override', () => {
+  const sparse = planBandDodge(
+    rows({ Eng: ['L1', 'L2'], Sales: ['L2', 'L3'], HR: ['L3', 'L4'], Ops: ['L4', 'L5'] }),
+    'cat', 'sub',
+  );
+
+  it('auto follows the compiler recommendation', () => {
+    expect(resolveDodge(sparse, 'auto').mode).toBe('local');
+    expect(resolveDodge(sparse, undefined).mode).toBe('local');
+  });
+
+  it('explicit modes override', () => {
+    expect(resolveDodge(sparse, 'none').mode).toBe('none');
+    expect(resolveDodge(sparse, 'global').mode).toBe('global');
+    expect(resolveDodge(sparse, 'local').mode).toBe('local');
+  });
+
+  it('lane count is maxPerBand for local, global distinct for global', () => {
+    expect(resolveDodge(sparse, 'local').laneCount).toBe(2);
+    expect(resolveDodge(sparse, 'global').laneCount).toBe(5);
+    expect(resolveDodge(sparse, 'none').laneCount).toBe(1);
+  });
+
+  it('forcing a dodge mode on redundant color downgrades to none', () => {
+    const redundant = planBandDodge(rows({ A: ['A'], B: ['B'] }), 'cat', 'sub');
+    expect(resolveDodge(redundant, 'global').mode).toBe('none');
+    expect(resolveDodge(redundant, 'local').mode).toBe('none');
+  });
+
+  it('laneCountForMode matches resolveDodge', () => {
+    expect(laneCountForMode(sparse, 'global')).toBe(5);
+    expect(laneCountForMode(sparse, 'local')).toBe(2);
+    expect(laneCountForMode(sparse, 'none')).toBe(1);
+  });
+});

--- a/packages/flint-js/tests/boxplot-grouped-dodge.test.ts
+++ b/packages/flint-js/tests/boxplot-grouped-dodge.test.ts
@@ -176,7 +176,7 @@ describe('boxplot color redundant with axis (no dodge)', () => {
     expect(sizeOf(spec)).toBeGreaterThan(stepOf(spec) * 0.5);
   });
 
-  it('sparse cross-product (dept × level) → dodges, sized by GLOBAL lane count', () => {
+  it('sparse cross-product (dept × level) → auto: local (compact, centered)', () => {
     // 6 departments, 5 global levels, but each dept holds only 2 of them.
     const depts = ['D1', 'D2', 'D3', 'D4', 'D5', 'D6'];
     const levelPairs = [
@@ -186,20 +186,26 @@ describe('boxplot color redundant with axis (no dodge)', () => {
     depts.forEach((d, di) => {
       for (const lv of levelPairs[di]) for (let i = 0; i < 20; i++) rows.push({ Cat: d, Level: lv, Val: i });
     });
-    const spec = assembleVegaLite({
+    const input = {
       data: { values: rows },
       semantic_types: { Cat: 'Category', Level: 'Category', Val: 'Quantity' },
       chart_spec: {
         chartType: 'Boxplot',
         encodings: { x: { field: 'Cat' }, y: { field: 'Val' }, color: { field: 'Level' } },
         baseSize: { width: 700, height: 320 },
-      },
-    } as any) as any;
-    expect(spec.encoding?.xOffset?.field).toBe('Level');
-    // Global lane count is 5, so a box must fit the 5-lane pitch (band·0.8/5),
-    // NOT the max-per-band pitch of 2 — otherwise occupied lanes overlap.
-    const fiveLanePitch = (stepOf(spec) * 0.8) / 5;
-    expect(sizeOf(spec)).toBeLessThanOrEqual(fiveLanePitch);
+      } as any,
+    };
+    // Auto → local: centered quantitative offset + the computed transforms.
+    const local = assembleVegaLite(input as any) as any;
+    expect(local.encoding?.xOffset?.field).toBe('__off');
+    expect(local.transform?.some((t: any) => t.as === '__off')).toBe(true);
+
+    // Forced global → the fixed per-color lane grid, sized to the 5 global lanes.
+    input.chart_spec.chartProperties = { dodge: 'global' };
+    const global = assembleVegaLite(input as any) as any;
+    expect(global.encoding?.xOffset?.field).toBe('Level');
+    const fiveLanePitch = (stepOf(global) * 0.8) / 5;
+    expect(sizeOf(global)).toBeLessThanOrEqual(fiveLanePitch);
   });
 });
 
@@ -281,10 +287,10 @@ describe('grouped bar group redundant with axis (no dodge)', () => {
     expect(spec.encoding?.xOffset?.field).toBe('Grp');
   });
 
-  it('sparse / middle case (each band has a SUBSET of groups) still dodges', () => {
+  it('sparse / middle case (each band has a SUBSET of groups) → local (compact) dodge', () => {
     // 4 global groups, each category holds only 2 of them → maxPerBand 2,
-    // global 4 (the ambiguous zone). Most bands are multi-valued, so the
-    // nestedSnapThreshold leans to dodge rather than collapsing to full-width.
+    // global 4 (sparse). Auto → local: a compact per-band lane index rather
+    // than the full global grid.
     const cats = ['A', 'B', 'C', 'D'];
     const subset: Record<string, string[]> = {
       A: ['G1', 'G2'], B: ['G2', 'G3'], C: ['G3', 'G4'], D: ['G4', 'G1'],
@@ -294,29 +300,43 @@ describe('grouped bar group redundant with axis (no dodge)', () => {
     const spec = assembleVegaLite(
       groupedBarInput(rows, { Cat: 'Category', Grp: 'Category', Val: 'Quantity' }, 'Grp'),
     ) as any;
+    // Local dodge → centered per-band quantitative offset + the window/calc
+    // transforms that compute it.
+    expect(spec.encoding?.xOffset?.field).toBe('__off');
+    expect(spec.transform?.some((t: any) => t.window?.[0]?.as === '__laneIdx')).toBe(true);
+    expect(spec.transform?.some((t: any) => t.as === '__off')).toBe(true);
+  });
+
+  it('sparse grouped bar forced to global keeps the group field offset', () => {
+    const cats = ['A', 'B', 'C', 'D'];
+    const subset: Record<string, string[]> = {
+      A: ['G1', 'G2'], B: ['G2', 'G3'], C: ['G3', 'G4'], D: ['G4', 'G1'],
+    };
+    const rows: any[] = [];
+    for (const c of cats) for (const g of subset[c]) rows.push({ Cat: c, Grp: g, Val: c.charCodeAt(0) + g.length });
+    const input = groupedBarInput(rows, { Cat: 'Category', Grp: 'Category', Val: 'Quantity' }, 'Grp');
+    input.chart_spec.chartProperties = { dodge: 'global' };
+    const spec = assembleVegaLite(input) as any;
     expect(spec.encoding?.xOffset?.field).toBe('Grp');
   });
 
-  it('forcing colorLayout=nested collapses a genuine group to full-width', () => {
-    const cats = ['A', 'B', 'C'];
-    const grps = ['G1', 'G2'];
-    const rows: any[] = [];
-    for (const c of cats) for (const g of grps) rows.push({ Cat: c, Grp: g, Val: c.charCodeAt(0) + g.length });
-    const input = groupedBarInput(rows, { Cat: 'Category', Grp: 'Category', Val: 'Quantity' }, 'Grp');
-    // Boxplot honors colorLayout via the shared helper; grouped bar's group→
-    // xOffset suppression is confident-nested only, so this asserts the boxplot
-    // override path (the user-facing toggle) explicitly.
+  it('local dodge with one value per band auto-resolves to one-per-band (no offset)', () => {
+    // Grp is 1:1 with Cat → maxPerBand 1. Even when the user explicitly asks for
+    // `local`, there is nothing to subdivide, so it must collapse to full-width
+    // (no xOffset) rather than render a lone left-aligned sliver. (`none` is not
+    // a user-facing option — one-per-band is reached automatically.)
+    const pairs = [['A', 'Alpha'], ['B', 'Beta'], ['C', 'Gamma']];
+    const rows = pairs.map(([c, g], i) => ({ Cat: c, Grp: g, Val: (i + 1) * 5 }));
     const boxInput = {
       data: { values: rows },
       semantic_types: { Cat: 'Category', Grp: 'Category', Val: 'Quantity' },
       chart_spec: {
         chartType: 'Boxplot',
         encodings: { x: { field: 'Cat' }, y: { field: 'Val' }, color: { field: 'Grp' } },
-        chartProperties: { colorLayout: 'nested' },
+        chartProperties: { dodge: 'local' },
         baseSize: { width: 500, height: 320 },
       },
     } as any;
-    void input;
     const spec = assembleVegaLite(boxInput) as any;
     expect(spec.encoding?.xOffset).toBeUndefined();
   });

--- a/packages/flint-js/tests/boxplot-grouped-dodge.test.ts
+++ b/packages/flint-js/tests/boxplot-grouped-dodge.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, expect } from 'vitest';
-import { assembleVegaLite } from '../src';
+import { assembleVegaLite, assembleECharts } from '../src';
 
 /**
  * Regression: a boxplot with a color field subdividing a categorical axis must
@@ -123,3 +123,204 @@ describe('grouped boxplot dodging', () => {
     expect(spec.encoding?.yOffset).toBeUndefined();
   });
 });
+
+/**
+ * Regression: a boxplot whose `color` is redundant/nested with its categorical
+ * axis (`color == x`, or a 1:1 different-field pair) must NOT dodge — every box
+ * fills its whole band. Previously the template dodged by the global distinct
+ * color count, collapsing each box to ~1/N of the band. Genuine second
+ * dimensions (including sparse cross-products) must still dodge, sized by the
+ * global lane count.
+ */
+describe('boxplot color redundant with axis (no dodge)', () => {
+  const sizeOf = (s: any) => (typeof s.mark === 'object' ? s.mark.size : undefined);
+  const stepOf = (s: any) => Number(s.width?.step ?? s.height?.step);
+
+  function boxplotInput(rows: any[], types: Record<string, string>, color?: string) {
+    const encodings: any = { x: { field: 'Cat' }, y: { field: 'Val' } };
+    if (color) encodings.color = { field: color };
+    return {
+      data: { values: rows },
+      semantic_types: types,
+      chart_spec: { chartType: 'Boxplot', encodings, baseSize: { width: 500, height: 320 } },
+    } as any;
+  }
+
+  it('color == x → no offset, full-width boxes', () => {
+    const cats = ['G', 'PG', 'PG-13', 'R', 'Other', 'Unknown'];
+    const rows: any[] = [];
+    for (const c of cats) for (let i = 0; i < 20; i++) rows.push({ Cat: c, Val: i + (c.length * 3) });
+    const spec = assembleVegaLite(
+      boxplotInput(rows, { Cat: 'Category', Val: 'Quantity' }, 'Cat'),
+    ) as any;
+    expect(spec.encoding?.xOffset).toBeUndefined();
+    expect(spec.encoding?.yOffset).toBeUndefined();
+    // Full-width box (~band·0.7), not a ~band/6 sliver.
+    expect(sizeOf(spec)).toBeGreaterThan(stepOf(spec) * 0.5);
+  });
+
+  it('1:1 different field (code ↔ name) → no offset, full-width boxes', () => {
+    const pairs = [['US', 'United States'], ['CA', 'Canada'], ['MX', 'Mexico'], ['BR', 'Brazil']];
+    const rows: any[] = [];
+    for (const [code, name] of pairs) for (let i = 0; i < 20; i++) rows.push({ Cat: code, Name: name, Val: i });
+    const spec = assembleVegaLite({
+      data: { values: rows },
+      semantic_types: { Cat: 'Category', Name: 'Category', Val: 'Quantity' },
+      chart_spec: {
+        chartType: 'Boxplot',
+        encodings: { x: { field: 'Cat' }, y: { field: 'Val' }, color: { field: 'Name' } },
+        baseSize: { width: 500, height: 320 },
+      },
+    } as any) as any;
+    expect(spec.encoding?.xOffset).toBeUndefined();
+    expect(sizeOf(spec)).toBeGreaterThan(stepOf(spec) * 0.5);
+  });
+
+  it('sparse cross-product (dept × level) → dodges, sized by GLOBAL lane count', () => {
+    // 6 departments, 5 global levels, but each dept holds only 2 of them.
+    const depts = ['D1', 'D2', 'D3', 'D4', 'D5', 'D6'];
+    const levelPairs = [
+      ['L1', 'L2'], ['L2', 'L3'], ['L3', 'L4'], ['L4', 'L5'], ['L5', 'L1'], ['L1', 'L3'],
+    ];
+    const rows: any[] = [];
+    depts.forEach((d, di) => {
+      for (const lv of levelPairs[di]) for (let i = 0; i < 20; i++) rows.push({ Cat: d, Level: lv, Val: i });
+    });
+    const spec = assembleVegaLite({
+      data: { values: rows },
+      semantic_types: { Cat: 'Category', Level: 'Category', Val: 'Quantity' },
+      chart_spec: {
+        chartType: 'Boxplot',
+        encodings: { x: { field: 'Cat' }, y: { field: 'Val' }, color: { field: 'Level' } },
+        baseSize: { width: 700, height: 320 },
+      },
+    } as any) as any;
+    expect(spec.encoding?.xOffset?.field).toBe('Level');
+    // Global lane count is 5, so a box must fit the 5-lane pitch (band·0.8/5),
+    // NOT the max-per-band pitch of 2 — otherwise occupied lanes overlap.
+    const fiveLanePitch = (stepOf(spec) * 0.8) / 5;
+    expect(sizeOf(spec)).toBeLessThanOrEqual(fiveLanePitch);
+  });
+});
+
+/**
+ * ECharts parity: `color == x` must render a SINGLE boxplot series (not one
+ * series per color), which also avoids the degenerate [0,0,0,0,0] zero-boxes a
+ * per-color series would draw in every empty (category, color) cell.
+ */
+describe('ECharts boxplot color redundant with axis', () => {
+  it('color == x → one boxplot series, no zero-box data', () => {
+    const cats = ['G', 'PG', 'PG-13', 'R', 'Other', 'Unknown'];
+    const rows: any[] = [];
+    for (const c of cats) for (let i = 0; i < 20; i++) rows.push({ Cat: c, Val: i + c.length });
+    const option = assembleECharts({
+      data: { values: rows },
+      semantic_types: { Cat: 'Category', Val: 'Quantity' },
+      chart_spec: {
+        chartType: 'Boxplot',
+        encodings: { x: { field: 'Cat' }, y: { field: 'Val' }, color: { field: 'Cat' } },
+        baseSize: { width: 500, height: 320 },
+      },
+    } as any) as any;
+    const boxSeries = (option.series || []).filter((s: any) => s.type === 'boxplot');
+    expect(boxSeries.length).toBe(1);
+    // No degenerate all-zero five-number summaries.
+    for (const s of boxSeries) {
+      for (const d of s.data as any[]) {
+        if (Array.isArray(d)) expect(d.every((v: number) => v === 0)).toBe(false);
+      }
+    }
+  });
+});
+
+/**
+ * Grouped bar generalization: a `group` field that is redundant/nested with the
+ * categorical axis (group == x, or a 1:1 pair) must NOT dodge — otherwise every
+ * bar collapses to ~1/N of its band. Genuine grouped bars are untouched.
+ */
+describe('grouped bar group redundant with axis (no dodge)', () => {
+  function groupedBarInput(rows: any[], types: Record<string, string>, group: string) {
+    return {
+      data: { values: rows },
+      semantic_types: types,
+      chart_spec: {
+        chartType: 'Grouped Bar Chart',
+        encodings: { x: { field: 'Cat' }, y: { field: 'Val' }, group: { field: group } },
+        baseSize: { width: 500, height: 320 },
+      },
+    } as any;
+  }
+
+  it('group == x → no xOffset dodge', () => {
+    const cats = ['A', 'B', 'C', 'D'];
+    const rows = cats.map((c, i) => ({ Cat: c, Val: (i + 1) * 10 }));
+    const spec = assembleVegaLite(
+      groupedBarInput(rows, { Cat: 'Category', Val: 'Quantity' }, 'Cat'),
+    ) as any;
+    expect(spec.encoding?.xOffset).toBeUndefined();
+    expect(spec.encoding?.yOffset).toBeUndefined();
+  });
+
+  it('1:1 different field group → no xOffset dodge', () => {
+    const pairs = [['A', 'Alpha'], ['B', 'Beta'], ['C', 'Gamma']];
+    const rows = pairs.map(([c, g], i) => ({ Cat: c, Grp: g, Val: (i + 1) * 5 }));
+    const spec = assembleVegaLite(
+      groupedBarInput(rows, { Cat: 'Category', Grp: 'Category', Val: 'Quantity' }, 'Grp'),
+    ) as any;
+    expect(spec.encoding?.xOffset).toBeUndefined();
+  });
+
+  it('genuine group (x × group cross-product) still dodges', () => {
+    const cats = ['A', 'B', 'C'];
+    const grps = ['G1', 'G2'];
+    const rows: any[] = [];
+    for (const c of cats) for (const g of grps) rows.push({ Cat: c, Grp: g, Val: c.charCodeAt(0) + g.length });
+    const spec = assembleVegaLite(
+      groupedBarInput(rows, { Cat: 'Category', Grp: 'Category', Val: 'Quantity' }, 'Grp'),
+    ) as any;
+    expect(spec.encoding?.xOffset?.field).toBe('Grp');
+  });
+
+  it('sparse / middle case (each band has a SUBSET of groups) still dodges', () => {
+    // 4 global groups, each category holds only 2 of them → maxPerBand 2,
+    // global 4 (the ambiguous zone). Most bands are multi-valued, so the
+    // nestedSnapThreshold leans to dodge rather than collapsing to full-width.
+    const cats = ['A', 'B', 'C', 'D'];
+    const subset: Record<string, string[]> = {
+      A: ['G1', 'G2'], B: ['G2', 'G3'], C: ['G3', 'G4'], D: ['G4', 'G1'],
+    };
+    const rows: any[] = [];
+    for (const c of cats) for (const g of subset[c]) rows.push({ Cat: c, Grp: g, Val: c.charCodeAt(0) + g.length });
+    const spec = assembleVegaLite(
+      groupedBarInput(rows, { Cat: 'Category', Grp: 'Category', Val: 'Quantity' }, 'Grp'),
+    ) as any;
+    expect(spec.encoding?.xOffset?.field).toBe('Grp');
+  });
+
+  it('forcing colorLayout=nested collapses a genuine group to full-width', () => {
+    const cats = ['A', 'B', 'C'];
+    const grps = ['G1', 'G2'];
+    const rows: any[] = [];
+    for (const c of cats) for (const g of grps) rows.push({ Cat: c, Grp: g, Val: c.charCodeAt(0) + g.length });
+    const input = groupedBarInput(rows, { Cat: 'Category', Grp: 'Category', Val: 'Quantity' }, 'Grp');
+    // Boxplot honors colorLayout via the shared helper; grouped bar's group→
+    // xOffset suppression is confident-nested only, so this asserts the boxplot
+    // override path (the user-facing toggle) explicitly.
+    const boxInput = {
+      data: { values: rows },
+      semantic_types: { Cat: 'Category', Grp: 'Category', Val: 'Quantity' },
+      chart_spec: {
+        chartType: 'Boxplot',
+        encodings: { x: { field: 'Cat' }, y: { field: 'Val' }, color: { field: 'Grp' } },
+        chartProperties: { colorLayout: 'nested' },
+        baseSize: { width: 500, height: 320 },
+      },
+    } as any;
+    void input;
+    const spec = assembleVegaLite(boxInput) as any;
+    expect(spec.encoding?.xOffset).toBeUndefined();
+  });
+});
+
+
+

--- a/packages/flint-js/tests/violin.test.ts
+++ b/packages/flint-js/tests/violin.test.ts
@@ -209,6 +209,73 @@ describe('Vega-Lite Violin Plot — shapes & cardinalities', () => {
   });
 });
 
+describe('Vega-Lite Violin Plot — grouped by a colour sub-group', () => {
+  function groupedInput(subgroups: string[]) {
+    const cats = ['Eng', 'Sales', 'HR'];
+    const rows: any[] = [];
+    let s = 1;
+    const rnd = () => { s = (s * 1103515245 + 12345) & 0x7fffffff; return s / 0x7fffffff; };
+    cats.forEach((c, ci) => subgroups.forEach((g, gi) => {
+      for (let i = 0; i < 30; i++) {
+        rows.push({ Dept: c, Shift: g, Salary: Math.round(40000 + ci * 15000 + gi * 9000 + rnd() * 50000) });
+      }
+    }));
+    return {
+      data: { values: rows },
+      semantic_types: { Dept: 'Category', Shift: 'Category', Salary: 'Amount' },
+      chart_spec: {
+        chartType: 'Violin Plot',
+        encodings: { x: 'Dept', y: 'Salary', color: 'Shift' },
+        baseSize: { width: 620, height: 380 },
+      },
+    };
+  }
+
+  it('keeps a 2-value sub-group as a split violin (one panel per category)', () => {
+    const s = assembleVegaLite(groupedInput(['Day', 'Night'])) as any;
+    // Split: still the per-category wrap facet, colour = sub-group, no row grid.
+    expect(s.encoding.facet?.field).toBe('Dept');
+    expect(s.encoding.row ?? null).toBeNull();
+    expect(s.encoding.color.field).toBe('Shift');
+    // The centre-stacked mirror seats the two sub-groups on either half.
+    expect(s.encoding.x.stack).toBe('center');
+  });
+
+  it('lays out a 3+ value sub-group as an independent-violin grid (category × sub-group)', () => {
+    const s = assembleVegaLite(groupedInput(['Day', 'Night', 'Swing'])) as any;
+    expect(s.encoding.column?.field).toBe('Dept');
+    expect(s.encoding.row?.field).toBe('Shift');
+    // Density keyed per (category, sub-group) so each grid cell is its own shape.
+    expect(s.transform[0].groupby).toEqual(
+      expect.arrayContaining(['Dept', 'Shift']),
+    );
+    // Colour legend suppressed — the row headers already label the sub-group.
+    expect(s.encoding.color.legend).toBeNull();
+  });
+
+  it('does NOT grid a redundant (1:1) colour — stays one violin per category', () => {
+    const cats = ['A', 'B', 'C', 'D'];
+    const rows: any[] = [];
+    let s2 = 5;
+    const rnd = () => { s2 = (s2 * 1103515245 + 12345) & 0x7fffffff; return s2 / 0x7fffffff; };
+    cats.forEach((c, ci) => {
+      for (let i = 0; i < 30; i++) rows.push({ Dept: c, Tag: `${c}_t`, Salary: Math.round(40000 + ci * 12000 + rnd() * 40000) });
+    });
+    const s = assembleVegaLite({
+      data: { values: rows },
+      semantic_types: { Dept: 'Category', Tag: 'Category', Salary: 'Amount' },
+      chart_spec: {
+        chartType: 'Violin Plot',
+        encodings: { x: 'Dept', y: 'Salary', color: 'Tag' },
+        baseSize: { width: 560, height: 360 },
+      },
+    }) as any;
+    // 1:1 colour ⇒ no dodge: per-category wrap facet, no row grid.
+    expect(s.encoding.facet?.field).toBe('Dept');
+    expect(s.encoding.row ?? null).toBeNull();
+  });
+});
+
 describe('Violin Plot gallery examples compile', () => {
   for (const tc of genViolinTests()) {
     it(`Vega-Lite: ${tc.title}`, () => {

--- a/packages/flint-mcp/package.json
+++ b/packages/flint-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flint-chart-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Model Context Protocol server for Flint — compile, validate, and render semantic chart specs to Vega-Lite, ECharts, or Chart.js artifacts (PNG/SVG) in-process.",
   "keywords": [
     "mcp",
@@ -68,7 +68,7 @@
     "@resvg/resvg-js": "^2.6.2",
     "chart.js": "^4.4.0",
     "echarts": "^6.0.0",
-    "flint-chart": "^0.2.1",
+    "flint-chart": "^0.2.2",
     "vega": "^6.0.0",
     "vega-interpreter": "^2.2.1",
     "vega-lite": "^6.0.0",

--- a/site/src/components/ChartCodeModal.tsx
+++ b/site/src/components/ChartCodeModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { TestCase } from 'flint-chart/test-data';
-import { assembleVegaLite, assembleECharts, assembleChartjs } from 'flint-chart';
 import { JsonCodeMirror } from './JsonCodeMirror';
 import { ScaleToFit } from './ScaleToFit';
 import { WallChart } from './WallChart';
@@ -9,7 +8,7 @@ import { testCaseToAssemblyInput } from '../shared/test-case-utils';
 import { buildPanelModel } from '../shared/chart-options';
 import { buildGalleryEditorHref } from '../shared/editor-payload';
 import { humanizeVariants } from '../shared/wall-title';
-import { BACKEND_LABELS } from '../shared/supported-backends';
+import { BACKEND_LABELS, BACKENDS } from '../shared/supported-backends';
 import type { ChartEntry } from '../shared/chart-categories';
 import { siteTheme } from '../shared/theme';
 
@@ -70,8 +69,8 @@ export function ChartCodeModal({
   }, [testCase, tempOptions]);
 
   const panelModel = useMemo(
-    () => (displayInput ? buildPanelModel(displayInput) : null),
-    [displayInput],
+    () => (displayInput ? buildPanelModel(displayInput, chart.backend) : null),
+    [displayInput, chart.backend],
   );
 
   const inputText = useMemo(
@@ -83,12 +82,7 @@ export function ChartCodeModal({
     if (!testCase) return '';
     try {
       const input = testCaseToAssemblyInput(testCase);
-      const spec =
-        chart.backend === 'vegalite'
-          ? assembleVegaLite(input)
-          : chart.backend === 'echarts'
-            ? assembleECharts(input)
-            : assembleChartjs(input);
+      const spec = BACKENDS[chart.backend].assemble(input);
       // Drop Flint's private `_`-prefixed annotations (`_pivot`, `_warnings`,
       // `_width`, `_height`): they are internal metadata for the host/runtime,
       // not part of the actual backend spec a user would render or copy.

--- a/site/src/components/DocChart.tsx
+++ b/site/src/components/DocChart.tsx
@@ -1,12 +1,11 @@
 import { useMemo, type CSSProperties } from 'react';
-import { assembleVegaLite, assembleECharts, assembleChartjs } from 'flint-chart';
 import { TEST_GENERATORS } from 'flint-chart/test-data';
 import { VegaLiteView } from './VegaLiteView';
 import { EChartsView } from './EChartsView';
 import { ChartjsView } from './ChartjsView';
 import { ScaleToFit } from './ScaleToFit';
 import { testCaseToAssemblyInput, type CanvasSize } from '../shared/test-case-utils';
-import type { PreviewBackend } from '../shared/supported-backends';
+import { BACKENDS, type PreviewBackend } from '../shared/supported-backends';
 import { siteTheme } from '../shared/theme';
 
 type Row = Record<string, unknown>;
@@ -125,14 +124,10 @@ export function DocChart({ source, backend = 'vegalite' }: { source: string; bac
         const prepared = input.options
           ? { ...base, options: { ...base.options, ...input.options } }
           : base;
-        if (backend === 'echarts') return { ok: true as const, kind: 'echarts' as const, value: assembleECharts(prepared as never) };
-        if (backend === 'chartjs') return { ok: true as const, kind: 'chartjs' as const, value: assembleChartjs(prepared as never) };
-        return { ok: true as const, kind: 'vegalite' as const, value: assembleVegaLite(prepared as never) };
+        return { ok: true as const, kind: backend, value: BACKENDS[backend].assemble(prepared as never) };
       }
       const prepared = preAggregate(input);
-      if (backend === 'echarts') return { ok: true as const, kind: 'echarts' as const, value: assembleECharts(prepared as never) };
-      if (backend === 'chartjs') return { ok: true as const, kind: 'chartjs' as const, value: assembleChartjs(prepared as never) };
-      return { ok: true as const, kind: 'vegalite' as const, value: assembleVegaLite(prepared as never) };
+      return { ok: true as const, kind: backend, value: BACKENDS[backend].assemble(prepared as never) };
     } catch (err) {
       return { ok: false as const, err: (err as Error)?.message ?? String(err) };
     }

--- a/site/src/components/DodgeToggleFigure.tsx
+++ b/site/src/components/DodgeToggleFigure.tsx
@@ -1,0 +1,183 @@
+import { useMemo, useState } from 'react';
+import { assembleVegaLite } from 'flint-chart';
+import { VegaLiteView } from './VegaLiteView';
+import { siteTheme } from '../shared/theme';
+
+/**
+ * Dev-playground section demonstrating the color/group band-dodge heuristic and
+ * the `colorLayout` toggle. Three regimes render side by side and all respond to
+ * the toggle:
+ *   - redundant  (color == x)          → Auto: nested (full-width boxes)
+ *   - sparse     (dept × level subset) → Auto: dodge, sized by global lane count
+ *   - full       (country × gender)    → Auto: dodge
+ * Forcing `dodge` / `nested` overrides Auto in every regime.
+ */
+
+type Dodge = 'auto' | 'local' | 'global';
+
+interface Row { cat: string; sub: string; val: number }
+
+// Tiny deterministic PRNG so the demo is stable across renders.
+function makeRand(seed: number) {
+  let s = seed;
+  return () => {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    return s / 0x7fffffff;
+  };
+}
+
+function buildRows(bands: Record<string, string[]>, seed: number): Row[] {
+  const rand = makeRand(seed);
+  const rows: Row[] = [];
+  for (const [cat, subs] of Object.entries(bands)) {
+    for (const sub of subs) {
+      const center = 30 + (sub.charCodeAt(sub.length - 1) % 7) * 8;
+      for (let i = 0; i < 18; i++) rows.push({ cat, sub, val: Math.round(center + rand() * 40) });
+    }
+  }
+  return rows;
+}
+
+// Regime 1: color == x (redundant). Each band has exactly one color.
+const REDUNDANT: Record<string, string[]> = {
+  G: ['G'], PG: ['PG'], 'PG-13': ['PG-13'], R: ['R'], Other: ['Other'],
+};
+// Regime 2: sparse cross-product. 5 global levels, each dept holds 2.
+const SPARSE: Record<string, string[]> = {
+  Eng: ['L1', 'L2'], Sales: ['L2', 'L3'], HR: ['L3', 'L4'], Ops: ['L4', 'L5'], Legal: ['L5', 'L1'],
+};
+// Regime 3: full cross-product. Every band has both colors.
+const FULL: Record<string, string[]> = {
+  USA: ['M', 'F'], Japan: ['M', 'F'], Brazil: ['M', 'F'], Kenya: ['M', 'F'],
+};
+
+interface Regime { key: string; title: string; note: string; bands: Record<string, string[]>; seed: number }
+
+const REGIMES: Regime[] = [
+  { key: 'redundant', title: 'Redundant  (color = x)', note: 'maxPerBand 1 → Auto: none', bands: REDUNDANT, seed: 11 },
+  { key: 'sparse', title: 'Sparse  (dept × level)', note: '1 < maxPerBand < global → Auto: local', bands: SPARSE, seed: 23 },
+  { key: 'full', title: 'Full  (country × gender)', note: 'maxPerBand = global → Auto: global', bands: FULL, seed: 37 },
+];
+
+function boxplotSpec(bands: Record<string, string[]>, seed: number, dodge: Dodge): unknown {
+  const rows = buildRows(bands, seed);
+  return assembleVegaLite({
+    data: { values: rows },
+    semantic_types: { cat: 'Category', sub: 'Category', val: 'Quantity' },
+    chart_spec: {
+      chartType: 'Boxplot',
+      encodings: { x: { field: 'cat' }, y: { field: 'val' }, color: { field: 'sub' } },
+      chartProperties: { dodge },
+      baseSize: { width: 260, height: 220 },
+    },
+  } as never);
+}
+
+const TOGGLE: { value: Dodge; label: string }[] = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'local', label: 'Local' },
+  { value: 'global', label: 'Global' },
+];
+
+export function DodgeToggleFigure() {
+  const [dodge, setDodge] = useState<Dodge>('auto');
+  const specs = useMemo(
+    () => REGIMES.map((r) => ({ ...r, spec: boxplotSpec(r.bands, r.seed, dodge) })),
+    [dodge],
+  );
+
+  return (
+    <section style={wrapStyle}>
+      <div style={headerRowStyle}>
+        <div>
+          <h3 style={titleStyle}>Color / group band-dodge</h3>
+          <p style={subtitleStyle}>
+            One rule (<code>planBandDodge</code>) decides dodge vs. full-width: gate on max distinct
+            colors within any single band, lane count = global distinct. The <code>dodge</code>{' '}
+            toggle overrides Auto.
+          </p>
+        </div>
+        <div style={toggleStyle} role="tablist" aria-label="Color layout">
+          {TOGGLE.map((t) => (
+            <button
+              key={t.value}
+              type="button"
+              onClick={() => setDodge(t.value)}
+              style={t.value === dodge ? toggleBtnActive : toggleBtn}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div style={gridStyle}>
+        {specs.map((r) => (
+          <figure key={r.key} style={cardStyle}>
+            <figcaption style={captionStyle}>
+              <span style={captionTitle}>{r.title}</span>
+              <span style={captionNote}>{r.note}</span>
+            </figcaption>
+            <VegaLiteView spec={r.spec} />
+          </figure>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const wrapStyle: React.CSSProperties = {
+  width: 960,
+  boxSizing: 'border-box',
+  background: '#fff',
+  border: '1px solid rgba(0,0,0,0.08)',
+  borderRadius: 10,
+  padding: 20,
+  fontFamily: siteTheme.fontSans,
+  color: siteTheme.text,
+};
+const headerRowStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-start',
+  gap: 16,
+  marginBottom: 16,
+};
+const titleStyle: React.CSSProperties = { margin: '0 0 4px', fontSize: 16, fontWeight: 600 };
+const subtitleStyle: React.CSSProperties = { margin: 0, fontSize: 12.5, lineHeight: 1.5, color: 'rgba(0,0,0,0.6)', maxWidth: 560 };
+const toggleStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  border: '1px solid rgba(0,0,0,0.12)',
+  borderRadius: 8,
+  overflow: 'hidden',
+  flexShrink: 0,
+};
+const toggleBtn: React.CSSProperties = {
+  padding: '6px 12px',
+  fontSize: 12.5,
+  border: 'none',
+  background: '#fff',
+  color: 'rgba(0,0,0,0.65)',
+  cursor: 'pointer',
+};
+const toggleBtnActive: React.CSSProperties = {
+  ...toggleBtn,
+  background: siteTheme.accent ?? '#4c78a8',
+  color: '#fff',
+  fontWeight: 600,
+};
+const gridStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gap: 16,
+};
+const cardStyle: React.CSSProperties = {
+  margin: 0,
+  border: '1px solid rgba(0,0,0,0.06)',
+  borderRadius: 8,
+  padding: 10,
+  background: '#fcfcfd',
+};
+const captionStyle: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 2, marginBottom: 6 };
+const captionTitle: React.CSSProperties = { fontSize: 12.5, fontWeight: 600 };
+const captionNote: React.CSSProperties = { fontSize: 11, color: 'rgba(0,0,0,0.5)' };

--- a/site/src/components/LocalDodgeFigure.tsx
+++ b/site/src/components/LocalDodgeFigure.tsx
@@ -1,0 +1,324 @@
+import { useMemo } from 'react';
+import { VegaLiteView } from './VegaLiteView';
+import { EChartsView } from './EChartsView';
+import { ChartjsView } from './ChartjsView';
+import { siteTheme } from '../shared/theme';
+
+/**
+ * FEASIBILITY PROTOTYPE (dev-playground only, raw hand-built specs — NOT the
+ * flint engine). Tests whether "local dodge" is achievable in all three
+ * backends for a *spiky* sparse case: most bands have one value, one band has
+ * two. Global-lane dodge reserves `global` lanes everywhere (catastrophic:
+ * 7 thin lanes here); local dodge only needs `maxPerBand` (2).
+ *
+ * Techniques demonstrated:
+ *   - VL global  — xOffset by the color field → domain = 7 global colors.
+ *   - VL local   — xOffset by a precomputed per-band `laneIdx` → domain = 2.
+ *   - VL layered — single-value bands full-width (no offset) + multi-value
+ *                  bands dodged: the "true" local dodge (full-width singles).
+ *   - ECharts    — one series per lane (maxPerBand series), per-bar color.
+ *   - Chart.js   — one dataset per lane, per-bar color.
+ */
+
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+// Spiky: every band has ONE type except Thu which has TWO. Types are distinct
+// per band → global distinct = 7, maxPerBand = 2.
+const BANDS: Record<string, string[]> = {
+  Mon: ['Alpha'], Tue: ['Bravo'], Wed: ['Charlie'], Thu: ['Delta', 'Echo'], Fri: ['Foxtrot'], Sat: ['Golf'],
+};
+const TYPE_COLOR: Record<string, string> = {
+  Alpha: '#4c78a8', Bravo: '#f58518', Charlie: '#e45756', Delta: '#72b7b2',
+  Echo: '#54a24b', Foxtrot: '#eeca3b', Golf: '#b279a2',
+};
+const TYPES = Object.keys(TYPE_COLOR);
+const MAX_PER_BAND = Math.max(...Object.values(BANDS).map((t) => t.length)); // 2
+
+interface Row { day: string; type: string; value: number; laneIdx: number; localCount: number }
+
+function buildRows(): Row[] {
+  const rows: Row[] = [];
+  for (const day of DAYS) {
+    const types = BANDS[day];
+    types.forEach((type, i) => {
+      rows.push({ day, type, value: 30 + (type.charCodeAt(0) % 15) * 4 + i * 8, laneIdx: i, localCount: types.length });
+    });
+  }
+  return rows;
+}
+
+const STEP = 34; // same band width everywhere so lane-count differences are visible.
+
+const vlX = {
+  field: 'day', type: 'nominal', sort: DAYS,
+  axis: { labelAngle: 0, title: null },
+} as const;
+
+function vlBase(rows: Row[]) {
+  return {
+    data: { values: rows },
+    // `for: 'position'` pins the step to the DAY band; without it VL multiplies
+    // the step by the offset-lane count → the plot balloons to ~lanes× wide and
+    // clips. This is exactly why global dodge (7 lanes) must not blow up width.
+    width: { step: STEP, for: 'position' },
+    height: 190,
+    config: { view: { stroke: null }, axis: { grid: false } },
+  };
+}
+const vlColor = {
+  field: 'type', type: 'nominal',
+  scale: { domain: TYPES, range: TYPES.map((t) => TYPE_COLOR[t]) },
+  legend: null,
+} as const;
+
+function vlGlobalSpec(rows: Row[]) {
+  return {
+    ...vlBase(rows),
+    mark: 'bar',
+    encoding: {
+      x: vlX,
+      xOffset: { field: 'type', type: 'nominal' }, // 7 global lanes
+      y: { field: 'value', type: 'quantitative', axis: { title: null } },
+      color: vlColor,
+    },
+  };
+}
+function vlLayeredSpec(rows: Row[]) {
+  const enc = (dodge: boolean) => ({
+    x: vlX,
+    ...(dodge ? { xOffset: { field: 'laneIdx', type: 'nominal' } } : {}),
+    y: { field: 'value', type: 'quantitative', axis: { title: null } },
+    color: vlColor,
+  });
+  return {
+    ...vlBase(rows),
+    resolve: { scale: { xOffset: 'shared' } },
+    layer: [
+      { transform: [{ filter: 'datum.localCount === 1' }], mark: 'bar', encoding: enc(false) }, // full-width singles
+      { transform: [{ filter: 'datum.localCount > 1' }], mark: 'bar', encoding: enc(true) },     // dodged multis
+    ],
+  };
+}
+
+function echartsLocalOption(rows: Row[]) {
+  // Native category axis (labels auto-center under each band) + custom rects
+  // centered WITHIN each band across maxPerBand lanes. Avoids fragile manual
+  // label positioning; same centering math as VL.
+  const items: { di: number; value: number; laneIdx: number; localCount: number; color: string }[] = [];
+  DAYS.forEach((day, di) => {
+    const dayRows = rows.filter((r) => r.day === day).sort((a, b) => a.laneIdx - b.laneIdx);
+    dayRows.forEach((r, i) => items.push({ di, value: r.value, laneIdx: i, localCount: dayRows.length, color: TYPE_COLOR[r.type] }));
+  });
+  const colors = items.map((it) => it.color);
+  return {
+    _width: 300, _height: 220,
+    grid: { left: 34, right: 8, top: 12, bottom: 26 },
+    xAxis: { type: 'category', data: DAYS, axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{
+      type: 'custom',
+      renderItem: (params: any, api: any) => {
+        const di = api.value(0);
+        const val = api.value(1);
+        const laneIdx = api.value(2);
+        const localCount = api.value(3);
+        const base = api.coord([di, 0]);
+        const top = api.coord([di, val]);
+        const bandW = api.size([1, 0])[0];
+        const lanePitch = bandW / MAX_PER_BAND;
+        const cx = base[0] + (laneIdx - (localCount - 1) / 2) * lanePitch;
+        const barW = lanePitch * 0.8;
+        return {
+          type: 'rect',
+          shape: { x: cx - barW / 2, y: top[1], width: barW, height: base[1] - top[1] },
+          style: { fill: colors[params.dataIndex] },
+        };
+      },
+      encode: { x: 0, y: 1 },
+      data: items.map((it) => [it.di, it.value, it.laneIdx, it.localCount]),
+    }],
+  };
+}
+
+function chartjsLocalConfig(rows: Row[]) {
+  // Uniform + centered via a LINEAR x-axis: place each bar at its slot centre
+  // with a constant barThickness; a small plugin draws the centered group
+  // labels (Chart.js' category axis can't center singles either).
+  const { bars, labels, total } = uniformCenteredLayout(rows);
+  return {
+    _width: 300, _height: 220,
+    type: 'bar',
+    data: {
+      datasets: [{
+        data: bars.map((b) => ({ x: (b.x0 + b.x1) / 2, y: b.value })),
+        backgroundColor: bars.map((b) => TYPE_COLOR[b.type]),
+        barThickness: Math.round(SLOT_PX * 0.82),
+      }],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      layout: { padding: { bottom: 14 } },
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { type: 'linear', min: 0, max: total, offset: false, ticks: { display: false }, grid: { display: false } },
+        y: { beginAtZero: true },
+      },
+    },
+    plugins: [{
+      id: 'groupLabels',
+      afterDraw(chart: any) {
+        const { ctx, scales: { x }, chartArea } = chart;
+        ctx.save();
+        ctx.fillStyle = '#333';
+        ctx.font = '11px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        for (const l of labels) ctx.fillText(l.day, x.getPixelForValue(l.center), chartArea.bottom + 4);
+        ctx.restore();
+      },
+    }],
+  };
+}
+
+const SLOT_PX = 22; // per-item slot width for the computed-position layouts.
+
+// Uniform + centered layout (the chosen resolution): EVERY band is the SAME
+// width = maxPerBand slots (sized to the busiest band), each band's items are
+// CENTERED within it, and every bar is one slot wide (constant). Single-item
+// bands get half-slot padding on each side → the bar sits centered under the
+// (uniform, evenly-spaced) group tick.
+function uniformCenteredLayout(rows: Row[]) {
+  const bars: (Row & { x0: number; x1: number })[] = [];
+  const labels: { day: string; center: number; boundary: number }[] = [];
+  DAYS.forEach((day, ci) => {
+    const items = rows.filter((r) => r.day === day).sort((a, b) => a.laneIdx - b.laneIdx);
+    const bandStart = ci * MAX_PER_BAND;
+    const pad = (MAX_PER_BAND - items.length) / 2; // center the cluster in the band
+    items.forEach((r, i) => {
+      const slot = bandStart + pad + i;
+      bars.push({ ...r, x0: slot + 0.1, x1: slot + 0.9 });
+    });
+    labels.push({ day, center: bandStart + MAX_PER_BAND / 2, boundary: bandStart + MAX_PER_BAND });
+  });
+  return { bars, labels, total: DAYS.length * MAX_PER_BAND };
+}
+
+function vlComputedSpec(layout: { bars: (Row & { x0: number; x1: number })[]; labels: { day: string; center: number; boundary: number }[]; total: number }) {
+  const { bars, labels, total } = layout;
+  const xScale = { domain: [0, total], nice: false } as const;
+  return {
+    width: total * SLOT_PX,
+    height: 190,
+    config: { view: { stroke: null }, axis: { grid: false } },
+    layer: [
+      {
+        data: { values: bars },
+        mark: 'bar',
+        encoding: {
+          x: {
+            field: 'x0', type: 'quantitative', scale: xScale,
+            // Keep the axis BASELINE (domain line) for grounding, but no numeric
+            // ticks/labels — the group names come from the centered text layer.
+            axis: { domain: true, ticks: false, labels: false, grid: false, title: null },
+          },
+          x2: { field: 'x1' },
+          // A bar with x+x2 is a rect → it needs an explicit vertical extent,
+          // otherwise it collapses to a zero-height segment at y=value.
+          y: { field: 'value', type: 'quantitative', axis: { title: null } },
+          y2: { datum: 0 },
+          color: vlColor,
+        },
+      },
+      {
+        data: { values: labels.slice(0, -1).map((l) => ({ b: l.boundary })) },
+        mark: { type: 'rule', color: 'rgba(0,0,0,0.12)', strokeDash: [2, 2] },
+        encoding: { x: { field: 'b', type: 'quantitative', scale: xScale, axis: null } },
+      },
+      {
+        data: { values: labels },
+        mark: { type: 'text', baseline: 'top', dy: 6, fontSize: 11 },
+        encoding: {
+          x: { field: 'center', type: 'quantitative', scale: xScale, axis: null },
+          y: { datum: 0 },
+          text: { field: 'day' },
+        },
+      },
+    ],
+  };
+}
+
+// Proportional layout: each ITEM gets a fixed-width slot, so a band with k items
+// occupies k slots (k× width), bars stay a constant width, and the group label is
+// centered under its cluster. Sidesteps both the global-lane gaps and the
+// left-anchor/centering problem — at the cost of unequal band widths.
+function proportionalLayout(rows: Row[]) {
+  const ordered = [...rows].sort(
+    (a, b) => DAYS.indexOf(a.day) - DAYS.indexOf(b.day) || a.laneIdx - b.laneIdx,
+  );
+  const bars: (Row & { x0: number; x1: number })[] = [];
+  const labels: { day: string; center: number; boundary: number }[] = [];
+  let slot = 0;
+  let curDay: string | null = null;
+  let dayStart = 0;
+  for (const r of ordered) {
+    if (r.day !== curDay) {
+      if (curDay !== null) labels.push({ day: curDay, center: (dayStart + slot) / 2, boundary: slot });
+      curDay = r.day;
+      dayStart = slot;
+    }
+    bars.push({ ...r, x0: slot + 0.08, x1: slot + 0.92 });
+    slot += 1;
+  }
+  if (curDay !== null) labels.push({ day: curDay, center: (dayStart + slot) / 2, boundary: slot });
+  return { bars, labels, total: slot };
+}
+
+interface Cell { key: string; label: string; note: string; render: () => JSX.Element }
+
+export function LocalDodgeFigure() {
+  const rows = useMemo(buildRows, []);
+  const cells: Cell[] = [
+    { key: 'vl-global', label: 'VL · global dodge', note: '7 lanes everywhere → 1⁄7 bars (the problem)', render: () => <VegaLiteView spec={vlGlobalSpec(rows)} /> },
+    { key: 'vl-uniform', label: 'VL · uniform + centered ★', note: 'every band = maxPerBand wide; items centered; constant bar width', render: () => <VegaLiteView spec={vlComputedSpec(uniformCenteredLayout(rows))} /> },
+    { key: 'vl-layered', label: 'VL · local (layered)', note: 'singles full-width + Thu split (variable width)', render: () => <VegaLiteView spec={vlLayeredSpec(rows)} /> },
+    { key: 'vl-prop', label: 'VL · proportional width', note: 'Thu gets 2× space; band width ∝ item count', render: () => <VegaLiteView spec={vlComputedSpec(proportionalLayout(rows))} /> },
+    { key: 'ec-local', label: 'ECharts · uniform + centered', note: 'native category axis + custom rects centered per band', render: () => <EChartsView option={echartsLocalOption(rows)} constrain={false} /> },
+    { key: 'cj-local', label: 'Chart.js · uniform + centered', note: 'linear x + barThickness + label plugin', render: () => <ChartjsView config={chartjsLocalConfig(rows)} constrain={false} /> },
+  ];
+
+  return (
+    <section style={wrapStyle}>
+      <div>
+        <h3 style={titleStyle}>Local dodge — feasibility (spiky sparse: 1,1,1,2,1,1)</h3>
+        <p style={subtitleStyle}>
+          Prototype specs (not the engine). Global dodge reserves <code>global</code> = 7 lanes in
+          every band; local dodge only needs <code>maxPerBand</code> = 2. Same band width across all
+          tiles so the lane-count difference is visible.
+        </p>
+      </div>
+      <div style={gridStyle}>
+        {cells.map((c) => (
+          <figure key={c.key} style={cardStyle}>
+            <figcaption style={capStyle}>
+              <span style={capTitle}>{c.label}</span>
+              <span style={capNote}>{c.note}</span>
+            </figcaption>
+            <div style={{ overflow: 'hidden' }}>{c.render()}</div>
+          </figure>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const wrapStyle: React.CSSProperties = {
+  width: 960, boxSizing: 'border-box', background: '#fff',
+  border: '1px solid rgba(0,0,0,0.08)', borderRadius: 10, padding: 20,
+  fontFamily: siteTheme.fontSans, color: siteTheme.text,
+};
+const titleStyle: React.CSSProperties = { margin: '0 0 4px', fontSize: 16, fontWeight: 600 };
+const subtitleStyle: React.CSSProperties = { margin: '0 0 16px', fontSize: 12.5, lineHeight: 1.5, color: 'rgba(0,0,0,0.6)', maxWidth: 640 };
+const gridStyle: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16 };
+const cardStyle: React.CSSProperties = { margin: 0, border: '1px solid rgba(0,0,0,0.06)', borderRadius: 8, padding: 10, background: '#fcfcfd', minWidth: 0 };
+const capStyle: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 2, marginBottom: 6 };
+const capTitle: React.CSSProperties = { fontSize: 12.5, fontWeight: 600 };
+const capNote: React.CSSProperties = { fontSize: 11, color: 'rgba(0,0,0,0.5)' };

--- a/site/src/components/TripleChart.tsx
+++ b/site/src/components/TripleChart.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { TestCase } from 'flint-chart/test-data';
-import { assembleVegaLite, assembleECharts, assembleChartjs } from 'flint-chart';
 import { VegaLiteView } from './VegaLiteView';
 import { EChartsView } from './EChartsView';
 import { ChartjsView } from './ChartjsView';
 import { testCaseToAssemblyInput } from '../shared/test-case-utils';
 import {
+  BACKENDS,
   BACKEND_LABELS,
   getSupportedBackends,
   type PreviewBackend,
@@ -42,9 +42,7 @@ export function TripleChart({
 
   const compiled = useMemo(() => {
     try {
-      if (backend === 'vegalite') return { ok: true as const, value: assembleVegaLite(input) };
-      if (backend === 'echarts') return { ok: true as const, value: assembleECharts(input) };
-      return { ok: true as const, value: assembleChartjs(input) };
+      return { ok: true as const, value: BACKENDS[backend].assemble(input) };
     } catch (err) {
       return { ok: false as const, err };
     }

--- a/site/src/components/WallChart.tsx
+++ b/site/src/components/WallChart.tsx
@@ -1,11 +1,10 @@
 import { useMemo } from 'react';
 import type { TestCase } from 'flint-chart/test-data';
-import { assembleVegaLite, assembleECharts, assembleChartjs } from 'flint-chart';
 import { VegaLiteView } from './VegaLiteView';
 import { EChartsView } from './EChartsView';
 import { ChartjsView } from './ChartjsView';
 import { testCaseToAssemblyInput, thumbnailCanvasSize, type CanvasSize } from '../shared/test-case-utils';
-import type { PreviewBackend } from '../shared/supported-backends';
+import { BACKENDS, type PreviewBackend } from '../shared/supported-backends';
 import { siteTheme } from '../shared/theme';
 
 /**
@@ -45,9 +44,7 @@ export function WallChart({
 
   const compiled = useMemo(() => {
     try {
-      if (backend === 'vegalite') return { ok: true as const, value: assembleVegaLite(input) };
-      if (backend === 'echarts') return { ok: true as const, value: assembleECharts(input) };
-      return { ok: true as const, value: assembleChartjs(input) };
+      return { ok: true as const, value: BACKENDS[backend].assemble(input) };
     } catch (err) {
       return { ok: false as const, err };
     }

--- a/site/src/routes/DevPlayground.tsx
+++ b/site/src/routes/DevPlayground.tsx
@@ -1,6 +1,8 @@
 import { siteTheme } from '../shared/theme';
 import { SpecPipelineFigure } from '../components/SpecPipelineFigure';
 import { McpAppMockup } from '../components/McpAppMockup';
+import { DodgeToggleFigure } from '../components/DodgeToggleFigure';
+import { LocalDodgeFigure } from '../components/LocalDodgeFigure';
 import { ChatMockup } from './McpServer';
 
 const PAPER = '#ffffff';
@@ -10,6 +12,10 @@ export function DevPlayground() {
   return (
     <main style={pageStyle}>
       <SpecPipelineFigure />
+
+      <DodgeToggleFigure />
+
+      <LocalDodgeFigure />
 
       <section className="dev-playground-dialog-figure" style={dialogFigureStyle}>
         <ChatMockup />

--- a/site/src/routes/Editor.tsx
+++ b/site/src/routes/Editor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { assembleVegaLite, assembleECharts, assembleChartjs, type ChartAssemblyInput } from 'flint-chart';
+import type { ChartAssemblyInput } from 'flint-chart';
 import { SiteShell } from '../components/SiteShell';
 import { JsonCodeMirror } from '../components/JsonCodeMirror';
 import { ResizeSplit } from '../components/ResizeSplit';
@@ -11,6 +11,7 @@ import { loadEditorPayload, readEditorCaseParam, readGalleryCaseParams } from '.
 import { testCaseToAssemblyInput } from '../shared/test-case-utils';
 import {
   ALL_BACKENDS,
+  BACKENDS,
   BACKEND_LABELS,
   getSupportedBackends,
   type PreviewBackend,
@@ -110,14 +111,10 @@ export function Editor() {
   const compiledByBackend = useMemo(() => {
     if (!parsed.ok) return { ok: false as const, err: parsed.err };
     const input = parsed.value as ChartAssemblyInput;
-    return {
-      ok: true as const,
-      value: {
-        vegalite: compile(() => assembleVegaLite(input)),
-        echarts: compile(() => assembleECharts(input)),
-        chartjs: compile(() => assembleChartjs(input)),
-      },
-    };
+    const value = Object.fromEntries(
+      ALL_BACKENDS.map((b) => [b, compile(() => BACKENDS[b].assemble(input))]),
+    ) as Record<PreviewBackend, CompileResult<unknown>>;
+    return { ok: true as const, value };
   }, [parsed]);
 
   const activeCompiled = compiledByBackend.ok ? compiledByBackend.value[backend] : null;

--- a/site/src/shared/chart-options.ts
+++ b/site/src/shared/chart-options.ts
@@ -27,6 +27,7 @@ import type {
   PivotSurface,
   RawEncodingValue,
 } from 'flint-chart';
+import { BACKENDS, type PreviewBackend } from './supported-backends';
 
 /** Control descriptor shared by chart properties and encoding actions. */
 export type ControlSpec =
@@ -117,8 +118,33 @@ function actionValue(
   }
 }
 
+/**
+ * Chart-property keys the given backend's template actually implements.
+ *
+ * The option list is derived from the Vega-Lite template (`getChartOptions`
+ * assembles VL), but each backend template declares its own `properties` — a
+ * *subset* of the knobs for that chart type (e.g. Chart.js `polarArea` has no
+ * cutout, so a rose chart there can't do "Inner Radius" or "Gap"). We intersect
+ * the shown controls with the selected backend's declared set, hiding dead
+ * controls that would silently do nothing. Returns `null` when there is nothing
+ * to narrow by (the backend template declares no properties → fall back to the
+ * full VL list). For Vega-Lite itself this is a no-op: the option list already
+ * *is* the VL template's properties, so the intersection keeps everything.
+ */
+function backendSupportedPropertyKeys(
+  chartType: string,
+  backend: PreviewBackend,
+): Set<string> | null {
+  const props = BACKENDS[backend].getTemplateDef(chartType)?.properties;
+  if (!props || props.length === 0) return null;
+  return new Set(props.map((p) => p.key));
+}
+
 /** Build the option model (properties + encoding actions) for the input. */
-export function buildPanelModel(input: ChartAssemblyInput): PanelModel {
+export function buildPanelModel(
+  input: ChartAssemblyInput,
+  backend: PreviewBackend = 'vegalite',
+): PanelModel {
   const def = vlGetTemplateDef(input.chart_spec.chartType);
 
   let properties: ChartOption[] = [];
@@ -126,6 +152,14 @@ export function buildPanelModel(input: ChartAssemblyInput): PanelModel {
     properties = getChartOptions(input).filter((o) => o.applicable);
   } catch {
     properties = [];
+  }
+
+  // Non-Vega-Lite backends only honor a subset of the VL properties; drop the
+  // controls the selected backend's template doesn't implement so the options
+  // bar never shows a knob that does nothing.
+  const supported = backendSupportedPropertyKeys(input.chart_spec.chartType, backend);
+  if (supported) {
+    properties = properties.filter((o) => supported.has(o.key));
   }
 
   const encodings = normalizeEncodings(input);

--- a/site/src/shared/supported-backends.ts
+++ b/site/src/shared/supported-backends.ts
@@ -1,24 +1,65 @@
 import {
+  assembleVegaLite,
+  assembleECharts,
+  assembleChartjs,
   cjsGetTemplateDef,
   ecGetTemplateDef,
   vlGetTemplateDef,
+  type ChartAssemblyInput,
 } from 'flint-chart';
 
 export type PreviewBackend = 'vegalite' | 'echarts' | 'chartjs';
 
-export const ALL_BACKENDS: PreviewBackend[] = ['vegalite', 'echarts', 'chartjs'];
+/** A backend's template def (or `undefined` when it has no template for a type). */
+type TemplateDef = ReturnType<typeof vlGetTemplateDef>;
 
-export const BACKEND_LABELS: Record<PreviewBackend, string> = {
-  vegalite: 'Vega-Lite',
-  echarts: 'ECharts',
-  chartjs: 'Chart.js',
+/**
+ * Everything the site needs to drive one rendering backend, in one row.
+ *
+ * This is the single dispatch point for "do X for the selected backend" so the
+ * rest of the app never branches on `backend === 'vegalite'` etc. Adding a new
+ * backend is one entry here (plus the `PreviewBackend` union) — consumers
+ * (`getSupportedBackends`, the options panel, the chart views) pick it up for
+ * free instead of each growing another `if`-ladder.
+ */
+export interface BackendAdapter {
+  id: PreviewBackend;
+  /** Human-readable name shown in the UI. */
+  label: string;
+  /** Compile a Flint input into this backend's native spec/config. */
+  assemble: (input: ChartAssemblyInput) => unknown;
+  /** This backend's template for a chart type (`undefined` = unsupported). */
+  getTemplateDef: (chartType: string) => TemplateDef;
+}
+
+export const BACKENDS: Record<PreviewBackend, BackendAdapter> = {
+  vegalite: {
+    id: 'vegalite',
+    label: 'Vega-Lite',
+    assemble: assembleVegaLite,
+    getTemplateDef: vlGetTemplateDef,
+  },
+  echarts: {
+    id: 'echarts',
+    label: 'ECharts',
+    assemble: assembleECharts,
+    getTemplateDef: ecGetTemplateDef,
+  },
+  chartjs: {
+    id: 'chartjs',
+    label: 'Chart.js',
+    assemble: assembleChartjs,
+    getTemplateDef: cjsGetTemplateDef,
+  },
 };
+
+export const ALL_BACKENDS = Object.keys(BACKENDS) as PreviewBackend[];
+
+export const BACKEND_LABELS = Object.fromEntries(
+  ALL_BACKENDS.map((backend) => [backend, BACKENDS[backend].label]),
+) as Record<PreviewBackend, string>;
 
 /** Backends that have a registered template for the given chart type. */
 export function getSupportedBackends(chartType: string): PreviewBackend[] {
-  return ALL_BACKENDS.filter((backend) => {
-    if (backend === 'vegalite') return !!vlGetTemplateDef(chartType);
-    if (backend === 'echarts') return !!ecGetTemplateDef(chartType);
-    return !!cjsGetTemplateDef(chartType);
-  });
+  return ALL_BACKENDS.filter((backend) => !!BACKENDS[backend].getTemplateDef(chartType));
 }

--- a/site/src/shared/wall-variants.ts
+++ b/site/src/shared/wall-variants.ts
@@ -28,11 +28,18 @@ export function selectVariants(tests: TestCase[], cap = 4): TestCase[] {
   const clean = tests.filter((t) => !(t.tags ?? []).some((tag) => SKIP_TAGS.has(tag)));
   const pool = clean.length > 0 ? clean : tests;
 
-  const facetIdx = pool.findIndex((t) => (t.tags ?? []).includes('gallery-facet'));
-  if (facetIdx === -1) return strideSample(pool, cap);
+  // Always-show examples (e.g. the color/group dodge demonstrations) are pinned
+  // and appended in addition to the sampled set, so they can't be dropped by the
+  // even sampling regardless of where they sit in the generator.
+  const isPinned = (t: TestCase) => (t.tags ?? []).includes('gallery-pin');
+  const pinned = pool.filter(isPinned);
+  const rest = pool.filter((t) => !isPinned(t));
 
-  // Pin the faceted example last; fill remaining slots from the rest.
-  const facet = pool[facetIdx];
-  const rest = pool.filter((_, i) => i !== facetIdx);
-  return [...strideSample(rest, Math.max(cap - 1, 0)), facet];
+  const facetIdx = rest.findIndex((t) => (t.tags ?? []).includes('gallery-facet'));
+  const sampled = facetIdx === -1
+    ? strideSample(rest, cap)
+    // Pin the faceted example last; fill remaining slots from the rest.
+    : [...strideSample(rest.filter((_, i) => i !== facetIdx), Math.max(cap - 1, 0)), rest[facetIdx]];
+
+  return [...sampled, ...pinned];
 }


### PR DESCRIPTION
This pull request introduces version 0.2.2, bringing significant improvements to grouped chart rendering and chart property controls, especially for bar charts and violin plots across Vega-Lite, ECharts, and Chart.js. The update also refines rose chart behaviors and documentation, and fixes sorting and alignment issues. The most important changes are grouped below:

**Grouped Chart Enhancements**
* Grouped violin plots in Vega-Lite now render as split violins for two groups and as a grid for three or more, improving clarity over the previous overlapping mirror approach.
* Added local (compact) and global (aligned) dodge modes for grouped bar charts (Vega-Lite, ECharts, Chart.js) and boxplots (Vega-Lite, ECharts), selectable via the new `dodge` chart property. This makes sparse grouped data more readable. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R38) [[2]](diffhunk://#diff-8e91dd10432c461a8eef847fec6ddbb619ca46588967fbcf9304f5fb3abe110eL239-R254) [[3]](diffhunk://#diff-8e91dd10432c461a8eef847fec6ddbb619ca46588967fbcf9304f5fb3abe110eR271-R274) [[4]](diffhunk://#diff-8e91dd10432c461a8eef847fec6ddbb619ca46588967fbcf9304f5fb3abe110eL287-R362) [[5]](diffhunk://#diff-8e91dd10432c461a8eef847fec6ddbb619ca46588967fbcf9304f5fb3abe110eR400-R424) [[6]](diffhunk://#diff-54a8acaaa6a55618156c9f5a648ff1070d8a9ee8f76896eb495d56ff6e9e778dR69) [[7]](diffhunk://#diff-54a8acaaa6a55618156c9f5a648ff1070d8a9ee8f76896eb495d56ff6e9e778dL90-R93) [[8]](diffhunk://#diff-f65c325bd517c8fe3991660c853a4ea0b931b61a16bf61a0fbd037ddddc82e6aR116) [[9]](diffhunk://#diff-f65c325bd517c8fe3991660c853a4ea0b931b61a16bf61a0fbd037ddddc82e6aR220) [[10]](diffhunk://#diff-5a17272407813e7b4e26d5600ae6b459057606339814163dce8960fbfa86d053L78-R80)

**Chart Property and API Changes**
* The `dodge` chart property options are now limited to `auto`, `local`, and `global`. The manual `none` option was removed, and one-per-band collapsing is now handled automatically. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R38) [[2]](diffhunk://#diff-8e91dd10432c461a8eef847fec6ddbb619ca46588967fbcf9304f5fb3abe110eR400-R424)
* Documentation for Vega-Lite, ECharts, and Chart.js has been updated to describe the new `dodge` property and its options. [[1]](diffhunk://#diff-5a17272407813e7b4e26d5600ae6b459057606339814163dce8960fbfa86d053L78-R80) [[2]](diffhunk://#diff-54a8acaaa6a55618156c9f5a648ff1070d8a9ee8f76896eb495d56ff6e9e778dR69) [[3]](diffhunk://#diff-54a8acaaa6a55618156c9f5a648ff1070d8a9ee8f76896eb495d56ff6e9e778dL90-R93) [[4]](diffhunk://#diff-f65c325bd517c8fe3991660c853a4ea0b931b61a16bf61a0fbd037ddddc82e6aR116) [[5]](diffhunk://#diff-f65c325bd517c8fe3991660c853a4ea0b931b61a16bf61a0fbd037ddddc82e6aR220)

**Rose Chart Improvements**
* The Vega-Lite Rose Chart no longer exposes an inner-radius control, aligning with the intended semantics (no donut hole). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R38) [[2]](diffhunk://#diff-f65c325bd517c8fe3991660c853a4ea0b931b61a16bf61a0fbd037ddddc82e6aL350)
* The "Sort slices" option in Vega-Lite Rose Charts now reliably reorders wedges and their legend by value.
* Chart.js Rose Chart alignment now correctly rotates wedges via the radial scale’s `startAngle` property, fixing a previous bug where the option was ignored. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R38) [[2]](diffhunk://#diff-dccd20441fb8c8278a78a0ad208ef3a73425884ae1621b815f834cd02d4deb35L110-R115) [[3]](diffhunk://#diff-dccd20441fb8c8278a78a0ad208ef3a73425884ae1621b815f834cd02d4deb35L131-R137)

**Versioning and Changelog**
* Bumped version to 0.2.2 and updated the changelog and GitHub comparison links accordingly. [[1]](diffhunk://#diff-6fa1adf4f44d227a15e563b2a72b320c7cc74162d648ab61ab2f7cf4b538a117L3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL37-R65)

**Bug Fixes**
* Fixed sorting and alignment issues in Vega-Lite and Chart.js Rose Charts, ensuring correct visual and legend ordering.

These changes collectively improve grouped chart readability, streamline chart property controls, and resolve several chart rendering bugs.