### PR TITLE
fix: warn about unknown chart input keys

### DIFF
--- a/packages/flint-js/src/chartjs/assemble.ts
+++ b/packages/flint-js/src/chartjs/assemble.ts
@@ -44,6 +44,7 @@ import { decideColorMaps } from '../core/color-decisions';
 import { cjsApplyLayoutToSpec, cjsApplyTooltips } from './instantiate-spec';
 import { normalizeStaticSeries } from '../core/static-series';
 import { normalizeChartProperties } from '../core/normalize-properties';
+import { validateUnknownInputKeys } from '../core/validate-input-keys';
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -130,6 +131,11 @@ export function assembleChartjs(input: ChartAssemblyInput): any {
         const swapped = cjsGetTemplateDef(transformed.chartType) as ChartTemplateDef | undefined;
         if (swapped) chartTemplate = swapped;
     }
+    warnings.push(...validateUnknownInputKeys(
+        [authoredTemplate, chartTemplate],
+        input.chart_spec.chartProperties,
+        input.options,
+    ));
 
     // Compose Category-B encoding-action overrides (stored by the host in
     // chartProperties, keyed by action key) onto the post-transform encodings

--- a/packages/flint-js/src/chartjs/templates/combo.ts
+++ b/packages/flint-js/src/chartjs/templates/combo.ts
@@ -48,6 +48,7 @@ export const cjsComboChartDef: ChartTemplateDef = {
     template: { mark: 'bar', encoding: {} },
     channels: ['x', 'y', 'column', 'row'],
     markCognitiveChannel: 'length',
+    additionalPropertyKeys: ['lineField'],
     declareLayoutMode: (cs, table) => {
         const result = detectBandedAxisFromSemantics(cs, table, { preferAxis: 'x' });
         return {

--- a/packages/flint-js/src/core/types.ts
+++ b/packages/flint-js/src/core/types.ts
@@ -942,6 +942,9 @@ export interface ChartTemplateDef {
     /** Optional configurable properties for the chart type */
     properties?: ChartPropertyDef[];
 
+    /** Non-control chartProperties keys consumed directly by the template. */
+    additionalPropertyKeys?: string[];
+
     /**
      * Opt out of a backend's *generic* column/row facet-splitting pass, even
      * though the template declares `x`/`y` (so the axis-less `hasAxes` gate

--- a/packages/flint-js/src/core/validate-input-keys.ts
+++ b/packages/flint-js/src/core/validate-input-keys.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+    AssembleOptions,
+    ChartTemplateDef,
+    ChartWarning,
+} from './types';
+import {
+    TRANSFORM_ARRANGE_KEY,
+    TRANSFORM_CHART_TYPE_KEY,
+} from './pivot';
+
+const GLOBAL_CHART_PROPERTY_KEYS = [
+    TRANSFORM_ARRANGE_KEY,
+    TRANSFORM_CHART_TYPE_KEY,
+    'facetColumns',
+    'pivot',
+] as const;
+
+const ASSEMBLE_OPTION_KEY_MAP = {
+    addTooltips: true,
+    stepPadding: true,
+    elasticity: true,
+    maxStretch: true,
+    maxStretchX: true,
+    maxStretchY: true,
+    facetElasticity: true,
+    minStep: true,
+    maxColorValues: true,
+    minSubplotSize: true,
+    facetFixedPadding: true,
+    facetGap: true,
+    facetColumns: true,
+    defaultBandSize: true,
+    maxBandSize: true,
+    baseLabelFontSize: true,
+    baseTitleFontSize: true,
+    maintainContinuousAxisRatio: true,
+    continuousMarkCrossSection: true,
+    facetAspectRatioResistance: true,
+    autoFacetWrap: true,
+    targetBandAR: true,
+} satisfies Record<keyof AssembleOptions, true>;
+
+const ASSEMBLE_OPTION_KEYS = Object.keys(ASSEMBLE_OPTION_KEY_MAP).sort();
+const KNOWN_ASSEMBLE_OPTION_KEYS = new Set(ASSEMBLE_OPTION_KEYS);
+
+function collectChartPropertyKeys(
+    templates: readonly ChartTemplateDef[],
+): string[] {
+    const keys = new Set<string>(GLOBAL_CHART_PROPERTY_KEYS);
+    for (const template of templates) {
+        for (const property of template.properties ?? []) {
+            keys.add(property.key);
+        }
+        for (const key of template.additionalPropertyKeys ?? []) {
+            keys.add(key);
+        }
+        for (const action of template.encodingActions ?? []) {
+            keys.add(action.key);
+        }
+        if (template.pivot?.key) {
+            keys.add(template.pivot.key);
+        }
+    }
+    return [...keys].sort();
+}
+
+/**
+ * Warn about input keys that the assembler will not consume.
+ *
+ * Both the authored and effective templates should be supplied so properties
+ * remain valid across a chart-type transform. Unknown keys are left untouched
+ * to preserve forward compatibility; callers only receive diagnostics.
+ */
+export function validateUnknownInputKeys(
+    templates: readonly ChartTemplateDef[],
+    chartProperties: Record<string, any> | undefined,
+    options: AssembleOptions | undefined,
+): ChartWarning[] {
+    const warnings: ChartWarning[] = [];
+    const chartPropertyKeys = collectChartPropertyKeys(templates);
+    const knownChartProperties = new Set(chartPropertyKeys);
+    const chartName = templates[templates.length - 1]?.chart ?? 'this chart';
+
+    for (const key of Object.keys(chartProperties ?? {})) {
+        if (knownChartProperties.has(key)) continue;
+        warnings.push({
+            severity: 'warning',
+            code: 'unknown-chart-property',
+            message: `chartProperties.${key}: unknown property for ${chartName}. Available properties: ${chartPropertyKeys.join(', ')}.`,
+        });
+    }
+
+    for (const key of Object.keys(options ?? {})) {
+        if (KNOWN_ASSEMBLE_OPTION_KEYS.has(key)) continue;
+        warnings.push({
+            severity: 'warning',
+            code: 'unknown-assemble-option',
+            message: `options.${key}: unknown assemble option. Available options: ${ASSEMBLE_OPTION_KEYS.join(', ')}.`,
+        });
+    }
+
+    return warnings;
+}

--- a/packages/flint-js/src/echarts/assemble.ts
+++ b/packages/flint-js/src/echarts/assemble.ts
@@ -75,6 +75,7 @@ import { decideColorMaps } from '../core/color-decisions';
 import { getPaletteForScheme } from './colormap';
 import { normalizeStaticSeries } from '../core/static-series';
 import { normalizeChartProperties } from '../core/normalize-properties';
+import { validateUnknownInputKeys } from '../core/validate-input-keys';
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -169,6 +170,11 @@ export function assembleECharts(input: ChartAssemblyInput): any {
         const swapped = ecGetTemplateDef(transformed.chartType) as ChartTemplateDef | undefined;
         if (swapped) chartTemplate = swapped;
     }
+    warnings.push(...validateUnknownInputKeys(
+        [authoredTemplate, chartTemplate],
+        input.chart_spec.chartProperties,
+        input.options,
+    ));
 
     // Compose Category-B encoding-action overrides (stored by the host in
     // chartProperties, keyed by action key) onto the post-transform encodings

--- a/packages/flint-js/src/echarts/templates/parallel.ts
+++ b/packages/flint-js/src/echarts/templates/parallel.ts
@@ -58,6 +58,7 @@ export const ecParallelCoordinatesDef: ChartTemplateDef = {
     template: { mark: 'line', encoding: {} },
     channels: ['color', 'detail'],
     markCognitiveChannel: 'position',
+    additionalPropertyKeys: ['dimensions'],
     instantiate: (spec, ctx) => {
         const { channelSemantics, table, chartProperties } = ctx;
         if (table.length === 0) return;

--- a/packages/flint-js/src/plotly/assemble.ts
+++ b/packages/flint-js/src/plotly/assemble.ts
@@ -48,6 +48,7 @@ import { plApplyCartesianAxisSpacing, plApplyLayoutToSpec, plApplyTooltips, plAp
 import { plCombineFacetPanels, niceBounds, type PlotlyFacetPanel } from './facet';
 import { normalizeStaticSeries } from '../core/static-series';
 import { normalizeChartProperties } from '../core/normalize-properties';
+import { validateUnknownInputKeys } from '../core/validate-input-keys';
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -141,6 +142,11 @@ export function assemblePlotly(input: ChartAssemblyInput): any {
         const swapped = plGetTemplateDef(transformed.chartType) as ChartTemplateDef | undefined;
         if (swapped) chartTemplate = swapped;
     }
+    warnings.push(...validateUnknownInputKeys(
+        [authoredTemplate, chartTemplate],
+        input.chart_spec.chartProperties,
+        input.options,
+    ));
     const encodings = applyEncodingOverrides(chartTemplate, transformed.encodings, chartProperties);
 
     // Optional aggregation transform — see vegalite/assemble for rationale.

--- a/packages/flint-js/src/vegalite/assemble.ts
+++ b/packages/flint-js/src/vegalite/assemble.ts
@@ -66,6 +66,7 @@ import { computeLayout, computeChannelBudgets, computeMinSubplotDimensions, deri
 import { vlApplyLayoutToSpec, vlApplyTooltips } from './instantiate-spec';
 import { normalizeStaticSeries } from '../core/static-series';
 import { normalizeChartProperties } from '../core/normalize-properties';
+import { validateUnknownInputKeys } from '../core/validate-input-keys';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -202,6 +203,11 @@ export function assembleVegaLite(input: ChartAssemblyInput): any {
         const swapped = vlGetTemplateDef(transformed.chartType) as ChartTemplateDef | undefined;
         if (swapped) chartTemplate = swapped;
     }
+    warnings.push(...validateUnknownInputKeys(
+        [authoredTemplate, chartTemplate],
+        input.chart_spec.chartProperties,
+        input.options,
+    ));
     const composedEncodings = applyEncodingOverrides(chartTemplate, transformed.encodings, chartProperties);
 
     // Template-level encoding normalization (e.g. Sparkline remaps its series

--- a/packages/flint-js/tests/chart-properties-validation.test.ts
+++ b/packages/flint-js/tests/chart-properties-validation.test.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 
 import { describe, it, expect } from 'vitest';
-import { assembleVegaLite } from '../src';
+import {
+    assembleChartjs,
+    assembleECharts,
+    assemblePlotly,
+    assembleVegaLite,
+} from '../src';
 
 const BASE = {
     data: {
@@ -73,5 +78,145 @@ describe('Regression — discrete property value validation', () => {
         const spec = assemble({ regressionMethod: 'linear' });
         expect(regressionTransform(spec).method).toBeUndefined();
         expect(spec._warnings).toBeUndefined();
+    });
+});
+
+describe('Unknown input key validation', () => {
+    const lineInput: any = {
+        data: {
+            values: [
+                { x: 'A', y: 1 },
+                { x: 'B', y: 2 },
+            ],
+        },
+        semantic_types: { x: 'Category', y: 'Quantity' },
+        chart_spec: {
+            chartType: 'Line Chart',
+            encodings: { x: { field: 'x' }, y: { field: 'y' } },
+            chartProperties: {
+                lineWidth: 5,
+                pointSize: 12,
+                totallyFakeKnob: true,
+            },
+        },
+        options: {
+            fontSize: 18,
+            bogusOption: 'xyz',
+        },
+    };
+
+    const assemblers = [
+        ['Vega-Lite', assembleVegaLite],
+        ['ECharts', assembleECharts],
+        ['Chart.js', assembleChartjs],
+        ['Plotly', assemblePlotly],
+    ] as const;
+
+    function unknownInputPaths(spec: any): string[] {
+        return (spec._warnings ?? [])
+            .filter(
+                (warning: any) =>
+                    warning.code === 'unknown-chart-property' ||
+                    warning.code === 'unknown-assemble-option',
+            )
+            .map((warning: any) => warning.message.split(':', 1)[0]);
+    }
+
+    for (const [backend, assembler] of assemblers) {
+        it(`warns about unknown chartProperties and options in ${backend}`, () => {
+            const spec = assembler(lineInput);
+
+            expect(unknownInputPaths(spec)).toEqual([
+                'chartProperties.lineWidth',
+                'chartProperties.pointSize',
+                'chartProperties.totallyFakeKnob',
+                'options.fontSize',
+                'options.bogusOption',
+            ]);
+        });
+    }
+
+    it('accepts template, encoding-action, transform, layout, and assembler keys', () => {
+        const spec = assembleVegaLite({
+            data: {
+                values: [
+                    { category: 'A', value: 1 },
+                    { category: 'B', value: 2 },
+                ],
+            },
+            semantic_types: { category: 'Category', value: 'Quantity' },
+            chart_spec: {
+                chartType: 'Bar Chart',
+                encodings: {
+                    x: { field: 'category' },
+                    y: { field: 'value' },
+                },
+                chartProperties: {
+                    cornerRadius: 2,
+                    sort: 'value-desc',
+                    chartType: 'Bar Chart',
+                    arrange: 'identity',
+                    pivot: 'identity',
+                    facetColumns: 2,
+                },
+            },
+            options: {
+                addTooltips: true,
+                baseLabelFontSize: 12,
+                targetBandAR: 10,
+            },
+        });
+
+        expect(unknownInputPaths(spec)).toEqual([]);
+    });
+
+    it('accepts template-specific chartProperties that are not UI controls', () => {
+        const parallel = assembleECharts({
+            data: {
+                values: [
+                    { group: 'A', speed: 10, weight: 100 },
+                    { group: 'B', speed: 20, weight: 200 },
+                ],
+            },
+            semantic_types: {
+                group: 'Category',
+                speed: 'Quantity',
+                weight: 'Quantity',
+            },
+            chart_spec: {
+                chartType: 'Parallel Coordinates',
+                encodings: { color: { field: 'group' } },
+                chartProperties: {
+                    dimensions: ['weight', 'speed'],
+                },
+            },
+        });
+        const combo = assembleChartjs({
+            data: {
+                values: [
+                    { month: 'Jan', revenue: 100, growth: 10 },
+                    { month: 'Feb', revenue: 120, growth: 20 },
+                ],
+            },
+            semantic_types: {
+                month: 'Category',
+                revenue: 'Quantity',
+                growth: 'Quantity',
+            },
+            chart_spec: {
+                chartType: 'Combo Chart',
+                encodings: {
+                    x: { field: 'month' },
+                    y: { field: 'revenue' },
+                },
+                chartProperties: {
+                    lineField: 'growth',
+                },
+            },
+        });
+
+        for (const spec of [parallel, combo]) {
+            expect(unknownInputPaths(spec)).toEqual([]);
+        }
     });
 });

--- a/packages/flint-mcp/tests/server.test.ts
+++ b/packages/flint-mcp/tests/server.test.ts
@@ -116,6 +116,31 @@ describe('MCP server', () => {
     expect(payload.valid).toBe(true);
   });
 
+  it('validate_chart reports unknown properties and options as warnings', async () => {
+    const res: any = await client.callTool({
+      name: 'validate_chart',
+      arguments: {
+        ...barChart,
+        chart_spec: {
+          ...barChart.chart_spec,
+          chartProperties: { totallyFakeKnob: true },
+        },
+        options: { bogusOption: 'xyz' },
+        backend: 'vegalite',
+      },
+    });
+    const payload = JSON.parse(res.content[0].text);
+
+    expect(payload.valid).toBe(true);
+    expect(payload.errors).toEqual([]);
+    expect(payload.warnings.map((w: any) => w.code)).toEqual(
+      expect.arrayContaining([
+        'unknown-chart-property',
+        'unknown-assemble-option',
+      ]),
+    );
+  });
+
   it('validate_chart rejects malformed specs before assembly', async () => {
     for (const chart_spec of [
       { ...barChart.chart_spec, encodings: {} },


### PR DESCRIPTION
## Summary

- warn for unknown `chartProperties` and `options` keys across the Vega-Lite, ECharts, Chart.js, and Plotly assemblers
- derive accepted chart property keys from both the authored and effective templates, including property controls, encoding actions, pivot keys, and explicit template-only keys
- preserve forward compatibility by leaving unknown inputs untouched and keeping validation successful
- add regression coverage for all four assemblers and the MCP `validate_chart` tool

Fixes #68

## Testing

- `flint-js`: 39 test files, 658 tests passed
- `flint-mcp`: 4 test files, 51 tests passed
- `eslint`: 0 errors (30 existing warnings)
- ESM, CJS, and declaration builds passed
- `tsc --noEmit` still reports the existing `src/vegalite/templates/scatter.ts:338` implicit-`any` error from `dev`; this PR does not modify that file