### PR TITLE
feat(vegalite): add Calendar Heatmap template

### DIFF
--- a/agent-skills/flint-chart-author/SKILL.md
+++ b/agent-skills/flint-chart-author/SKILL.md
@@ -268,6 +268,7 @@ properties"). Required channels are noted.
 | `"Boxplot"` | x, y, color, opacity, column, row | category + measure; props `whiskerMethod`, `showOutliers`, `dodge` |
 | `"ECDF Plot"` | x, color, detail, column, row | x = measure; cumulative distribution (step line); prop `showPoints` |
 | `"Heatmap"` | x, y, color, column, row | color = the measure |
+| `"Calendar Heatmap"` | x, color | x = date; color = daily value (summed per day); GitHub-style week × weekday grid |
 | `"Line Chart"` | x, y, color, strokeDash, detail, opacity, column, row | props `interpolate`, `showPoints` |
 | `"Sparkline"` | x, y, color, detail, row, column | x + y required; small-multiple mini trend lines, one per series (series from `color` or `detail`); props `interpolate`, `baseline`, `trendWidth` |
 | `"Bump Chart"` | x, y, color, detail, column, row | rank-over-time lines |
@@ -321,7 +322,7 @@ type column.
 **Backend coverage.** Vega-Lite supports all of the above. Other backends
 support a subset (verify if targeting a non-VL backend):
 
-- **ECharts** adds: `"Calendar Heatmap"`, `"Gauge"`,
+- **ECharts** adds: `"Gauge"`,
   `"Funnel"`, `"Treemap"`, `"Sunburst"`, `"Sankey"`,
   `"Parallel Coordinates"`, `"Graph"`, `"Tree"`.
 - **Chart.js** supports: Scatter, Bubble, Bar, Grouped Bar, Stacked Bar,

--- a/docs/reference-vegalite.md
+++ b/docs/reference-vegalite.md
@@ -6,7 +6,7 @@ The Vega-Lite backend serves as Flint's reference implementation and offers the 
 
 ## What this page covers
 
-This reference lists the 35 chart types currently supported by the Vega-Lite backend, grouped into 6 categories. Each chart entry shows:
+This reference lists the 36 chart types currently supported by the Vega-Lite backend, grouped into 6 categories. Each chart entry shows:
 
 - **Encoding channels** — the visual roles accepted in `chart_spec.encodings`, such as `x`, `y`, `color`, `size`, `column`, or `row`.
 - **Options** — template-specific `chart_spec.chartProperties` keys, including control type, domain, default, availability, and description.
