### PR TITLE
fix(flint-py): point run_full_eval at the moved fixture corpus

### DIFF
--- a/packages/flint-py/tools/run_full_eval.py
+++ b/packages/flint-py/tools/run_full_eval.py
@@ -1,8 +1,8 @@
 """Run the Python `assemble_vegalite` against every extracted JS fixture.
 
 Categorises each fixture as PASS, MISMATCH, PY_ERROR, or NO_EXPECTED, then
-writes a structured `results.json` and a human-readable `REPORT.md` to
-`flint-py/tests/fixtures/` for downstream analysis.
+writes a structured `results.json` next to the corpus in `shared/test-data/`
+and a human-readable `FULL_GALLERY_REPORT.md` to `flint-py/tests/`.
 
 Usage:
     python flint-py/tools/run_full_eval.py
@@ -20,7 +20,11 @@ from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
-FIXTURES = ROOT / "tests" / "fixtures"
+# The fixture corpus moved to shared/test-data in 1d1ee39 ("rename
+# agents→agent-skills, test-fixtures→test-data"); results.json is tracked
+# alongside it. The report stays under tests/, where the committed copy lives.
+FIXTURES = ROOT.parent.parent / "shared" / "test-data"
+REPORT_DIR = ROOT / "tests"
 
 sys.path.insert(0, str(ROOT))
 from flint.vegalite import assemble_vegalite  # noqa: E402
@@ -342,7 +346,7 @@ def main() -> int:
         "Without these fixes the report would show ~70 MISMATCH cases.\n"
     )
 
-    out_path = FIXTURES.parent / "FULL_GALLERY_REPORT.md"
+    out_path = REPORT_DIR / "FULL_GALLERY_REPORT.md"
     out_path.write_text("".join(lines))
     print(f"Wrote {out_path}")
     print("Summary:")


### PR DESCRIPTION
## Summary

- `tools/run_full_eval.py` exits with `ERROR: manifest.json not found` and evaluates nothing: `FIXTURES` still points at `packages/flint-py/tests/fixtures/`, but the corpus moved to `shared/test-data/` in `1d1ee39`.
- Repointing `FIXTURES` on its own would have dragged the report along with it, since line 345 derived that path as `FIXTURES.parent` — hence the separate `REPORT_DIR`.
- Repointing the corpus and giving the report its own constant brings the tool back; it writes `results.json` and `FULL_GALLERY_REPORT.md` to the two locations where the committed copies already live.

## Context

Found while investigating #80. The eval tool is the instrument that measures `flint-py` against the JS reference, so having it run again is the prerequisite for acting on anything in that issue.

## Changes

`packages/flint-py/tools/run_full_eval.py` (+8 / −4):

- `FIXTURES` → `shared/test-data/`, with a comment naming the commit that moved it.
- New `REPORT_DIR = ROOT / "tests"` so `FULL_GALLERY_REPORT.md` keeps landing next to its committed copy rather than following the corpus.
- Module docstring updated to name both output locations.

## Review focus

1. **Are those the two output locations you want?** `results.json` goes to `shared/test-data/results.json` (which is tracked there already) and the report to `packages/flint-py/tests/FULL_GALLERY_REPORT.md` (likewise). I inferred the intent from where the committed copies sit — say the word if either belongs elsewhere.
2. **Should the regenerated outputs be part of this PR?** Running the tool rewrites both files. I left them out so the diff stays at the fix. See the note below on what they now say.

## Test plan

- [x] `uv run python tools/run_full_eval.py` from `packages/flint-py` — completes and prints: `PASS: 476`, `MISMATCH: 180`, `PY_ERROR: 0`, `JS_ERROR: 1`, `FIXTURE_MISSING: 0`.
- [x] Confirmed the two outputs land on the committed copies (`git status` shows exactly `packages/flint-py/tests/FULL_GALLERY_REPORT.md` and `shared/test-data/results.json` as modified, nothing untracked).
- [x] Cross-checked the tool's `MISMATCH: 180` against `uv run pytest -q`, which reports 180 failures. Two independent instruments, same number.
- [x] Reverted both regenerated artifacts, leaving the diff at the one file.

## Notes for reviewers

- **What the refreshed report says.** Regenerating it turns the summary from `658 / 658 (100.0%)` into `476 / 656 (72.6%)`. That drop is what #80 is about; it is not caused by this change, which touches only where the tool reads and writes.
- **Small pre-existing inconsistency, not fixed here.** The report generator prints "There are **N** specs that differ … i.e. the Python port matches the JS reference on every ported chart type for every gallery test case" as one unconditional sentence, so with `N > 0` it contradicts itself. Left alone to keep this diff to the paths; happy to send a follow-up.
