### PR TITLE
Warn when an ordinal is compiled as a bar length (#85)

### DIFF
--- a/packages/flint-js/src/core/index.ts
+++ b/packages/flint-js/src/core/index.ts
@@ -133,6 +133,7 @@ export {
 // Phase modules (analysis pipeline — VL-free)
 export { resolveChannelSemantics, convertTemporalData } from './resolve-semantics';
 export { filterOverflow } from './filter-overflow';
+export { detectOrdinalAsMagnitude } from './ordinal-magnitude';
 export { computeLayout, computeChannelBudgets } from './compute-layout';
 export {
     normalizeStaticSeries,

--- a/packages/flint-js/src/core/ordinal-magnitude.ts
+++ b/packages/flint-js/src/core/ordinal-magnitude.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Ordinal-as-magnitude detection.
+ *
+ * An ordinal answers "which position", not "how much". Rank 1 is ahead of rank 5
+ * but it is not five times anything, so a bar whose length is the rank invents a
+ * magnitude the data does not carry — and reads as the inverse of the ranking,
+ * because last place gets the longest bar.
+ *
+ * Semantics resolve `Rank` to `ordinal`, so the mistake is not made there. It
+ * appears when a template overrides that and emits the field as `quantitative` on
+ * a position channel. The check therefore reads the compiled spec rather than the
+ * resolved semantics: templates that encode the same field by position are left
+ * alone, and a template that starts encoding it as a length later is covered
+ * without changing this file.
+ */
+
+import type { ChannelSemantics, ChartWarning, MarkCognitiveChannel } from './types';
+
+/**
+ * Semantic types that carry order but no magnitude.
+ *
+ * `Rank` only for now. `ID` is deliberately excluded: it is not ordered, so its
+ * problem on a length channel is a different one.
+ */
+const ORDINAL_SEMANTIC_TYPES = new Set(['Rank']);
+
+/** Channels a mark's length is read from. */
+const VALUE_CHANNELS = ['x', 'y'] as const;
+
+/**
+ * True when `spec` encodes `field` as quantitative on one of the value channels,
+ * anywhere in a possibly concatenated / faceted / layered spec.
+ */
+function encodesAsMagnitude(spec: unknown, field: string): boolean {
+    if (!spec || typeof spec !== 'object') return false;
+
+    if (Array.isArray(spec)) {
+        return spec.some((entry) => encodesAsMagnitude(entry, field));
+    }
+
+    const node = spec as Record<string, any>;
+    const encoding = node.encoding;
+    if (encoding && typeof encoding === 'object') {
+        for (const channel of VALUE_CHANNELS) {
+            const def = encoding[channel];
+            if (def && def.field === field && def.type === 'quantitative') return true;
+        }
+    }
+
+    return Object.values(node).some((child) => encodesAsMagnitude(child, field));
+}
+
+/**
+ * Warn when a length-encoding template compiled an order-only field onto a value
+ * channel as a magnitude.
+ *
+ * @param chartType             Chart type name, for the message.
+ * @param markCognitiveChannel  How the template's mark encodes its value.
+ * @param channelSemantics      Resolved semantics, source of each channel's field.
+ * @param compiledSpec          The assembled backend spec.
+ */
+export function detectOrdinalAsMagnitude(
+    chartType: string,
+    markCognitiveChannel: MarkCognitiveChannel | undefined,
+    channelSemantics: Record<string, ChannelSemantics>,
+    compiledSpec: unknown,
+): ChartWarning[] {
+    if (markCognitiveChannel !== 'length') return [];
+
+    const warnings: ChartWarning[] = [];
+    const seen = new Set<string>();
+
+    for (const channel of VALUE_CHANNELS) {
+        const cs = channelSemantics[channel];
+        const semanticType = cs?.semanticAnnotation?.semanticType;
+        if (!cs?.field || !semanticType || !ORDINAL_SEMANTIC_TYPES.has(semanticType)) continue;
+        if (seen.has(cs.field)) continue;
+        if (!encodesAsMagnitude(compiledSpec, cs.field)) continue;
+
+        seen.add(cs.field);
+        warnings.push({
+            severity: 'warning',
+            code: 'ordinal-as-magnitude',
+            channel,
+            field: cs.field,
+            message:
+                `${channel}: '${cs.field}' is ${semanticType}, an order rather than a magnitude, ` +
+                `but ${chartType} encodes it as a bar length, so the longest bar is last place. ` +
+                `Bind a measured value to ${channel} and let the ${semanticType.toLowerCase()} order ` +
+                `the rows, or pick a chart type that encodes ${channel} by position.`,
+        });
+    }
+    return warnings;
+}

--- a/packages/flint-js/src/vegalite/assemble.ts
+++ b/packages/flint-js/src/vegalite/assemble.ts
@@ -62,6 +62,7 @@ import { inferVisCategory, computeZeroDecision } from '../core/semantic-types';
 import { resolveChannelSemantics, convertTemporalData } from '../core/resolve-semantics';
 import { toTypeString, type SemanticAnnotation } from '../core/field-semantics';
 import { filterOverflow } from '../core/filter-overflow';
+import { detectOrdinalAsMagnitude } from '../core/ordinal-magnitude';
 import { computeLayout, computeChannelBudgets, computeMinSubplotDimensions, deriveStretchCaps, resolveBaseSize, resolveFacetColumnsOption } from '../core/compute-layout';
 import { vlApplyLayoutToSpec, vlApplyTooltips } from './instantiate-spec';
 import { normalizeStaticSeries } from '../core/static-series';
@@ -683,6 +684,15 @@ export function assembleVegaLite(input: ChartAssemblyInput): any {
         warnings.push(...vgObj._warnings);
         delete vgObj._warnings;
     }
+
+    // Read after instantiation: semantics resolve Rank to ordinal, so a magnitude
+    // encoding of it only exists once a template has overridden that. Reported
+    // rather than corrected — which value belongs on the bar is the author's call.
+    warnings.push(
+        ...detectOrdinalAsMagnitude(
+            chartType, chartTemplate.markCognitiveChannel, channelSemantics, vgObj,
+        ),
+    );
 
     // --- restructureFacets (VL-specific) ---
     // The facet grid (including wrapping) was already decided by

--- a/packages/flint-js/tests/ordinal-as-magnitude.test.ts
+++ b/packages/flint-js/tests/ordinal-as-magnitude.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from 'vitest';
+import { assembleVegaLite } from '../src';
+
+// A rank is an order, not a magnitude: 1st is ahead of 5th but not five times
+// anything. A template that encodes it as a bar length therefore renders the
+// ranking backwards — last place gets the longest, and the output is well-formed,
+// so nothing downstream questions it.
+const RANKED = [
+    { Engine: 'Inworld TTS-2', Rank: 1, Score: 91 },
+    { Engine: 'xAI leo', Rank: 2, Score: 84 },
+    { Engine: 'Kokoro am_michael', Rank: 3, Score: 77 },
+    { Engine: 'Gemini', Rank: 4, Score: 63 },
+    { Engine: 'Inworld 1.5-max', Rank: 5, Score: 51 },
+];
+
+function warningsFor(chartType: string, xField: string, semantic: Record<string, string>) {
+    const spec: any = assembleVegaLite({
+        data: { values: RANKED },
+        semantic_types: semantic,
+        chart_spec: {
+            chartType,
+            encodings: { y: { field: 'Engine' }, x: { field: xField } },
+            baseSize: { width: 560, height: 280 },
+        },
+    } as any);
+    return ((spec._warnings ?? []) as any[]).filter((w) => w.code === 'ordinal-as-magnitude');
+}
+
+describe('ordinal bound to a length encoding', () => {
+    it('warns when Bar Table compiles Rank as a bar length', () => {
+        const warnings = warningsFor('Bar Table', 'Rank', { Engine: 'Name', Rank: 'Rank' });
+
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].severity).toBe('warning');
+        expect(warnings[0].channel).toBe('x');
+        expect(warnings[0].field).toBe('Rank');
+        expect(warnings[0].message).toContain('Bar Table');
+    });
+
+    it('stays quiet for Bar Chart, which encodes the same Rank by position', () => {
+        // Semantics resolve Rank to ordinal for both templates; only Bar Table
+        // overrides that. Keying the check on the compiled spec is what keeps this
+        // case silent.
+        expect(warningsFor('Bar Chart', 'Rank', { Engine: 'Name', Rank: 'Rank' })).toHaveLength(0);
+    });
+
+    it('stays quiet when a real magnitude drives the bar', () => {
+        expect(warningsFor('Bar Table', 'Score', { Engine: 'Name', Score: 'Score' })).toHaveLength(0);
+    });
+
+    it('does not fire on a template whose mark encodes by position', () => {
+        // Line Chart is markCognitiveChannel 'position', so a Rank axis there is
+        // the documented behaviour rather than a fabricated magnitude.
+        const spec: any = assembleVegaLite({
+            data: { values: RANKED },
+            semantic_types: { Engine: 'Name', Rank: 'Rank' },
+            chart_spec: {
+                chartType: 'Line Chart',
+                encodings: { x: { field: 'Engine' }, y: { field: 'Rank' } },
+                baseSize: { width: 560, height: 280 },
+            },
+        } as any);
+        const warnings = ((spec._warnings ?? []) as any[]).filter(
+            (w) => w.code === 'ordinal-as-magnitude',
+        );
+        expect(warnings).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Fixes #85.

## What the input does today

The reported spec compiles `Rank` onto the bar's length **and** a sequential colour ramp:

```jsonc
// x — drives bar length
{ "field": "Rank", "type": "quantitative", "axis": null, "scale": { "nice": false } }
// color — sequential ramp
{ "field": "Rank", "type": "quantitative", "legend": null, "scale": { "range": ["#cdebd3", "#41a25f"] } }
```

Rank 1 gets the shortest, palest bar; last place gets the longest, darkest. `validate_chart` returns `valid: true` with zero warnings.

## One correction to the diagnosis

The issue reads this as a template gap. It partly is — but the semantics layer is **not** where it goes wrong, which matters for where a fix can live.

Instrumenting `resolveChannelSemantics` for both templates on identical input:

```
Bar Table  mcc=length  x: { field: Rank, type: ordinal, semanticType: Rank }
Bar Chart  mcc=length  x: { field: Rank, type: ordinal, semanticType: Rank }
```

`Rank` resolves to **`ordinal` for both**. Bar Table then overrides that and emits `quantitative` on x. So a check against the resolved semantics cannot separate the two templates — at that point they are identical, and my first attempt at exactly that warned on neither.

## The change

The check reads the **compiled spec** instead. For a template whose `markCognitiveChannel` is `'length'`, an order-only semantic type appearing as a `quantitative` `x`/`y` encoding is a magnitude the data does not carry.

Keying on `markCognitiveChannel` — which templates already declare — is what makes this general, and is the closest thing in the codebase to the "generalises to any template that adds a magnitude encoding later" property the issue asks for. Bar Chart encodes the same field by position and stays silent without being special-cased.

```
x: 'Rank' is Rank, an order rather than a magnitude, but Bar Table encodes it as a
bar length, so the longest bar is last place. Bind a measured value to x and let the
rank order the rows, or pick a chart type that encodes x by position.
```

**Reported rather than corrected**, which is the recommendation in the issue and I think the right call: an ordinal has no magnitude to substitute, so what belongs on the bar instead is the author's decision. Changing what Bar Table renders for an ordinal is a design question I did not want to answer on your behalf — happy to follow up with that instead, or as well, if you would rather the template also changed.

`Rank` only. `ID` is deliberately excluded: it is not ordered, so its problem on a length channel is a different one and deserves its own decision.

## Verified

| Case | Warnings |
|---|---|
| Bar Table + Rank — the reported input | **1** |
| Bar Chart + Rank — identical field | 0 |
| Bar Table + a real measure | 0 |
| Line Chart (`position`) + Rank | 0 |

- `npm run test:js` — **1092 passed**, 54 files, including 4 new.
- `npm run typecheck` clean; `npm run lint` clean on the touched files (repo-wide is 0 errors / 30 pre-existing warnings, none in this diff).
- `npm run test:mcp` has 10 failures in `tests/file-reference.test.ts` — Windows path handling, **identical on a clean checkout with this branch stashed**, unrelated to this change.

## Not addressed

The two smaller observations at the end of #85 — Bar Table emitting no number format, and `Hits across 6 clips` rendering as `Hits_across 6_clips` in wrapped headers — are separate from the ordinal question and left alone to keep this to one topic. Say the word and I will pick either up.