@@ -410,6 +410,12 @@ The **Availability** column shows whether a parameter is `always` available or `
 | `independentYAxis` | toggle | on / off | `false` | conditional | Use independent y-scales for facets. |
 | `xAxisType` | choice | `temporal` (Temporal), `nominal` (Discrete) | — | conditional | Interpret the x-axis as a continuous time scale or discrete bands. |
 | `yAxisType` | choice | `temporal` (Temporal), `nominal` (Discrete) | — | conditional | Interpret the y-axis as a continuous time scale or discrete bands. |
+
+### ![](chart-icon-calendar.svg) Calendar Heatmap
+
+**Encoding channels:** `x`, `color`
+
+_No template-specific parameters._
 
 ### ![](chart-icon-bar-table.svg) Bar Table
 

--- a/packages/flint-js/src/vegalite/templates/calendar.ts
+++ b/packages/flint-js/src/vegalite/templates/calendar.ts
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Vega-Lite Calendar Heatmap template.
+ *
+ * The ECharts backend has a first-class calendar coordinate system; Vega-Lite
+ * has none, but it does not need computed week/day fields either — `timeUnit`
+ * expresses the GitHub-style grid directly from a single date field:
+ *   x  →  timeUnit 'yearweek' (one ordinal column per calendar week)
+ *   y  →  timeUnit 'day'      (Sun–Sat, one ordinal row per weekday)
+ * so the same date field drives both axes and the sum-per-cell aggregation
+ * collapses to one value per calendar day.
+ *
+ * Encoding:
+ *   x     (temporal) → the date of each cell
+ *   color (quantitative) → the cell value (defaults to a count of 1)
+ */
+
+import { ChartTemplateDef, EncodingActionDef } from '../../core/types';
+
+/** Weekday row order, Monday-first — mirrors the ECharts template's dayLabel.firstDay = 1. */
+const WEEKDAY_ORDER = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+/**
+ * Sequential schemes. Named Vega-Lite schemes pass through as `scale.scheme`;
+ * 'github' has no built-in Vega-Lite equivalent, so it resolves to an explicit
+ * `scale.range` (the same low→high ramp the ECharts template uses).
+ */
+const GITHUB_RANGE = ['#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39'];
+const VL_SCHEMES = new Set(['viridis', 'blues', 'greens', 'reds', 'oranges', 'purples']);
+
+export const vlCalendarHeatmapDef: ChartTemplateDef = {
+    chart: 'Calendar Heatmap',
+    template: { mark: { type: 'rect', cornerRadius: 2 }, encoding: {} },
+    channels: ['x', 'color'],
+    markCognitiveChannel: 'color',
+    declareLayoutMode: () => ({
+        // Both axes are ordinal bands (week columns × weekday rows); square-ish
+        // cells read as a calendar rather than a stretched grid.
+        axisFlags: { x: { banded: true }, y: { banded: true } },
+    }),
+    instantiate: (spec, ctx) => {
+        const dateField = ctx.channelSemantics.x?.field;
+        const valueField = ctx.channelSemantics.color?.field;
+        if (!dateField) return;
+
+        const encScheme = ctx.encodings?.color?.scheme;
+        const scheme = encScheme && encScheme !== 'default' ? encScheme : 'viridis';
+        const colorScale =
+            scheme === 'github'
+                ? { range: GITHUB_RANGE }
+                : { scheme: VL_SCHEMES.has(scheme) ? scheme : 'viridis' };
+
+        spec.encoding = {
+            // One ordinal column per calendar week; month initials label the axis.
+            x: {
+                field: dateField,
+                timeUnit: 'yearweek',
+                type: 'ordinal',
+                title: null,
+                axis: {
+                    format: '%b',
+                    labelAngle: 0,
+                    labelOverlap: true,
+                    tickBand: 'extent',
+                    domain: false,
+                    ticks: false,
+                },
+            },
+            // Sun–Sat rows, Monday-first to match the ECharts calendar.
+            y: {
+                field: dateField,
+                timeUnit: 'day',
+                type: 'ordinal',
+                title: null,
+                sort: WEEKDAY_ORDER,
+                axis: { domain: false, ticks: false },
+            },
+            // Sum collapses multiple rows sharing a calendar day into one cell.
+            color: {
+                ...(valueField
+                    ? { field: valueField, aggregate: 'sum' }
+                    : { aggregate: 'count' }),
+                type: 'quantitative',
+                legend: { title: null },
+                scale: colorScale,
+            },
+        };
+    },
+    encodingActions: [
+        {
+            key: 'colorScheme',
+            label: 'Scheme',
+            isApplicable: (ctx) => !!ctx.encodings.color?.field,
+            dependencies: ['color'],
+            control: {
+                type: 'discrete',
+                options: [
+                    { value: undefined, label: 'Default (Viridis)' },
+                    { value: 'viridis', label: 'Viridis' },
+                    { value: 'github', label: 'GitHub' },
+                    { value: 'blues', label: 'Blues' },
+                    { value: 'greens', label: 'Greens' },
+                    { value: 'reds', label: 'Reds' },
+                    { value: 'oranges', label: 'Oranges' },
+                    { value: 'purples', label: 'Purples' },
+                ],
+            },
+            get: (enc) => enc.color?.scheme,
+            set: (enc, value) => ({ ...enc, color: { ...enc.color, scheme: value } }),
+        },
+    ] as EncodingActionDef[],
+};

--- a/packages/flint-js/src/vegalite/templates/calendar.ts
+++ b/packages/flint-js/src/vegalite/templates/calendar.ts
@@ -49,7 +49,9 @@ export const vlCalendarHeatmapDef: ChartTemplateDef = {
         const scheme = encScheme && encScheme !== 'default' ? encScheme : 'viridis';
         const colorScale =
             scheme === 'github'
-                ? { range: GITHUB_RANGE }
+                // Quantile scale snaps counts into the 5 canonical GitHub buckets
+                // (equal-count bins → discrete levels), rather than a smooth ramp.
+                ? { type: 'quantile' as const, range: GITHUB_RANGE }
                 : { scheme: VL_SCHEMES.has(scheme) ? scheme : 'viridis' };
 
         spec.encoding = {

--- a/packages/flint-js/src/vegalite/templates/index.ts
+++ b/packages/flint-js/src/vegalite/templates/index.ts
@@ -37,6 +37,7 @@ import { radarChartDef } from './radar';
 import { roseChartDef } from './rose';
 import { mapDef, choroplethDef } from './map';
 import { kpiCardDef } from './kpi-card';
+import { vlCalendarHeatmapDef } from './calendar';
 
 /**
  * Cross-cutting properties injected into every template that supports
@@ -288,7 +289,7 @@ export const vlTemplateDefs: { [key: string]: ChartTemplateDef[] } = Object.from
         "Distributions":   [histogramDef, densityPlotDef, ecdfPlotDef, violinPlotDef, boxplotDef, pyramidChartDef, candlestickChartDef],
         "Lines & Areas":   [lineChartDef, sparklineDef, bumpChartDef, slopeChartDef, areaChartDef, streamgraphDef, rangeAreaChartDef],
         "Circular":        [pieChartDef, donutChartDef, roseChartDef, radarChartDef],
-        "Tables & Maps":   [heatmapDef, barTableDef, kpiCardDef, mapDef, choroplethDef],
+        "Tables & Maps":   [heatmapDef, vlCalendarHeatmapDef, barTableDef, kpiCardDef, mapDef, choroplethDef],
     }).map(([category, defs]) => [category, defs.map(withInjectedProperties)]),
 );
 

--- a/packages/flint-js/tests/calendar-vegalite.test.ts
+++ b/packages/flint-js/tests/calendar-vegalite.test.ts
@@ -74,11 +74,14 @@ describe('Vega-Lite Calendar Heatmap', () => {
         expect(spec.encoding.color.field).toBeUndefined();
     });
 
-    it('resolves the github scheme to an explicit range (no built-in Vega-Lite scheme)', () => {
+    it('resolves the github scheme to a quantile scale over the canonical 5-bucket range', () => {
         const spec = assembleVegaLite(calInput({ scheme: 'github' })) as any;
         expect(spec.encoding.color.scale.scheme).toBeUndefined();
-        expect(Array.isArray(spec.encoding.color.scale.range)).toBe(true);
-        expect(spec.encoding.color.scale.range[0]).toBe('#ebedf0');
+        // Quantile scale → discrete GitHub buckets, not a continuous ramp.
+        expect(spec.encoding.color.scale.type).toBe('quantile');
+        expect(spec.encoding.color.scale.range).toEqual([
+            '#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39',
+        ]);
     });
 
     it('passes a named scheme straight through to scale.scheme', () => {

--- a/packages/flint-js/tests/calendar-vegalite.test.ts
+++ b/packages/flint-js/tests/calendar-vegalite.test.ts
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from 'vitest';
+import { assembleVegaLite, assembleECharts, vlGetTemplateDef } from '../src';
+
+/**
+ * Vega-Lite Calendar Heatmap — parity with the ECharts calendar template.
+ *
+ * Vega-Lite has no first-class calendar coordinate system, so the grid is
+ * expressed with `timeUnit`: the same date field drives `yearweek` (week
+ * columns) on x and `day` (weekday rows) on y, and `sum` collapses rows that
+ * share a calendar day into one cell.
+ */
+
+const DAILY = [
+    { date: '2024-01-01', value: 5 },
+    { date: '2024-01-02', value: 9 },
+    { date: '2024-01-02', value: 1 }, // same day → summed with the row above
+    { date: '2024-01-08', value: 12 },
+    { date: '2024-02-05', value: 3 },
+];
+
+function calInput(extraEnc?: Record<string, unknown>) {
+    return {
+        data: { values: DAILY },
+        semantic_types: { date: 'Date', value: 'Amount' },
+        chart_spec: {
+            chartType: 'Calendar Heatmap',
+            encodings: { x: { field: 'date' }, color: { field: 'value', ...extraEnc } },
+            baseSize: { width: 420, height: 160 },
+        },
+    };
+}
+
+describe('Vega-Lite Calendar Heatmap', () => {
+    it('is registered in the Vega-Lite template registry', () => {
+        expect(vlGetTemplateDef('Calendar Heatmap')).toBeDefined();
+    });
+
+    it('drives both axes from the one date field via yearweek × day', () => {
+        const spec = assembleVegaLite(calInput()) as any;
+        expect(spec.mark?.type ?? spec.mark).toBe('rect');
+        expect(spec.encoding.x.field).toBe('date');
+        expect(spec.encoding.x.timeUnit).toBe('yearweek');
+        expect(spec.encoding.y.field).toBe('date');
+        expect(spec.encoding.y.timeUnit).toBe('day');
+    });
+
+    it('orders weekday rows Monday-first (matches the ECharts calendar)', () => {
+        const spec = assembleVegaLite(calInput()) as any;
+        expect(spec.encoding.y.sort).toEqual(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
+    });
+
+    it('sums the value per calendar day', () => {
+        const spec = assembleVegaLite(calInput()) as any;
+        expect(spec.encoding.color.field).toBe('value');
+        expect(spec.encoding.color.aggregate).toBe('sum');
+        expect(spec.encoding.color.type).toBe('quantitative');
+    });
+
+    it('falls back to a per-day count when no value field is given', () => {
+        const input = {
+            data: { values: DAILY },
+            semantic_types: { date: 'Date' },
+            chart_spec: {
+                chartType: 'Calendar Heatmap',
+                encodings: { x: { field: 'date' } },
+                baseSize: { width: 420, height: 160 },
+            },
+        };
+        const spec = assembleVegaLite(input) as any;
+        expect(spec.encoding.color.aggregate).toBe('count');
+        expect(spec.encoding.color.field).toBeUndefined();
+    });
+
+    it('resolves the github scheme to an explicit range (no built-in Vega-Lite scheme)', () => {
+        const spec = assembleVegaLite(calInput({ scheme: 'github' })) as any;
+        expect(spec.encoding.color.scale.scheme).toBeUndefined();
+        expect(Array.isArray(spec.encoding.color.scale.range)).toBe(true);
+        expect(spec.encoding.color.scale.range[0]).toBe('#ebedf0');
+    });
+
+    it('passes a named scheme straight through to scale.scheme', () => {
+        const spec = assembleVegaLite(calInput({ scheme: 'blues' })) as any;
+        expect(spec.encoding.color.scale.scheme).toBe('blues');
+    });
+
+    it('assembles the same chart type on both backends (registry parity)', () => {
+        const vl = assembleVegaLite(calInput()) as any;
+        const ec = assembleECharts(calInput()) as any;
+        expect(vl.encoding.x.timeUnit).toBe('yearweek'); // VL: timeUnit grid
+        expect(ec.series?.[0]?.coordinateSystem).toBe('calendar'); // EC: calendar coord
+    });
+});

--- a/packages/flint-mcp/assets/flint-chart-author.SKILL.md
+++ b/packages/flint-mcp/assets/flint-chart-author.SKILL.md
@@ -268,6 +268,7 @@ properties"). Required channels are noted.
 | `"Boxplot"` | x, y, color, opacity, column, row | category + measure; props `whiskerMethod`, `showOutliers`, `dodge` |
 | `"ECDF Plot"` | x, color, detail, column, row | x = measure; cumulative distribution (step line); prop `showPoints` |
 | `"Heatmap"` | x, y, color, column, row | color = the measure |
+| `"Calendar Heatmap"` | x, color | x = date; color = daily value (summed per day); GitHub-style week × weekday grid |
 | `"Line Chart"` | x, y, color, strokeDash, detail, opacity, column, row | props `interpolate`, `showPoints` |
 | `"Sparkline"` | x, y, color, detail, row, column | x + y required; small-multiple mini trend lines, one per series (series from `color` or `detail`); props `interpolate`, `baseline`, `trendWidth` |
 | `"Bump Chart"` | x, y, color, detail, column, row | rank-over-time lines |
@@ -321,7 +322,7 @@ type column.
 **Backend coverage.** Vega-Lite supports all of the above. Other backends
 support a subset (verify if targeting a non-VL backend):
 
-- **ECharts** adds: `"Calendar Heatmap"`, `"Gauge"`,
+- **ECharts** adds: `"Gauge"`,
   `"Funnel"`, `"Treemap"`, `"Sunburst"`, `"Sankey"`,
   `"Parallel Coordinates"`, `"Graph"`, `"Tree"`.
 - **Chart.js** supports: Scatter, Bubble, Bar, Grouped Bar, Stacked Bar,


### PR DESCRIPTION
## What

Adds a **Calendar Heatmap** template to the Vega-Lite backend, bringing it to
parity with the ECharts backend (`ecCalendarHeatmapDef`).

ECharts has a first-class `calendar` coordinate system; Vega-Lite has none. The
ECharts `calendar.ts` header notes that VL "has no first-class calendar; would
fake it with rect + computed week/day fields." It turns out no computed fields
are needed — `timeUnit` expresses the GitHub-style grid directly from a single
date field:

- **x** → `timeUnit: 'yearweek'` (one ordinal column per calendar week)
- **y** → `timeUnit: 'day'` (Sun–Sat rows, Monday-first to match the ECharts `dayLabel.firstDay = 1`)
- **color** → `aggregate: 'sum'` collapses rows sharing a calendar day into one cell

so the same date field drives both axes with no core changes.

## Encoding

| channel | role |
|---|---|
| `x` (date) | the date of each cell |
| `color` (quantitative) | the cell value; falls back to a per-day count when omitted |

## Scheme handling

Mirrors the ECharts template's `encodingActions`: named Vega-Lite schemes
(`viridis`/`blues`/`greens`/`reds`/`oranges`/`purples`) pass through as
`scale.scheme`; `github` has no built-in Vega-Lite equivalent, so it resolves to
an explicit `scale.range` (the same low→high ramp the ECharts template uses).

## Changes

- `vegalite/templates/calendar.ts` — new `vlCalendarHeatmapDef`
- register in `vlTemplateDefs` (Tables & Maps group, next to Heatmap)
- `tests/calendar-vegalite.test.ts` — 8 cases: registry, dual-axis `timeUnit`
  projection, Monday-first row order, per-day sum, count fallback, `github`
  range vs named scheme, and cross-backend parity. The assembled spec is also
  verified through `vl.compile`.
- regenerate `docs/reference-vegalite.md`; move Calendar Heatmap from the
  SKILL.md "ECharts adds" list into the shared template table (+ synced bundled
  asset)

## Open questions

- **Weekday-first convention**: rows are Monday-first to stay consistent with the
  shipped ECharts calendar (`dayLabel.firstDay = 1`), so the same spec renders the
  same way on both backends. This differs from GitHub's own contribution graph,
  which starts the week on Sunday. I kept parity with the existing backend rather
  than mirroring GitHub. If you'd rather the canonical calendar follow GitHub
  (Sunday-first), that's a cross-backend convention change — ECharts and Vega-Lite
  together — which I'm happy to do as a separate PR so the two backends stay aligned.
- **Multi-year spans**: `yearweek` produces a continuous band that widens with
  range; the ECharts template shrinks its cell size instead. This PR relies on
  `labelOverlap` + the container width. Happy to add explicit cell sizing if you
  prefer.
- **Recommendation layer**: I did not add a Calendar recommendation rule (a
  temporal `x` + quantitative `color` heuristic). Let me know if you'd like one.
