### PR TITLE
add interactive data report demo to the interaction lab

### DIFF
--- a/packages/flint-js/src/vegalite/interactions/gestures/navigation.ts
+++ b/packages/flint-js/src/vegalite/interactions/gestures/navigation.ts
@@ -107,7 +107,6 @@ export function mountVegaNavigationGesture(
         dragged = false;
         setDragging(true);
         container.style.cursor = 'grabbing';
-        container.setPointerCapture(event.pointerId);
         emit({
             type: 'navigation', phase: 'start', operation: 'pan', axes,
             modifiers: interactionModifiers(event),
@@ -132,6 +131,14 @@ export function mountVegaNavigationGesture(
         const delta = session.move(localPoint(event));
         pendingDelta = { x: pendingDelta.x + delta.x, y: pendingDelta.y + delta.y };
         if (session.dragDistance() < 4) return;
+        if (!dragged && !container.hasPointerCapture(event.pointerId)) {
+            // Capture only once this is a real pan, so a plain click still reaches the marks.
+            try {
+                container.setPointerCapture(event.pointerId);
+            } catch {
+                // Synthetic pointer events have no active pointer to capture.
+            }
+        }
         dragged = true;
         setSuppressClick(true);
         emit({

--- a/packages/flint-js/src/vegalite/interactions/gestures/region.ts
+++ b/packages/flint-js/src/vegalite/interactions/gestures/region.ts
@@ -425,7 +425,19 @@ export function mountVegaRegionGesture(options: VegaRegionGestureOptions): VegaR
         pointerId = event.pointerId;
         committed = new Set(getSelected());
         setDragging(true);
-        container.setPointerCapture(event.pointerId);
+    };
+    // Capture only once the pointer has actually moved into a drag. Capturing on
+    // pointerdown would redirect the following click to the container, so a plain
+    // click on a mark, legend entry, or axis label would never reach the renderer.
+    const beginDragCapture = (event: PointerEvent): void => {
+        setSuppressClick(true);
+        if (!container.hasPointerCapture(event.pointerId)) {
+            try {
+                container.setPointerCapture(event.pointerId);
+            } catch {
+                // Synthetic pointer events have no active pointer to capture.
+            }
+        }
     };
     const pointerMove = (event: PointerEvent): void => {
         if (!dragStart || pointerId !== event.pointerId) {
@@ -458,7 +470,7 @@ export function mountVegaRegionGesture(options: VegaRegionGestureOptions): VegaR
             if (last && Math.hypot(point.x - last.x, point.y - last.y) < 2) return;
             lassoPoints.push(point);
             if (lassoPoints.length < 3) return;
-            setSuppressClick(true);
+            beginDragCapture(event);
             showLasso(lassoPoints);
             dispatchLasso('preview', lassoPoints, event);
             return;
@@ -467,21 +479,21 @@ export function mountVegaRegionGesture(options: VegaRegionGestureOptions): VegaR
             if (initialSector && angularSession) {
                 const edited = sectorForEdit(polarPointerAngle(point, angularSession.frame));
                 if (!edited) return;
-                setSuppressClick(true);
+                beginDragCapture(event);
                 showAngularSector(edited);
                 dispatchAngularRegion('preview', edited, event, angularAction);
                 return;
             }
             angularSession?.move(point);
             if (!angularSession || angularSession.dragDistance() < 4) return;
-            setSuppressClick(true);
+            beginDragCapture(event);
             const sector = angularSession.sector();
             showAngularSector(sector);
             dispatchAngularRegion('preview', sector, event);
             return;
         }
         if (cartesianDragDistance(dragStart, point, regionAxis) < 4) return;
-        setSuppressClick(true);
+        beginDragCapture(event);
         const interval = regionAxis === 'xy' ? undefined : intervalForDrag(point);
         const points = interval ? intervalPoints(interval, intervalAxis()) : { start: dragStart, end: point };
         if (interval) showInterval(interval);

--- a/site/.env.example
+++ b/site/.env.example
@@ -1,0 +1,13 @@
+# Model configuration for the "Demo: interactive data report" playground page.
+# Copy this file to site/.env.local (ignored by git) and fill in the key.
+# Vite only exposes variables that start with VITE_ to the page.
+# The dev server restarts on its own when a .env file changes.
+
+# Required. Requests go straight from the browser to the API.
+VITE_OPENAI_API_KEY=
+
+# Optional. Any chat-completions model the endpoint accepts.
+VITE_OPENAI_MODEL=gpt-5.4
+
+# Optional. Point this at a compatible proxy or an Azure/OpenRouter-style endpoint.
+VITE_OPENAI_BASE_URL=https://api.openai.com/v1

--- a/site/src/main.tsx
+++ b/site/src/main.tsx
@@ -32,6 +32,7 @@ import { InteractionCandidates } from './playground/InteractionCandidates';
 import { ExternalToChartLab } from './playground/ExternalToChartLab';
 import { ChartToExternalLab } from './playground/ChartToExternalLab';
 import { BespokeInteractionLab } from './playground/BespokeInteractionLab';
+import { InteractiveDataReportLab } from './playground/InteractiveDataReportLab';
 import { StyleReferences } from './playground/StyleReferences';
 import { FullTestCases } from './playground/FullTestCases';
 import { DebugGym } from './playground/DebugGym';
@@ -92,6 +93,7 @@ function AppRoutes({ locale }: { locale: Locale }) {
           <Route path="external-to-chart" element={<ExternalToChartLab />} />
           <Route path="chart-to-external" element={<ChartToExternalLab />} />
           <Route path="bespoke-interaction" element={<BespokeInteractionLab />} />
+          <Route path="interactive-data-report" element={<InteractiveDataReportLab />} />
           <Route path="interaction-candidates" element={<InteractionCandidates />} />
           <Route path="style-references/:house?" element={<StyleReferences />} />
           <Route path="debug-gym" element={<DebugGym />} />

--- a/site/src/playground/InteractiveDataReportLab.tsx
+++ b/site/src/playground/InteractiveDataReportLab.tsx
@@ -1,0 +1,513 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from 'react';
+import { Check, ChevronLeft, ChevronRight, GripVertical, Pause, Pencil, Play, Plus, Trash2, X } from 'lucide-react';
+import { InteractionDemoChart } from './InteractionDemoChart';
+import { AGENT, COUNTRIES, DEFAULT_STORY, OPENING, SCALES, STORY } from './interactive-data-report-content';
+import {
+  agentChartOf,
+  asSentence,
+  selectionSentence,
+  sentencesOf,
+  type Message,
+  type Paragraph,
+  type Row,
+  type SectionSpec,
+  type Sentence,
+} from './interactive-data-report-model';
+import {
+  AgentPanel,
+  CONNECTION,
+  PresetEditor,
+  ReportParagraph,
+  ReportSentence,
+  sentenceElementId,
+  useAgentChat,
+  usePresets,
+  useReportChart,
+  type EditablePresets,
+  type ReportChart,
+} from './interactive-data-report-ui';
+import type { OpenAIConnection } from './openai-chat-client';
+import './interaction-transport.css';
+import './interactive-data-report-chat.css';
+import './interactive-data-report.css';
+
+/*
+ * The interactive data report: one chart, three ways to read it. Every section is one
+ * chart bound to its sentences by `useReportChart`, plus a text renderer on top: the
+ * report's paragraphs, the slides, or the agent's chat. What the sections say lives in
+ * `interactive-data-report-content.ts`; how sentences and charts read each other lives in
+ * `interactive-data-report-model.ts` and `interactive-data-report-ui.tsx`.
+ */
+
+/* ---------- shared pieces of a section ---------- */
+
+function SectionHeader({ spec, presets }: { spec: SectionSpec; presets: EditablePresets }) {
+  return (
+    <header className="it-example-header idr-section-header">
+      <div>
+        <h2>{spec.title}</h2>
+        <p>{spec.lede}</p>
+      </div>
+      <PresetEditor editable={presets} />
+    </header>
+  );
+}
+
+/** The spec with the presets the reader has mounted; the chart rebuilds when they change. */
+function useEditableSpec(spec: SectionSpec): { live: SectionSpec; presets: EditablePresets } {
+  const presets = usePresets(spec);
+  const live = useMemo(() => ({ ...spec, presets: presets.presets }), [presets.presets, spec]);
+  return { live, presets };
+}
+
+const scrollToSentence = (sectionId: string) => (item: Sentence) =>
+  document.getElementById(sentenceElementId(sectionId, item))?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+
+/* ---------- 1. the report: paragraphs beside the chart ---------- */
+
+/** One figure of the report: the text beside its chart, each reading the other. */
+export function ReportSection({ spec }: { spec: SectionSpec }) {
+  const { live, presets } = useEditableSpec(spec);
+  const sentences = useMemo(() => sentencesOf(spec.paragraphs), [spec.paragraphs]);
+  const jump = useMemo(() => scrollToSentence(spec.id), [spec.id]);
+  const report = useReportChart(live, sentences, jump);
+
+  return (
+    <article className="it-example idr-section" id={`section-${spec.id}`}>
+      <SectionHeader spec={spec} presets={presets} />
+      <div className="it-workspace it-workspace-external idr-workspace">
+        <section className="it-control-panel idr-report-panel" aria-label={`Report: ${spec.title}`}>
+          <h3 className="it-component-title">Report</h3>
+          <div className="idr-report">
+            {spec.paragraphs.map((paragraph, index) => (
+              <ReportParagraph key={index} parts={paragraph} report={report} sectionId={spec.id} />
+            ))}
+          </div>
+          <button type="button" className="it-reset" onClick={report.clear}>Clear chart and pins</button>
+        </section>
+        <section className="it-chart-panel">
+          <InteractionDemoChart {...report.chartProps} />
+        </section>
+      </div>
+    </article>
+  );
+}
+
+/* ---------- 2. the slides: one sentence at a time ---------- */
+
+const SLIDE_MS = 5000;
+
+/** The slides of one chart: a sideways scroller, one sentence per page, with the controls under it. */
+function SlidePanel({ slides, report }: { slides: readonly Sentence[]; report: ReportChart }) {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const frame = useRef(0);
+  const [index, setIndex] = useState(0);
+  const [playing, setPlaying] = useState(false);
+
+  // The slide on show is the pinned sentence; a change replaces it in one render.
+  const { ready, show } = report;
+  useEffect(() => {
+    if (!ready) return;
+    void show(slides[index] ?? null);
+  }, [index, ready, show, slides]);
+
+  // The panel scrolls sideways one slide at a time, and the slide in view is the one on show.
+  const onScroll = useCallback(() => {
+    if (frame.current !== 0) return;
+    frame.current = window.requestAnimationFrame(() => {
+      frame.current = 0;
+      const scroller = scrollerRef.current;
+      if (!scroller || scroller.clientWidth === 0) return;
+      const next = Math.round(scroller.scrollLeft / scroller.clientWidth);
+      setIndex(Math.min(slides.length - 1, Math.max(0, next)));
+    });
+  }, [slides.length]);
+  useEffect(() => () => { if (frame.current !== 0) window.cancelAnimationFrame(frame.current); }, []);
+
+  const go = useCallback((next: number) => {
+    const target = Math.min(slides.length - 1, Math.max(0, next));
+    const scroller = scrollerRef.current;
+    if (scroller) scroller.scrollTo({ left: target * scroller.clientWidth, behavior: 'smooth' });
+    else setIndex(target);
+  }, [slides.length]);
+
+  // A sideways swipe scrolls on its own. A mouse wheel moves up and down, so one notch
+  // steps one slide; the lock keeps a long notch from skipping slides.
+  const indexRef = useRef(index);
+  indexRef.current = index;
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    let locked = false;
+    const onWheel = (event: WheelEvent) => {
+      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+      event.preventDefault();
+      setPlaying(false);
+      if (locked) return;
+      locked = true;
+      window.setTimeout(() => { locked = false; }, 450);
+      go(indexRef.current + Math.sign(event.deltaY));
+    };
+    scroller.addEventListener('wheel', onWheel, { passive: false });
+    return () => scroller.removeEventListener('wheel', onWheel);
+  }, [go]);
+
+  useEffect(() => {
+    if (!playing) return;
+    if (index >= slides.length - 1) {
+      setPlaying(false);
+      return;
+    }
+    const timer = window.setTimeout(() => go(index + 1), SLIDE_MS);
+    return () => window.clearTimeout(timer);
+  }, [go, index, playing, slides.length]);
+
+  return (
+    <section className="idr-slide-panel" aria-label="Slides">
+      <div className="idr-slide-scroller" ref={scrollerRef} onScroll={onScroll}>
+        {slides.map((slide, slideIndex) => (
+          <div key={slide.id} className={`idr-slide${slideIndex === index ? ' is-active' : ''}`} aria-current={slideIndex === index ? 'step' : undefined}>
+            <span className="idr-slide-count">Slide {slideIndex + 1} of {slides.length}</span>
+            <p className="idr-slide-sentence">{asSentence(slide.text)}</p>
+          </div>
+        ))}
+      </div>
+      <div className="idr-slide-controls">
+        <button type="button" className="idr-control" onClick={() => go(index - 1)} disabled={index === 0} aria-label="Previous slide">
+          <ChevronLeft size={16} strokeWidth={2} aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className={`idr-control${playing ? ' is-playing' : ''}`}
+          onClick={() => setPlaying((current) => !current)}
+          aria-pressed={playing}
+          aria-label={playing ? 'Pause' : 'Play'}
+        >
+          {playing ? <Pause size={15} strokeWidth={2} aria-hidden="true" /> : <Play size={15} strokeWidth={2} aria-hidden="true" />}
+        </button>
+        <button type="button" className="idr-control" onClick={() => go(index + 1)} disabled={index >= slides.length - 1} aria-label="Next slide">
+          <ChevronRight size={16} strokeWidth={2} aria-hidden="true" />
+        </button>
+        <ol className="idr-dots" aria-label="Slides">
+          {slides.map((entry, slideIndex) => (
+            <li key={entry.id} className={slideIndex === index ? 'is-active' : slideIndex < index ? 'is-done' : ''}>
+              <button type="button" onClick={() => go(slideIndex)} aria-label={asSentence(entry.text)} aria-current={slideIndex === index ? 'step' : undefined} />
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+export function SlideSection({ spec }: { spec: SectionSpec }) {
+  const { live, presets } = useEditableSpec(spec);
+  const slides = useMemo(() => sentencesOf(spec.paragraphs), [spec.paragraphs]);
+  const report = useReportChart(live, slides);
+  return (
+    <article className="it-example idr-section" id={`section-${spec.id}`}>
+      <SectionHeader spec={spec} presets={presets} />
+      <div className="it-workspace idr-slides idr-animated">
+        <SlidePanel slides={slides} report={report} />
+        <section className="it-chart-panel idr-slide-chart">
+          <InteractionDemoChart {...report.chartProps} />
+        </section>
+      </div>
+    </article>
+  );
+}
+
+/* ---------- 3. the agent: a chat whose answers are bound sentences ---------- */
+
+interface AgentSectionProps {
+  spec: SectionSpec;
+  opening?: readonly Message[];
+  connection?: OpenAIConnection;
+  /** The sentences the reader kept for the story, by the id of the chat sentence they came from. */
+  storyIds?: ReadonlySet<string>;
+  /** Adds a chat sentence to the story, or takes it out again. */
+  onToggleStory?: (item: Sentence) => void;
+}
+
+export function AgentSection({ spec, opening, connection = CONNECTION, storyIds, onToggleStory }: AgentSectionProps) {
+  // The chat needs the selection when a question goes out; the chart needs the chat's
+  // sentences to match against. A ref breaks the cycle between the two hooks.
+  const selectedRef = useRef<Row[]>([]);
+  const { live, presets } = useEditableSpec(spec);
+  const chat = useAgentChat({ spec: live, connection, opening, getSelected: () => selectedRef.current });
+  const jump = useMemo(() => scrollToSentence(spec.id), [spec.id]);
+  const report = useReportChart(live, chat.sentences, jump);
+  selectedRef.current = report.selected;
+
+  return (
+    <article className="it-example idr-section idr-chat-section" id={`section-${spec.id}`}>
+      <SectionHeader spec={spec} presets={presets} />
+      <div className="it-workspace it-workspace-outbound idr-chat-workspace">
+        <section className="it-chart-panel idr-chat-chart-panel">
+          <div className="idr-chat-chart">
+            <InteractionDemoChart {...report.chartProps} />
+          </div>
+        </section>
+        <AgentPanel chat={chat} report={report} sectionId={spec.id} connection={connection} adoptedIds={storyIds} onAdopt={onToggleStory} />
+      </div>
+    </article>
+  );
+}
+
+/* ---------- 4. the story: the sentences the reader kept, as a paragraph or as slides ---------- */
+
+type StoryFormat = 'paragraph' | 'slides';
+
+interface StoryRowProps {
+  item: Sentence;
+  report: ReportChart;
+  sectionId: string;
+  dragging: boolean;
+  drop: 'before' | 'after' | null;
+  onDragStart: () => void;
+  onDragOver: (event: DragEvent<HTMLLIElement>) => void;
+  onDrop: () => void;
+  onDragEnd: () => void;
+  onEdit: (text: string) => void;
+  onDelete: () => void;
+  /** Open the editor as soon as the row mounts: a sentence the reader has just created. */
+  startEditing?: boolean;
+}
+
+/** One sentence of the story: a grip to drag it, the bound sentence, a pencil that opens an editor, and a bin. */
+function StoryRow({ item, report, sectionId, dragging, drop, onDragStart, onDragOver, onDrop, onDragEnd, onEdit, onDelete, startEditing = false }: StoryRowProps) {
+  const [draft, setDraft] = useState<string | null>(startEditing ? item.text : null);
+  const finish = () => {
+    const text = draft?.trim();
+    if (text && text !== item.text) onEdit(asSentence(text));
+    setDraft(null);
+  };
+  return (
+    <li
+      className={`idr-story-row${dragging ? ' is-dragging' : ''}${drop ? ` is-drop-${drop}` : ''}`}
+      onDragOver={onDragOver}
+      onDrop={(event) => { event.preventDefault(); onDrop(); }}
+    >
+      <button
+        type="button"
+        className="idr-grip"
+        draggable
+        onDragStart={(event) => { event.dataTransfer.effectAllowed = 'move'; event.dataTransfer.setData('text/plain', item.id); onDragStart(); }}
+        onDragEnd={onDragEnd}
+        aria-label="Drag to move this sentence"
+        title="Drag to move"
+      >
+        <GripVertical size={13} aria-hidden="true" />
+      </button>
+      {draft === null ? (
+        <>
+          <span className="idr-story-text"><ReportSentence sentence={item} report={report} sectionId={sectionId} /></span>
+          <span className="idr-edit-actions">
+            <button type="button" className="idr-edit" onClick={() => setDraft(item.text)} aria-label="Edit this sentence" title="Edit">
+              <Pencil size={12} aria-hidden="true" />
+            </button>
+            <button type="button" className="idr-edit is-delete" onClick={onDelete} aria-label="Remove this sentence from the story" title="Remove">
+              <Trash2 size={12} aria-hidden="true" />
+            </button>
+          </span>
+        </>
+      ) : (
+        <>
+          <textarea
+            className="idr-story-editor"
+            value={draft}
+            rows={2}
+            autoFocus
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); finish(); }
+              if (event.key === 'Escape') setDraft(null);
+            }}
+            aria-label="Edit the sentence"
+          />
+          <span className="idr-edit-actions">
+            <button type="button" className="idr-edit is-done" onClick={finish} aria-label="Done" title="Done"><Check size={12} aria-hidden="true" /></button>
+            <button type="button" className="idr-edit" onClick={() => setDraft(null)} aria-label="Cancel" title="Cancel"><X size={12} aria-hidden="true" /></button>
+          </span>
+        </>
+      )}
+    </li>
+  );
+}
+
+interface StoryRowsProps {
+  story: readonly Sentence[];
+  report: ReportChart;
+  sectionId: string;
+  onChange: (story: Sentence[]) => void;
+  /** The sentence the reader has just created, which opens in its editor. */
+  newId: string | null;
+}
+
+/** The story as rows the reader can reorder by drag and edit in place. The chart updates stay with the sentences. */
+function StoryRows({ story, report, sectionId, onChange, newId }: StoryRowsProps) {
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [drop, setDrop] = useState<{ id: string; where: 'before' | 'after' } | null>(null);
+  // Drag events can arrive before the state from the previous one has rendered, so the
+  // handlers read the drag through refs and the state only paints it.
+  const dragRef = useRef<string | null>(null);
+  const dropRef = useRef<{ id: string; where: 'before' | 'after' } | null>(null);
+  const startDrag = (id: string) => { dragRef.current = id; setDragId(id); };
+  const hover = (id: string, where: 'before' | 'after') => { dropRef.current = { id, where }; setDrop({ id, where }); };
+
+  const finishDrag = () => {
+    const from = dragRef.current;
+    const to = dropRef.current;
+    if (from && to && to.id !== from) {
+      const moving = story.find((item) => item.id === from);
+      const rest = story.filter((item) => item.id !== from);
+      const at = rest.findIndex((item) => item.id === to.id) + (to.where === 'after' ? 1 : 0);
+      if (moving) onChange([...rest.slice(0, at), moving, ...rest.slice(at)]);
+    }
+    dragRef.current = null;
+    dropRef.current = null;
+    setDragId(null);
+    setDrop(null);
+  };
+
+  return (
+    <ol className="idr-story-rows" aria-label="Your story, one sentence per row">
+      {story.map((item) => (
+        <StoryRow
+          key={item.id}
+          item={item}
+          report={report}
+          sectionId={sectionId}
+          dragging={dragId === item.id}
+          drop={drop?.id === item.id && dragId !== item.id ? drop.where : null}
+          onDragStart={() => startDrag(item.id)}
+          onDragOver={(event) => {
+            if (!dragRef.current) return;
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+            const rect = event.currentTarget.getBoundingClientRect();
+            hover(item.id, event.clientY < rect.top + rect.height / 2 ? 'before' : 'after');
+          }}
+          onDrop={finishDrag}
+          onDragEnd={finishDrag}
+          onEdit={(text) => onChange(story.map((entry) => (entry.id === item.id ? { ...entry, text } : entry)))}
+          onDelete={() => onChange(story.filter((entry) => entry.id !== item.id))}
+          startEditing={item.id === newId}
+        />
+      ))}
+    </ol>
+  );
+}
+
+interface StorySectionProps {
+  spec: SectionSpec;
+  story: readonly Sentence[];
+  /** The story after a reorder or an edit. */
+  onChange: (story: Sentence[]) => void;
+}
+
+let ownCounter = 0;
+
+export function StorySection({ spec, story, onChange }: StorySectionProps) {
+  const [format, setFormat] = useState<StoryFormat>('paragraph');
+  const [newId, setNewId] = useState<string | null>(null);
+  const chart = useMemo(() => agentChartOf(spec.fixture, spec.presets), [spec.fixture, spec.presets]);
+  const { live, presets } = useEditableSpec(spec);
+  const paragraph = useMemo<Paragraph>(() => story.flatMap((item, index) => (index === 0 ? [item] : [' ', item])), [story]);
+  const storySpec = useMemo<SectionSpec>(() => ({ ...live, paragraphs: [paragraph] }), [live, paragraph]);
+  const jump = useMemo(() => scrollToSentence(spec.id), [spec.id]);
+  const report = useReportChart(storySpec, story, jump);
+
+  // The reader's own sentence: the chart's selection as an emphasis, with a text to rewrite.
+  const addOwn = () => {
+    ownCounter += 1;
+    const item = selectionSentence(`own-${ownCounter}`, report.selected, chart);
+    if (!item) return;
+    setNewId(item.id);
+    onChange([...story, item]);
+    setFormat('paragraph');
+  };
+  const canAdd = report.selected.length > 0;
+
+  return (
+    <article className="it-example idr-section" id={`section-${spec.id}`}>
+      <SectionHeader spec={spec} presets={presets} />
+      <div className="it-workspace idr-story idr-animated">
+        <section className="it-chart-panel idr-slide-chart">
+          <InteractionDemoChart {...report.chartProps} />
+        </section>
+        <section className="idr-story-panel" aria-label="Your story">
+          <div className="idr-format" role="tablist" aria-label="Story format">
+            <button type="button" role="tab" aria-selected={format === 'paragraph'} className={format === 'paragraph' ? 'is-active' : ''} onClick={() => setFormat('paragraph')}>Paragraph</button>
+            <button type="button" role="tab" aria-selected={format === 'slides'} className={format === 'slides' ? 'is-active' : ''} onClick={() => setFormat('slides')}>Slides</button>
+            {format === 'paragraph' && (
+              <button
+                type="button"
+                className="idr-add"
+                onClick={addOwn}
+                disabled={!canAdd}
+                title={canAdd ? 'Add a sentence about the selected records' : 'Select records on the chart first'}
+              >
+                <Plus size={12} strokeWidth={2.2} aria-hidden="true" /> Add sentence
+              </button>
+            )}
+          </div>
+          {story.length === 0 ? (
+            <div className="it-empty-state idr-story-empty">Press + after a sentence in the agent's answer to keep it here, or select records on this chart and add a sentence of your own.</div>
+          ) : format === 'paragraph' ? (
+            <StoryRows story={story} report={report} sectionId={spec.id} onChange={onChange} newId={newId} />
+          ) : (
+            <SlidePanel slides={story} report={report} />
+          )}
+        </section>
+      </div>
+    </article>
+  );
+}
+
+/* ---------- the page ---------- */
+
+/** A chat sentence as a story sentence: its own id, and a capital and a full stop of its own. */
+const toStoryEntry = (item: Sentence): Sentence => ({ ...item, id: `story-${item.id}`, text: asSentence(item.text) });
+
+
+export function InteractiveDataReportLab() {
+  // The story: chat sentences the reader kept, as copies with their own ids and full stops.
+  // It opens with the preset agent sentences the content file lists, in that order.
+  const [story, setStory] = useState<Sentence[]>(() => {
+    const said = OPENING.filter((message) => message.from === 'agent').flatMap((message) => sentencesOf(message.paragraphs));
+    return DEFAULT_STORY.flatMap((id) => said.filter((item) => item.id === id)).map(toStoryEntry);
+  });
+  const storyIds = useMemo(() => new Set(story.map((item) => item.id.slice('story-'.length))), [story]);
+  const toggleStory = useCallback((item: Sentence) => {
+    const id = `story-${item.id}`;
+    setStory((current) => (current.some((entry) => entry.id === id)
+      ? current.filter((entry) => entry.id !== id)
+      : [...current, toStoryEntry(item)]));
+  }, []);
+
+  return (
+    <div className="dev-page it-page idr-page">
+      <header className="dev-page-heading it-heading">
+        <h1>A report and its chart read each other</h1>
+        <p>
+          Each underlined sentence carries one chart update, written in the library's own update language.
+          Hover a sentence to preview it on the chart, or click it to pin it. Interact with the chart, and
+          the sentences that point at the same data rows light up. One chart runs through every section:
+          income against life expectancy for twelve countries.
+        </p>
+        {!CONNECTION.apiKey && (
+          <p className="idr-warning">
+            No API key is configured. Set <code>VITE_OPENAI_API_KEY</code> in <code>site/.env.local</code> to enable the agent.
+          </p>
+        )}
+      </header>
+      <div className="it-examples idr-sections">
+        <ReportSection spec={COUNTRIES} />
+        <SlideSection spec={SCALES} />
+        <AgentSection spec={AGENT} opening={OPENING} storyIds={storyIds} onToggleStory={toggleStory} />
+        <StorySection spec={STORY} story={story} onChange={setStory} />
+      </div>
+    </div>
+  );
+}

--- a/site/src/playground/PlaygroundShell.tsx
+++ b/site/src/playground/PlaygroundShell.tsx
@@ -34,6 +34,7 @@ const pages: NavEntry[] = [
       { to: 'interaction-dashboard', label: 'Demo: dashboard' },
       { to: 'external-to-chart', label: 'Demo: external to chart' },
       { to: 'chart-to-external', label: 'Demo: chart to external' },
+      { to: 'interactive-data-report', label: 'Demo: interactive data report' },
     ],
   },
   {

--- a/site/src/playground/interactive-data-report-chat.css
+++ b/site/src/playground/interactive-data-report-chat.css
@@ -1,0 +1,384 @@
+/*
+ * The chat panel of the interactive data report: the agent's turns, the suggested
+ * questions, the selection chip, and the composer.
+ */
+
+.idr-chat-page .it-examples {
+  width: min(100%, 1100px);
+}
+
+.idr-chat-page .it-heading code {
+  font-size: 12px;
+}
+
+.idr-chat-page-warning {
+  margin: 10px 0 0;
+  color: var(--it-warm);
+  font-size: 12px;
+}
+
+.idr-chat-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.idr-chat-preset-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 4px;
+  max-width: 360px;
+  margin: 2px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idr-chat-preset-list li { display: contents; }
+
+.idr-chat-chip-interaction {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--it-line);
+  border-radius: 12px;
+  padding: 3px 9px 3px 7px;
+  color: #4e5961;
+  background: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.idr-chat-chip-interaction svg { flex: none; color: var(--it-accent); }
+.idr-chat-chip-interaction.idr-chat-kind-viewport svg { color: #5b7fb5; }
+.idr-chat-chip-interaction.idr-chat-kind-order svg { color: #c0924a; }
+.idr-chat-chip-interaction.idr-chat-kind-hide svg { color: #9a6fa5; }
+.idr-chat-chip-interaction.idr-chat-kind-annotation svg { color: #4d9a74; }
+
+/* Workspace: chart on the left, the chart's agent on the right. */
+
+.idr-chat-workspace {
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  min-height: 420px;
+}
+
+.idr-chat-chart-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 16px 12px 12px;
+}
+
+.idr-chat-chart {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+.idr-chat-chart .it-chart-mount { display: flex; justify-content: center; min-width: 0; }
+
+.idr-chat-gestures {
+  margin: 0;
+  padding: 0 8px;
+  color: #7a858d;
+  font-size: 10px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.idr-chat-agent-panel {
+  gap: 10px;
+  padding: 16px 16px 14px;
+  background: #fbfcfc;
+}
+
+.idr-chat-agent-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.idr-chat-agent-head .it-component-title { margin: 0; }
+.idr-chat-agent-head span { color: var(--it-muted); font-size: 10px; }
+
+/* Context chips above the composer */
+
+.idr-chat-context-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.idr-chat-context-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 100%;
+  padding: 3px 8px 3px 7px;
+  border: 1px dashed var(--it-line);
+  border-radius: 6px;
+  color: var(--it-muted);
+  background: #fff;
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.idr-chat-context-chip svg { flex: none; }
+
+.idr-chat-context-chip.is-selection {
+  border-style: solid;
+  border-color: #cfe3dc;
+  background: #e6f2ee;
+  color: var(--it-accent);
+}
+
+.idr-chat-context-chip.is-agent {
+  border-style: solid;
+  border-color: #ead9cf;
+  background: #fbf3ee;
+  color: var(--it-warm);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.idr-chat-context-chip button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: 2px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.idr-chat-context-chip button:hover { background: rgba(0, 0, 0, 0.08); }
+
+/* Messages */
+
+.idr-chat-messages {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 220px;
+  padding: 6px 2px;
+  overflow-y: auto;
+}
+
+.idr-chat-messages-empty {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: var(--it-muted);
+  text-align: center;
+}
+
+.idr-chat-messages-empty p { max-width: 280px; margin: 0; font-size: 11.5px; line-height: 1.5; }
+.idr-chat-warning { color: var(--it-warm); }
+
+.idr-chat-turn { display: flex; flex-direction: column; gap: 5px; }
+.idr-chat-turn-user { align-items: flex-end; }
+.idr-chat-turn-assistant { align-items: flex-start; }
+
+.idr-chat-bubble {
+  max-width: 92%;
+  padding: 8px 12px;
+  border-radius: 9px;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.idr-chat-turn-user .idr-chat-bubble {
+  background: var(--it-accent);
+  color: #fff;
+  border-bottom-right-radius: 3px;
+}
+
+/* The answer reads like the report: a serif measure with generous leading, not a chat bubble. */
+.idr-chat-turn-assistant .idr-chat-bubble {
+  max-width: 100%;
+  padding: 4px 2px 2px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #3b454c;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 13.5px;
+  line-height: 1.85;
+  white-space: normal;
+}
+
+.idr-chat-turn-context {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 3px;
+  color: var(--it-muted);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.idr-chat-turn-assistant .idr-chat-turn-context { color: var(--it-warm); }
+.idr-chat-thinking { color: var(--it-muted); font-size: 12.5px; font-style: italic; }
+
+.idr-chat-cursor {
+  display: inline-block;
+  width: 6px;
+  height: 12px;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background: var(--it-accent);
+  animation: idr-chat-blink 1s steps(2, start) infinite;
+}
+
+@keyframes idr-chat-blink { to { visibility: hidden; } }
+
+.idr-chat-error {
+  padding: 5px 8px;
+  border-radius: 5px;
+  background: #fbeee7;
+  color: var(--it-warm);
+  font-size: 11px;
+}
+
+/* Prompts and composer */
+
+.idr-chat-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.idr-chat-suggestions button {
+  padding: 3px 9px;
+  border: 1px solid var(--it-line);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--it-ink);
+  font: inherit;
+  font-size: 10.5px;
+  cursor: pointer;
+}
+
+.idr-chat-suggestions button:hover:not(:disabled) { border-color: var(--it-accent); color: var(--it-accent); }
+.idr-chat-suggestions button:disabled { opacity: 0.5; cursor: default; }
+
+.idr-chat-composer {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.idr-chat-composer textarea {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 8px;
+  border: 1px solid var(--it-line);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  resize: vertical;
+}
+
+.idr-chat-composer textarea:focus { outline: 2px solid #e6f2ee; border-color: var(--it-accent); }
+
+.idr-chat-send {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--it-accent);
+  color: #fff;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.idr-chat-send:disabled { opacity: 0.45; cursor: default; }
+
+@media (max-width: 760px) {
+  .idr-chat-workspace { grid-template-columns: minmax(0, 1fr); }
+  .idr-chat-section-header { flex-direction: column; }
+  .idr-chat-preset-list { justify-content: flex-start; max-width: none; }
+  .idr-chat-agent-panel { border-left: 0; border-top: 1px solid #e9edef; }
+}
+
+/* Sentence-bound updates in the answer, as in the interactive data report */
+
+.idr-chat-answer p { margin: 0 0 12px; }
+.idr-chat-answer p:last-child { margin-bottom: 0; }
+
+.idr-chat-fragment {
+  display: inline;
+  border-bottom: 1px dotted #b3bcc2;
+  border-radius: 2px;
+  padding: 1px 1px;
+  color: inherit;
+  background: transparent;
+  cursor: help;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.idr-chat-fragment.idr-chat-kind-viewport { border-bottom-color: #9fb4d6; }
+.idr-chat-fragment.idr-chat-kind-order { border-bottom-color: #d3b98c; }
+.idr-chat-fragment.idr-chat-kind-hide { border-bottom-color: #c3a8ca; }
+.idr-chat-fragment.idr-chat-kind-annotation { border-bottom-color: #93bfa7; }
+
+.idr-chat-fragment:hover,
+.idr-chat-fragment.is-preview {
+  border-bottom: 1px solid var(--it-accent);
+  color: #0f5b47;
+  background: #eef7f3;
+}
+
+.idr-chat-fragment:focus-visible {
+  outline: 2px solid var(--it-accent);
+  outline-offset: 1px;
+}
+
+/* The plus sign after a sentence that a page can adopt into its own report. */
+.idr-chat-adopt {
+  display: inline-grid;
+  width: 14px;
+  height: 14px;
+  margin: 0 2px 0 3px;
+  border: 1px solid #cfd6da;
+  border-radius: 50%;
+  padding: 0;
+  color: #6f7a82;
+  background: #fff;
+  font: 700 11px/1 inherit;
+  place-items: center;
+  vertical-align: 1px;
+  cursor: pointer;
+}
+
+.idr-chat-adopt:hover {
+  border-color: var(--it-accent);
+  color: #fff;
+  background: var(--it-accent);
+}

--- a/site/src/playground/interactive-data-report-content.ts
+++ b/site/src/playground/interactive-data-report-content.ts
@@ -1,0 +1,147 @@
+import { MousePointerClick, Move, Scan, Target, Timer } from 'lucide-react';
+import {
+  clickHighlight,
+  doubleActivate,
+  hoverGroupFocus,
+  longPress,
+  navigate,
+  select,
+} from 'flint-chart/interactive';
+import { countriesFixture } from './interaction-demo-data';
+import {
+  emphasis,
+  fullView,
+  note,
+  preset,
+  sentence,
+  view,
+  type Message,
+  type SectionSpec,
+} from './interactive-data-report-model';
+
+/** The report: point selection, viewport navigation, and cohort hover on one chart. */
+export const COUNTRIES: SectionSpec = {
+  id: 'countries',
+  title: 'Interactive data report',
+  lede: 'Chart and report can be bi-directionally connected. Hover a sentence to preview it on the chart, or click it to pin it. Interact with the chart, and the sentences that point at the same data rows light up.',
+  fixture: countriesFixture,
+  presets: [
+    preset('set-style', 'Click highlight', MousePointerClick, clickHighlight({ id: 'focus', targets: ['mark', 'legend'] })),
+    preset('set-style', 'Select', Scan, select({ id: 'select' })),
+    preset('set-style', 'Hover group focus', Target, hoverGroupFocus({ id: 'group-hover', groupBy: 'Continent' })),
+  ],
+  paragraphs: [
+    [
+      'Across the twelve countries, income and longevity move together, but not in lockstep. ',
+      sentence('japan', 'Japan leads life expectancy at 84.2 years', emphasis({ Country: 'Japan' })),
+      ' despite a mid-tier income, while ',
+      sentence('norway', 'Norway, the richest country at $64,800 per person', emphasis({ Country: 'Norway' })),
+      ', trails it by two years. ',
+      sentence('us-norway', 'The United States earns nearly as much as Norway yet lives almost four years less', emphasis({ Country: 'United States' }, { Country: 'Norway' })),
+      '.',
+    ],
+    [
+      // Two ops on one sentence: the five are emphasized, and the longest-lived gets a note.
+      sentence(
+        'over-80',
+        'Only five countries average more than 80 years, and two of them are European. ',
+        emphasis({ Country: 'Norway' }, { Country: 'Germany' }, { Country: 'Chile' }, { Country: 'Japan' }, { Country: 'Australia' }),
+        note({ Country: 'Japan' }, '84.2 years, the longest'),
+      ),
+      '. At the other end, ',
+      sentence('nigeria', 'Nigeria combines the lowest life expectancy, 54.3 years, with one of the lowest incomes', emphasis({ Country: 'Nigeria' })),
+      ', and ',
+      sentence('ethiopia', 'Ethiopia reaches 66.2 years on just $2,000 per person', emphasis({ Country: 'Ethiopia' })),
+      '. ',
+      sentence('china-india', 'China and India, the two most populous countries, sit near the middle of the income range but differ by almost ten years of life expectancy.', emphasis({ Country: 'China' }, { Country: 'India' })),
+    ],
+  ],
+};
+
+/** The scale paragraph on its own, told as slides: its viewport updates glide. */
+export const SCALES: SectionSpec = {
+  id: 'scales',
+  title: 'The paragraph as slides',
+  lede: 'Turn the paragraph into slides for step-by-step storytelling. Each slide applies its update on the chart, and a CSS transition on the marks carries the chart from one sentence to the next. Step through with the arrows or press play.',
+  fixture: countriesFixture,
+  presets: [
+    preset('set-style', 'Click highlight', MousePointerClick, clickHighlight({ id: 'focus', targets: ['mark', 'legend'] })),
+    preset('set-viewport', 'Pan & zoom', Move, navigate({ id: 'navigate' })),
+    preset('set-style', 'Hover group focus', Target, hoverGroupFocus({ id: 'group-hover', groupBy: 'Continent' })),
+  ],
+  paragraphs: [
+    [
+      sentence('all', 'Taking closer looks at different parts of the chart reveals different patterns.', fullView('xy')),
+      sentence(
+        'rich',
+        'Above $30,000 per person the picture is crowded: five countries within six years of one another.',
+        view({ x: [30000, 110000] }),
+        emphasis({ Country: 'Norway' }, { Country: 'Germany' }, { Country: 'United States' }, { Country: 'Japan' }, { Country: 'Australia' }),
+      ),
+      sentence('poor', 'Below $10,000 sit Ethiopia, Nigeria, and India, spread across thirteen years of life expectancy.', view({ x: [1500, 10000] })),
+      sentence('catching-up', 'The 60-to-70-year band holds the three countries still catching up.', view({ y: [58, 72] })),
+    ],
+  ],
+};
+
+/** The agent's chart: point selection only, so a drag is a rectangle and never a pan. */
+export const AGENT: SectionSpec = {
+  id: 'agent',
+  title: 'Context for and from agent',
+  lede: 'User can use selection to provide context about their request for the agent. Vice versa, the agent can use selection to augment their response and provide context for the user.',
+  fixture: countriesFixture,
+  presets: [
+    preset('set-style', 'Click highlight', MousePointerClick, clickHighlight({ id: 'focus', targets: ['mark', 'legend'] })),
+    preset('set-style', 'Select', Scan, select({ id: 'select' })),
+    preset('set-style', 'Hover group focus', Target, hoverGroupFocus({ id: 'group-hover', groupBy: 'Continent' })),
+  ],
+  paragraphs: [],
+};
+
+/** The story: the sentences the reader kept from the chat, on their own chart. */
+export const STORY: SectionSpec = {
+  id: 'story',
+  title: 'From exploration to data story',
+  lede: 'Save interesting insights from your exploration as a data story, or create a new one from scratch.',
+  fixture: countriesFixture,
+  presets: [
+    preset('set-style', 'Click highlight', MousePointerClick, clickHighlight({ id: 'focus', targets: ['mark', 'legend'] })),
+    preset('set-style', 'Select', Scan, select({ id: 'select' })),
+  ],
+  paragraphs: [],
+};
+
+/** The messages the chat opens with, in order, written with the same builders as the report. */
+export const OPENING: Message[] = [
+  { from: 'user', paragraphs: [['What are the interesting findings in this chart?']] },
+  {
+    from: 'agent',
+    paragraphs: [
+      [
+        sentence('asia', 'Asia stretches from India at 67 years to Japan at 84', emphasis({ Continent: 'Asia' })),
+        ', while ',
+        sentence('africa', 'all three African countries sit below 67', emphasis({ Continent: 'Africa' })),
+        ' and ',
+        sentence('americas', 'the Americas cluster between 75 and 80', emphasis({ Continent: 'Americas' })),
+        '.',
+      ],
+    ],
+  },
+  {
+    from: 'user', paragraphs: [
+      [
+        sentence('user', 'Summarize the pattern of the selected data,', emphasis({ Country: 'Norway' }, { Country: 'Germany' }, { Country: 'United States' }, { Country: 'Japan' }, { Country: 'Australia' }))
+      ]
+    ]
+  },
+  {
+    from: 'agent', paragraphs: [
+      [
+        sentence('agent', 'The selection shows five relatively high GDP and high life expectancy countries, sitting in the upper-right portion overall.', emphasis({ Country: 'Norway' }, { Country: 'Germany' }, { Country: 'United States' }, { Country: 'Japan' }, { Country: 'Australia' }))
+      ]
+    ]
+  }
+];
+
+/** The sentences the story opens with, by id, in order: two from the first response and the second response. */
+export const DEFAULT_STORY: string[] = ['asia', 'africa', 'agent'];

--- a/site/src/playground/interactive-data-report-model.ts
+++ b/site/src/playground/interactive-data-report-model.ts
@@ -1,0 +1,732 @@
+import { assembleVegaLite, type ChartAssemblyInput } from 'flint-chart';
+import type {
+  CanvasInteractionDef,
+  ChartUpdateOp,
+  SemanticElement,
+  UpdateDomain,
+  UpdateTarget,
+} from 'flint-chart/interactive';
+import {
+  axisHighlight,
+  brushZoom,
+  clickAnnotate,
+  clickHighlight,
+  contextActivate,
+  doubleActivate,
+  dragReorder,
+  hoverGroupFocus,
+  lassoSelect,
+  legendToggle,
+  longPress,
+  navigate,
+  select,
+} from 'flint-chart/interactive';
+import {
+  EyeOff, GripVertical, Lasso, Menu, MessageSquareText, MousePointerClick, Move, Scan, Tag, Target, Timer, ZoomIn,
+  type LucideIcon,
+} from 'lucide-react';
+import type { InteractionDemoFixture } from './interaction-demo-data';
+
+/*
+ * The model of the interactive data report, with no React in it:
+ *   1. sentences, presets, and sections, and the builders that write them;
+ *   2. the data rows a sentence or a chart state points at, and the match between them;
+ *   3. the agent's wire format, and how an answer becomes sentences.
+ * A sentence is its text and the chart update it carries. Nothing else is stored.
+ */
+
+/* ======================================================================================
+ * 1. Sentences, presets, sections
+ * ====================================================================================== */
+
+export type Selector = Record<string, unknown>;
+export type Domain = [number, number];
+export type ViewportAxes = 'x' | 'y' | 'xy';
+
+/** A span of report text bound to one chart update: the ops are the sentence. */
+export interface Sentence {
+  id: string;
+  text: string;
+  /** Renderer-neutral update JSON, applied together as one retained ChartUpdate. */
+  ops: ChartUpdateOp[];
+}
+
+/** Plain text between sentences, or a bound sentence. */
+export type ReportPart = string | Sentence;
+export type Paragraph = ReportPart[];
+
+/** One chat message, from the user or the agent, as paragraphs of bound sentences and plain text. */
+export interface Message {
+  from: 'user' | 'agent';
+  paragraphs: Paragraph[];
+}
+
+/** The update op an interaction preset produces, and the kind of op a sentence carries. */
+export type PresetOp = 'set-style' | 'set-viewport' | 'set-order' | 'set-annotation';
+
+export interface Preset {
+  op: PresetOp;
+  /** Gesture label and icon, shared with the interaction gallery. */
+  label: string;
+  icon: LucideIcon;
+  def: CanvasInteractionDef;
+}
+
+/** One chart with the interactions it hosts and the paragraphs written about it. */
+export interface SectionSpec {
+  id: string;
+  title: string;
+  lede: string;
+  fixture: InteractionDemoFixture;
+  presets: Preset[];
+  paragraphs: Paragraph[];
+}
+
+/** A short name for each update op, for the chips. */
+export const OPS: Record<PresetOp, { title: string; description: string }> = {
+  'set-style': { title: 'Emphasis', description: 'Emphasizes the rows it names and mutes the rest.' },
+  'set-viewport': { title: 'Viewport', description: 'Sets the visible domain on x, y, or both.' },
+  'set-order': { title: 'Order', description: 'Sets the category order along an axis.' },
+  'set-annotation': { title: 'Annotation', description: 'Attaches a note to one data key.' },
+};
+
+/** CSS hook for an op: `idr-op-style`, `idr-op-viewport`, and so on. */
+export const opClass = (op: PresetOp): string => `idr-op-${op.slice('set-'.length)}`;
+
+export const isSentence = (part: ReportPart): part is Sentence => typeof part !== 'string';
+
+export const sentencesOf = (paragraphs: readonly Paragraph[]): Sentence[] => paragraphs.flat().filter(isSentence);
+
+/** A clause out of a longer text becomes a sentence of its own: a capital and a full stop. */
+export function asSentence(text: string): string {
+  const trimmed = text.trim().replace(/^[\s,;:.]+/, '').replace(/[,;:]$/, '');
+  const capital = trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+  return /[.!?]$/.test(capital) ? capital : `${capital}.`;
+}
+
+/* ---------- ops: a sentence carries any number, applied in the order listed ---------- */
+
+const EMPHASIS = { state: 'emphasized', mutedOpacity: 0.25 } as const;
+
+/** Emphasizes the rows the selectors name and mutes the rest. */
+export const emphasis = (...match: Selector[]): ChartUpdateOp =>
+  ({ op: 'set-style', targets: match.map((key) => ({ select: { key } })), value: EMPHASIS });
+/** Attaches a note to one data key. The key must resolve to exactly one element. */
+export const note = (match: Selector, text: string): ChartUpdateOp =>
+  ({ op: 'set-annotation', target: { select: { key: match } }, value: { text } });
+/** Sets the visible domain on x, y, or both. */
+export const view = (range: { x?: Domain; y?: Domain }): ChartUpdateOp => ({
+  op: 'set-viewport',
+  axes: range.x && range.y ? 'xy' : range.x ? 'x' : 'y',
+  value: { ...(range.x ? { x: range.x } : {}), ...(range.y ? { y: range.y } : {}) },
+});
+/** Restores the full domain on the axes given. */
+export const fullView = (axes: ViewportAxes): ChartUpdateOp => ({ op: 'set-viewport', axes, value: {} });
+
+/** A sentence: its text and the ops it carries. */
+export const sentence = (id: string, text: string, ...ops: ChartUpdateOp[]): Sentence => ({ id, text, ops });
+
+export const preset = (op: PresetOp, label: string, icon: LucideIcon, def: CanvasInteractionDef): Preset =>
+  ({ op, label, icon, def });
+
+/* ---------- the presets a chart can host ---------- */
+
+function encodedField(input: ChartAssemblyInput, channel: string): string | undefined {
+  const encodings = ((input.chart_spec as { encodings?: unknown }).encodings ?? {}) as Record<string, unknown>;
+  const encoding = encodings[channel];
+  if (typeof encoding === 'string') return encoding;
+  const named = encoding as { field?: unknown } | undefined;
+  return typeof named?.field === 'string' ? named.field : undefined;
+}
+
+
+/** Flint semantic types that make a column a measure; every other column is discrete. */
+const QUANTITATIVE_TYPES = new Set([
+  'Quantity', 'Count', 'Amount', 'Price', 'Percentage', 'Temperature', 'Profit', 'PercentageChange',
+  'Sentiment', 'Correlation', 'Rank', 'Score', 'Number', 'Currency',
+]);
+
+/** One interaction the reader can mount on a chart. */
+export interface PresetOption {
+  /** The interaction id, unique on the chart, and the id of the preset it makes. */
+  id: string;
+  op: PresetOp;
+  label: string;
+  icon: LucideIcon;
+  make: () => CanvasInteractionDef;
+}
+
+interface ChartSemantics {
+  navigationAxes: readonly ('x' | 'y')[];
+  reorderAxes: readonly { axis: 'x' | 'y'; field: string }[];
+}
+
+function semanticsOf(fixture: InteractionDemoFixture): ChartSemantics {
+  try {
+    const spec = assembleVegaLite(fixture.input) as { _interactionSemantics?: Partial<ChartSemantics> };
+    return { navigationAxes: spec._interactionSemantics?.navigationAxes ?? [], reorderAxes: spec._interactionSemantics?.reorderAxes ?? [] };
+  } catch {
+    return { navigationAxes: [], reorderAxes: [] };
+  }
+}
+
+/**
+ * The interactions that fit a chart: point gestures on every chart, a legend gesture when
+ * the color is discrete, navigation when an axis can pan, reorder when an axis is nominal.
+ * Section content picks its starting presets from here by id.
+ */
+export function presetCatalog(fixture: InteractionDemoFixture): PresetOption[] {
+  const input = fixture.input;
+  const types = (input.semantic_types ?? {}) as Record<string, string>;
+  const chartType = (input.chart_spec as { chartType: string }).chartType;
+  const discrete = (field: string | undefined): field is string =>
+    field !== undefined && field in types && !QUANTITATIVE_TYPES.has(types[field]);
+  const [x, y, color] = ['x', 'y', 'color'].map((channel) => encodedField(input, channel));
+  const group = discrete(color) ? color : undefined;
+  const axisField = chartType === 'Line Chart' ? undefined : discrete(y) ? y : discrete(x) ? x : undefined;
+  const semantics = semanticsOf(fixture);
+  const reorder = semantics.reorderAxes.find((axis) => axis.field === axisField) ?? semantics.reorderAxes[0];
+  const options: PresetOption[] = [
+    { id: 'focus', op: 'set-style', label: 'Click highlight', icon: MousePointerClick, make: () => clickHighlight({ id: 'focus', targets: group ? ['mark', 'legend'] : ['mark'] }) },
+    { id: 'hold', op: 'set-style', label: 'Long press', icon: Timer, make: () => longPress({ id: 'hold' }) },
+    { id: 'drill', op: 'set-style', label: 'Double click', icon: MousePointerClick, make: () => doubleActivate({ id: 'drill' }) },
+    { id: 'context', op: 'set-style', label: 'Context menu', icon: Menu, make: () => contextActivate({ id: 'context' }) },
+  ];
+  if (axisField) options.push({ id: 'axis', op: 'set-style', label: 'Axis label click', icon: Tag, make: () => axisHighlight({ id: 'axis' }) });
+  if (group) options.push({ id: 'group-hover', op: 'set-style', label: 'Hover group focus', icon: Target, make: () => hoverGroupFocus({ id: 'group-hover', groupBy: group }) });
+  options.push({ id: 'select', op: 'set-style', label: 'Select', icon: Scan, make: () => select({ id: 'select' }) });
+  if (chartType === 'Scatter Plot') options.push({ id: 'lasso', op: 'set-style', label: 'Lasso', icon: Lasso, make: () => lassoSelect({ id: 'lasso' }) });
+  if (semantics.navigationAxes.length > 0) {
+    const axes = semantics.navigationAxes.includes('x') ? 'x' : 'y';
+    options.push({ id: 'navigate', op: 'set-viewport', label: 'Pan & zoom', icon: Move, make: () => navigate({ id: 'navigate' }) });
+    options.push({ id: 'zoom', op: 'set-viewport', label: 'Brush zoom', icon: ZoomIn, make: () => brushZoom({ id: 'zoom', axes }) });
+  }
+  if (reorder) options.push({ id: 'reorder', op: 'set-order', label: 'Drag reorder', icon: GripVertical, make: () => dragReorder({ id: 'reorder' }) });
+  if (group) options.push({ id: 'legend', op: 'set-style', label: 'Legend toggle', icon: EyeOff, make: () => legendToggle({ id: 'legend' }) });
+  options.push({ id: 'annotate', op: 'set-annotation', label: 'Annotate', icon: MessageSquareText, make: () => clickAnnotate({ id: 'annotate' }) });
+  return options;
+}
+
+/** A plain drag pans when navigation is mounted, so the drag-to-select gestures cannot share the chart with it. */
+const DRAG_REGION = new Set(['select', 'lasso', 'zoom']);
+
+/** The options that can still join the mounted presets without a gesture conflict. */
+export function availablePresets(options: readonly PresetOption[], mounted: readonly Preset[]): PresetOption[] {
+  const ids = new Set(mounted.map((entry) => entry.def.id));
+  return options.filter((option) => {
+    if (ids.has(option.id)) return false;
+    if (option.id === 'navigate') return ![...ids].some((id) => DRAG_REGION.has(id));
+    if (DRAG_REGION.has(option.id)) return !ids.has('navigate');
+    return true;
+  });
+}
+
+/** The preset an option mounts. */
+export const presetOf = (option: PresetOption): Preset => preset(option.op, option.label, option.icon, option.make());
+
+/** The kinds of op a sentence carries, in order and without repeats, for its chips. */
+export function sentenceOps(item: Sentence): PresetOp[] {
+  const kinds: PresetOp[] = [];
+  for (const { op } of item.ops) {
+    const kind: PresetOp = op === 'set-viewport' || op === 'set-order' || op === 'set-annotation' ? op : 'set-style';
+    if (!kinds.includes(kind)) kinds.push(kind);
+  }
+  return kinds.length > 0 ? kinds : ['set-style'];
+}
+
+/** A chart fixture from rows and a chart spec, as the interaction demos define them. */
+export function makeFixture(
+  id: string,
+  title: string,
+  source: string,
+  chartType: string,
+  values: Record<string, unknown>[],
+  semanticTypes: Record<string, string>,
+  encodings: Record<string, unknown>,
+  chartProperties?: Record<string, unknown>,
+  baseSize = { width: 430, height: 270 },
+): InteractionDemoFixture {
+  return {
+    id,
+    title,
+    source,
+    input: {
+      data: { values },
+      semantic_types: semanticTypes,
+      chart_spec: { chartType, title, encodings, baseSize, chartProperties },
+    } as ChartAssemblyInput,
+  };
+}
+
+/* ======================================================================================
+ * 2. Rows: what a sentence and a chart state point at, and how well they match
+ * ====================================================================================== */
+
+export type Row = Record<string, unknown>;
+/** Row identities, see `rowId`. */
+export type RowSet = Set<string>;
+export type MatchLevel = 'full' | 'partial' | null;
+
+export function numeric(value: unknown): unknown {
+  return value instanceof Date ? value.getTime() : value;
+}
+
+/** A date may arrive as a Date, a timestamp, or the source text; all three name the same day. */
+export function sameValue(left: unknown, right: unknown): boolean {
+  const a = numeric(left);
+  const b = numeric(right);
+  if (Object.is(a, b)) return true;
+  if (typeof a === 'number' && typeof b === 'number') return a === b;
+  if (typeof a === 'number' && typeof b === 'string') return Date.parse(b) === a;
+  if (typeof a === 'string' && typeof b === 'number') return Date.parse(a) === b;
+  return false;
+}
+
+/** Text against a number or a date, as a model writes values: "84.2" matches 84.2. */
+export function looseEqual(left: unknown, right: unknown): boolean {
+  return sameValue(left, right) || String(left).trim().toLowerCase() === String(right).trim().toLowerCase();
+}
+
+/** A number for a range test. A Date, or a date string, becomes its timestamp. */
+export function asNumber(value: unknown): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const direct = Number(value);
+    return Number.isFinite(direct) ? direct : Date.parse(value);
+  }
+  return NaN;
+}
+
+/** One identity for a row, whichever object carries it. Dates and timestamps agree. */
+export function rowId(row: Row): string {
+  return JSON.stringify(Object.keys(row).sort().map((key) => [key, numeric(row[key])]));
+}
+
+export function rowMatches(row: Row, selector: Selector): boolean {
+  return Object.entries(selector).every(([field, expected]) => sameValue(row[field], expected));
+}
+
+/** The rows of a chart and the fields on its position axes. */
+export interface ChartRows {
+  rows: Row[];
+  x?: string;
+  y?: string;
+}
+
+export function chartRows(input: ChartAssemblyInput): ChartRows {
+  const rows = ((input.data as { values?: unknown }).values ?? []) as Row[];
+  return { rows, x: encodedField(input, 'x'), y: encodedField(input, 'y') };
+}
+
+/**
+ * Rows an element stands for. Source records when the chart knows them; otherwise the
+ * element's value acts as a selector over the chart's rows. A legend entry selects its
+ * series, and a mark's channel values select the row that carries them.
+ */
+export function elementRows(element: SemanticElement, chart: ChartRows): Row[] {
+  if (element.records?.length) return [...element.records];
+  const legend = element.value as { field?: unknown; domain?: { kind?: string; value?: unknown } };
+  const selector: Selector = typeof legend.field === 'string' && legend.domain?.kind === 'value'
+    ? { [legend.field]: legend.domain.value }
+    : element.value;
+  const rows = chart.rows.filter((row) => rowMatches(row, selector));
+  return rows.length > 0 ? rows : [element.value];
+}
+
+/** The identities of the rows a set of elements stands for. */
+export function rowsOf(elements: readonly SemanticElement[], chart: ChartRows): RowSet {
+  return new Set(elements.flatMap((element) => elementRows(element, chart)).map(rowId));
+}
+
+const cleanRow = (row: Row): Row => Object.fromEntries(Object.entries(row).filter(([field]) => !field.startsWith('__')));
+
+/** The source rows behind a set of elements, once each and without render fields: what leaves the chart. */
+export function recordsOf(elements: readonly SemanticElement[], chart: ChartRows): Row[] {
+  const seen = new Set<string>();
+  const records: Row[] = [];
+  for (const element of elements) {
+    for (const row of elementRows(element, chart)) {
+      const id = rowId(row);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      records.push(cleanRow(row));
+    }
+  }
+  return records;
+}
+
+const toDomain = (value: UpdateDomain | undefined): Domain | undefined => {
+  if (!value) return undefined;
+  const [start, end] = [asNumber(value[0]), asNumber(value[1])];
+  return Number.isFinite(start) && Number.isFinite(end) ? [Math.min(start, end), Math.max(start, end)] : undefined;
+};
+
+/** The rows inside a viewport. An axis without a domain, or without a field, keeps every row. */
+export function rowsInView(chart: ChartRows, viewportRange: { x?: Domain; y?: Domain }): Row[] {
+  const within = (row: Row, field: string | undefined, domain: Domain | undefined): boolean => {
+    if (!field || !domain) return true;
+    const value = asNumber(row[field]);
+    return Number.isFinite(value) && value >= domain[0] && value <= domain[1];
+  };
+  return chart.rows.filter((row) => within(row, chart.x, viewportRange.x) && within(row, chart.y, viewportRange.y));
+}
+
+function targetRows(target: UpdateTarget, chart: ChartRows): Row[] {
+  return 'select' in target
+    ? chart.rows.filter((row) => rowMatches(row, target.select.key))
+    : target.elements.flatMap((element) => elementRows(element, chart));
+}
+
+/** The rows a sentence points at: the rows its targets name, plus the rows inside its viewport. */
+export function sentenceRows(item: Sentence, chart: ChartRows): RowSet {
+  const rows: Row[] = [];
+  for (const op of item.ops) {
+    if (op.op === 'set-style') for (const target of op.targets) rows.push(...targetRows(target, chart));
+    else if (op.op === 'set-annotation') rows.push(...targetRows(op.target, chart));
+    else if (op.op === 'set-viewport') rows.push(...rowsInView(chart, { x: toDomain(op.value.x), y: toDomain(op.value.y) }));
+  }
+  return new Set(rows.map(rowId));
+}
+
+/** Rows in common over rows in either set. Two empty sets share nothing. */
+export function overlap(a: RowSet, b: RowSet): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let shared = 0;
+  for (const id of a) if (b.has(id)) shared += 1;
+  return shared / (a.size + b.size - shared);
+}
+
+/** The same rows on both sides is a full match; any row in common is a partial one. */
+export function levelOf(ratio: number): MatchLevel {
+  return ratio >= 1 ? 'full' : ratio > 0 ? 'partial' : null;
+}
+
+/* ======================================================================================
+ * 3. The agent: what it may say about a chart, and how its answer becomes sentences
+ * ====================================================================================== */
+
+/*
+ * The model cannot write `select.key` selectors: a strict response schema has no room for
+ * free-form objects. So it writes where-clauses as lists of field/value pairs, and the
+ * page resolves them against the chart's own rows into selectors on the key fields. That
+ * is the only place the agent's vocabulary differs from the report's.
+ */
+
+
+/** What the agent needs to know about a chart to bind sentences to it. */
+export interface AgentChart {
+  rows: Row[];
+  columns: string[];
+  /** The fields that identify one mark, the target of an emphasis. */
+  keyFields: string[];
+  /** The fields that identify one element for a note; adds the color field when it is discrete. */
+  annotationFields: string[];
+  /** Axes a viewport op can set: empty unless a navigation preset is mounted. */
+  viewportAxes: readonly ('x' | 'y')[];
+}
+
+function navigationAxesOf(fixture: InteractionDemoFixture): readonly ('x' | 'y')[] {
+  try {
+    const spec = assembleVegaLite(fixture.input) as { _interactionSemantics?: { navigationAxes?: readonly ('x' | 'y')[] } };
+    return spec._interactionSemantics?.navigationAxes ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/** The agent's view of a section's chart, derived from the fixture and the mounted presets. */
+export function agentChartOf(fixture: InteractionDemoFixture, presets: readonly Preset[]): AgentChart {
+  const input = fixture.input;
+  const types = (input.semantic_types ?? {}) as Record<string, string>;
+  const chartType = (input.chart_spec as { chartType: string }).chartType;
+  const discrete = (field: string | undefined): field is string =>
+    field !== undefined && field in types && !QUANTITATIVE_TYPES.has(types[field]);
+  const [x, y, color, detail] = ['x', 'y', 'color', 'detail'].map((channel) => encodedField(input, channel));
+  let keyFields: string[] = [];
+  if (chartType === 'Line Chart') keyFields = discrete(color) ? [color] : [];
+  else if (discrete(detail)) keyFields = [detail];
+  else keyFields = [x, y].filter(discrete);
+  if (keyFields.length === 0 && discrete(color)) keyFields = [color];
+  const annotationFields = discrete(color) && !keyFields.includes(color) ? [...keyFields, color] : keyFields;
+  return {
+    rows: chartRows(input).rows,
+    columns: Object.keys(types),
+    keyFields,
+    annotationFields,
+    viewportAxes: presets.some((entry) => entry.op === 'set-viewport') ? navigationAxesOf(fixture) : [],
+  };
+}
+
+export type AgentOpKind = 'highlight' | 'annotate' | 'viewport';
+
+/** One update as the model writes it. */
+export interface AgentUpdate {
+  op: AgentOpKind;
+  /** Records the update is about; each is a list of field/value pairs it must match. */
+  records: { pairs: { field: string; value: string }[] }[];
+  /** The note, for annotate. */
+  text: string | null;
+  /** [min, max] domains, for viewport. */
+  x: number[] | null;
+  y: number[] | null;
+}
+
+/** One part of an answer as the model writes it: text, the chart it speaks about, and its updates. */
+export interface AgentPart {
+  text: string;
+  /** The id of the chart the updates apply to; null when there are none, or when the page has one chart. */
+  chart: string | null;
+  updates: AgentUpdate[];
+}
+
+const RECORDS_SCHEMA = {
+  type: 'array',
+  description: 'Records the update is about, for highlight and annotate. Each record is a list of column/value pairs that it must match. Empty for viewport.',
+  items: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['pairs'],
+    properties: {
+      pairs: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['field', 'value'],
+          properties: { field: { type: 'string' }, value: { type: 'string' } },
+        },
+      },
+    },
+  },
+};
+
+/** The strict schema of one update. */
+export const UPDATE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['op', 'records', 'text', 'x', 'y'],
+  properties: {
+    op: { type: 'string', enum: ['highlight', 'annotate', 'viewport'] },
+    records: RECORDS_SCHEMA,
+    text: { type: ['string', 'null'], description: 'Annotation label for annotate, under 40 characters. Null otherwise.' },
+    x: { type: ['array', 'null'], items: { type: 'number' }, description: '[min, max] x domain for viewport. Null otherwise.' },
+    y: { type: ['array', 'null'], items: { type: 'number' }, description: '[min, max] y domain for viewport. Null otherwise.' },
+  },
+};
+
+/**
+ * The strict schema of an answer: parts in reading order, each with zero or more updates.
+ * With `withChart`, a part also names the chart its updates apply to.
+ */
+export function answerSchema(name: string, withChart: boolean): Record<string, unknown> {
+  return {
+    type: 'json_schema',
+    json_schema: {
+      name,
+      strict: true,
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['parts'],
+        properties: {
+          parts: {
+            type: 'array',
+            description: 'The answer in reading order. Concatenated, the texts form plain sentences without markdown. Use "\\n\\n" inside a text to start a new paragraph.',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: withChart ? ['text', 'chart', 'updates'] : ['text', 'updates'],
+              properties: {
+                text: { type: 'string' },
+                ...(withChart ? { chart: { type: ['string', 'null'], description: 'The id of the chart the updates apply to. Null when updates is empty.' } } : {}),
+                updates: {
+                  type: 'array',
+                  description: 'The updates the sentence carries, applied together on the chart. Usually one; a highlight and an annotation on the same records is a common pair. Empty for connecting words and general statements.',
+                  items: UPDATE_SCHEMA,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+/** The rules every agent gets on how to shape an answer. */
+export const ANSWER_RULES = [
+  'Answer as JSON with an ordered list of parts. Read together, the texts form two to five plain sentences without markdown.',
+  'A part whose text makes a claim about specific records or a visible range carries one or more updates, so the reader can hover that sentence to see it on the chart. A highlight and an annotation on the same records may go together. Keep such a part to the clause the reader can point at, and give each claim its own part.',
+  'Connecting words and general statements are parts with an empty updates list. Only use the update abilities the context lists. Where-clauses use column names and values exactly as in the chart\'s rows, as strings.',
+];
+
+/** The abilities line for one chart, as the context tells the model. */
+export function abilitiesText(chart: AgentChart): string {
+  const abilities = [`highlight and annotate take where-clauses on these columns: ${chart.columns.join(', ')}`];
+  if (chart.viewportAxes.length > 0) abilities.push(`viewport takes numeric [min, max] domains for: ${chart.viewportAxes.join(', ')}`);
+  return abilities.join('; ');
+}
+
+function normalizePart(raw: { text?: unknown; chart?: unknown; updates?: unknown }): AgentPart {
+  return {
+    text: String(raw.text ?? ''),
+    chart: typeof raw.chart === 'string' ? raw.chart : null,
+    updates: Array.isArray(raw.updates) ? (raw.updates as AgentUpdate[]) : [],
+  };
+}
+
+/** The parts of a complete answer, whatever shape the model gave them. */
+export function parseParts(content: string): AgentPart[] {
+  const parsed = JSON.parse(content) as { parts?: unknown };
+  return (Array.isArray(parsed.parts) ? parsed.parts : [])
+    .filter((raw): raw is { text: unknown } => typeof raw === 'object' && raw !== null && 'text' in raw)
+    .map(normalizePart);
+}
+
+/**
+ * The complete parts inside a partial JSON answer while it streams, so the sentences
+ * appear one by one. A part still being written is left out.
+ */
+export function extractParts(partial: string): AgentPart[] {
+  const start = partial.indexOf('"parts"');
+  if (start === -1) return [];
+  const open = partial.indexOf('[', start);
+  if (open === -1) return [];
+  const parts: AgentPart[] = [];
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let objectStart = -1;
+  for (let index = open + 1; index < partial.length; index += 1) {
+    const char = partial[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') { inString = true; continue; }
+    if (char === '{') {
+      if (depth === 0) objectStart = index;
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0 && objectStart !== -1) {
+        try {
+          const raw = JSON.parse(partial.slice(objectStart, index + 1)) as { text?: unknown };
+          if (typeof raw.text === 'string') parts.push(normalizePart(raw));
+        } catch {
+          // An incomplete part is skipped until more text arrives.
+        }
+        objectStart = -1;
+      }
+    } else if (char === ']' && depth === 0) {
+      break;
+    }
+  }
+  return parts;
+}
+
+/** The model sometimes runs two parts together; a space goes between them. */
+export function leadFor(previous: string | undefined, text: string): string {
+  if (!previous || /\s$/.test(previous) || /^[\s.,;:!?)]/.test(text)) return '';
+  return /[.!?]$/.test(previous) ? ' ' : '';
+}
+
+function isDomain(value: unknown): value is Domain {
+  return Array.isArray(value) && value.length === 2 && value.every((entry) => typeof entry === 'number' && Number.isFinite(entry));
+}
+
+/** Selectors on the given fields for the rows any where-clause of the update names, once each. */
+function selectorsFor(update: AgentUpdate, chart: AgentChart, fields: readonly string[]): Selector[] {
+  const clauses = (update.records ?? [])
+    .map((record) => Object.fromEntries((record.pairs ?? []).map((pair) => [pair.field, pair.value])))
+    .filter((clause) => Object.keys(clause).length > 0);
+  const matched = chart.rows.filter((row) => clauses.some((clause) =>
+    Object.entries(clause).every(([field, value]) => field in row && looseEqual(row[field], value))));
+  const seen = new Map<string, Selector>();
+  for (const row of matched) {
+    const selector = Object.fromEntries(fields.map((field) => [field, row[field]]));
+    seen.set(JSON.stringify(selector), selector);
+  }
+  return [...seen.values()];
+}
+
+/**
+ * The sentence for one part of an answer. Each update becomes the op the report would
+ * write itself: a highlight is an emphasis, an annotate is a note (with an emphasis on its
+ * key when no highlight accompanies it), a viewport is a view. Null when no update names
+ * anything the chart shows.
+ */
+export function toSentence(id: string, text: string, updates: readonly AgentUpdate[], chart: AgentChart): Sentence | null {
+  const ops: ChartUpdateOp[] = [];
+  for (const update of updates) {
+    switch (update.op) {
+      case 'highlight': {
+        const selectors = selectorsFor(update, chart, chart.keyFields);
+        if (selectors.length > 0) ops.push(emphasis(...selectors));
+        break;
+      }
+      case 'annotate': {
+        const [selector] = selectorsFor(update, chart, chart.annotationFields);
+        if (!selector) break;
+        ops.push(note(selector, String(update.text ?? '').slice(0, 80) || text.trim().slice(0, 40)));
+        if (!updates.some((other) => other.op === 'highlight')) ops.push(emphasis(selector));
+        break;
+      }
+      case 'viewport': {
+        if (chart.viewportAxes.length === 0) break;
+        const range: { x?: Domain; y?: Domain } = {};
+        if (isDomain(update.x) && chart.viewportAxes.includes('x')) range.x = update.x;
+        if (isDomain(update.y) && chart.viewportAxes.includes('y')) range.y = update.y;
+        ops.push(range.x || range.y ? view(range) : fullView(chart.viewportAxes.length === 2 ? 'xy' : chart.viewportAxes[0]));
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return ops.length > 0 ? sentence(id, text.trim(), ...ops) : null;
+}
+
+/**
+ * An answer as paragraphs of report parts: a part with updates that resolve becomes a
+ * sentence, any other part stays plain text. A "\n\n" inside a text starts a paragraph.
+ */
+export function toParagraphs(parts: readonly AgentPart[], idPrefix: string, chart: AgentChart): Paragraph[] {
+  const paragraphs: Paragraph[] = [[]];
+  parts.forEach((part, index) => {
+    const lead = leadFor(parts[index - 1]?.text, part.text);
+    part.text.split(/\n{2,}/).forEach((text, pieceIndex) => {
+      if (pieceIndex > 0) paragraphs.push([]);
+      if (text.length === 0) return;
+      const current = paragraphs[paragraphs.length - 1];
+      const bound = pieceIndex === 0 && part.updates.length > 0 ? toSentence(`${idPrefix}-${index}`, text, part.updates, chart) : null;
+      if (lead && pieceIndex === 0) current.push(lead);
+      current.push(bound ?? text);
+    });
+  });
+  return paragraphs.filter((paragraph) => paragraph.length > 0);
+}
+
+/**
+ * The selection as a sentence, so a question can carry what it was about: the records the
+ * chart pointed at when it went out, named by the key field and bound as an emphasis.
+ */
+export function selectionSentence(id: string, selected: readonly Row[], chart: AgentChart): Sentence | null {
+  if (selected.length === 0 || chart.keyFields.length === 0) return null;
+  const seen = new Map<string, Selector>();
+  for (const row of selected) {
+    const selector = Object.fromEntries(chart.keyFields.map((field) => [field, row[field]]));
+    seen.set(JSON.stringify(selector), selector);
+  }
+  const selectors = [...seen.values()];
+  const names = selectors.map((selector) => String(selector[chart.keyFields[0]]));
+  const shown = names.length > 4 ? `${names.slice(0, 3).join(', ')}, and ${names.length - 3} more` : names.join(', ');
+  return sentence(id, `${shown} selected`, emphasis(...selectors));
+}
+
+/** The plain text of an answer, as it goes into the chat history. */
+export const paragraphsText = (paragraphs: readonly Paragraph[]): string =>
+  paragraphs.map((paragraph) => paragraph.map((part) => (isSentence(part) ? part.text : part)).join('')).join('\n\n');

--- a/site/src/playground/interactive-data-report-ui.tsx
+++ b/site/src/playground/interactive-data-report-ui.tsx
@@ -1,0 +1,838 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
+import { Check, Plus, Scan, Send, Square, X } from 'lucide-react';
+import type {
+  ChartUpdateOp,
+  FlintInteractionEventDetail,
+  InteractionContext,
+  InteractionDef,
+  InteractiveChartSurface,
+  SemanticElement,
+  SemanticTarget,
+} from 'flint-chart/interactive';
+import { externalInteraction } from 'flint-chart/interactive';
+import type { InteractionDemoFixture } from './interaction-demo-data';
+import {
+  ANSWER_RULES,
+  OPS,
+  abilitiesText,
+  agentChartOf,
+  answerSchema,
+  availablePresets,
+  chartRows,
+  extractParts,
+  levelOf,
+  numeric,
+  opClass,
+  overlap,
+  paragraphsText,
+  parseParts,
+  presetCatalog,
+  presetOf,
+  recordsOf,
+  rowId,
+  rowsInView,
+  rowsOf,
+  selectionSentence,
+  sentenceRows,
+  sentencesOf,
+  toParagraphs,
+  type AgentChart,
+  type ChartRows,
+  type Domain,
+  type Message,
+  type Paragraph,
+  type Preset,
+  type PresetOption,
+  type Row,
+  type RowSet,
+  type SectionSpec,
+  type Sentence,
+} from './interactive-data-report-model';
+import {
+  DEFAULT_OPENAI_BASE_URL,
+  DEFAULT_OPENAI_MODEL,
+  streamChatCompletion,
+  type ChatMessage,
+  type OpenAIConnection,
+} from './openai-chat-client';
+
+/*
+ * The building blocks every section is made of:
+ *   - `useReportChart`, the one binding engine between a chart and its sentences;
+ *   - `ReportSentence` and `ReportParagraph`, the one way a bound sentence is rendered;
+ *   - `useAgentChat` and `AgentPanel`, a chat whose answers are paragraphs of sentences.
+ * A section is one chart, one engine, and one or more text renderers on top.
+ */
+
+/* ======================================================================================
+ * The binding engine
+ * ====================================================================================== */
+
+/*
+ * Retained update layers on the chart:
+ *   - the presets' own updates, keyed by their ids;
+ *   - `report-pin`, the sentence the reader pinned (or the slide on show);
+ *   - `report-preview`, the sentence under the pointer, cleared on leave.
+ * A probe interaction reads the chart's InteractionContext back. The chart state and each
+ * sentence both reduce to data rows, and a sentence lights up by the share of rows in common.
+ */
+const PREVIEW_ID = 'report-preview';
+const PIN_ID = 'report-pin';
+const PROBE_ID = 'report-probe';
+const READ_GUARD = { minVisibleFraction: 0.02, maxVisibleFraction: 1, overscrollFraction: 0 };
+
+interface Viewport {
+  x?: Domain;
+  y?: Domain;
+}
+
+interface ChartSnapshot {
+  selected: readonly SemanticElement[];
+  viewport?: Viewport;
+}
+
+interface ProbePayload {
+  receive: (context: InteractionContext) => void;
+}
+
+function toDomain(value: readonly [unknown, unknown] | undefined): Domain | undefined {
+  if (!value) return undefined;
+  const [start, end] = value.map((bound) => Number(numeric(bound)));
+  return Number.isFinite(start) && Number.isFinite(end) ? [Math.min(start, end), Math.max(start, end)] : undefined;
+}
+
+function snapshotOf(context: InteractionContext): ChartSnapshot {
+  const navigation = context.resolveNavigation?.(
+    { phase: 'commit', operation: 'pan', axes: 'xy', delta: { x: 0, y: 0 } },
+    READ_GUARD,
+  );
+  const viewportRange = navigation
+    ? { x: toDomain(navigation.value.x), y: toDomain(navigation.value.y) }
+    : undefined;
+  return {
+    selected: [...context.selected],
+    viewport: viewportRange && (viewportRange.x || viewportRange.y) ? viewportRange : undefined,
+  };
+}
+
+export interface ReportChart {
+  /** Spread onto an `InteractionDemoChart`. */
+  chartProps: {
+    fixture: InteractionDemoFixture;
+    interactions: InteractionDef[];
+    chartId: string;
+    onSurface: (surface: InteractiveChartSurface | null) => void;
+    onSemanticEvent: (detail: FlintInteractionEventDetail) => void;
+  };
+  rows: ChartRows;
+  ready: boolean;
+  hoveredId: string | null;
+  pinnedId: string | null;
+  /** Sentence -> chart, preview layer: on while the pointer is on the sentence. */
+  preview: (id: string) => void;
+  endPreview: (id: string) => void;
+  /** Sentence -> chart, pin layer. A pin replaces the chart's own state; pinning again unpins. */
+  pin: (item: Sentence) => Promise<void>;
+  /** Shows exactly one sentence, or none, in a single render: what a slide does. */
+  show: (item: Sentence | null) => Promise<void>;
+  unpin: () => Promise<void>;
+  /** Drops the pin and the presets' own state. */
+  clear: () => void;
+  /** Chart -> sentence: the underline classes for a sentence. */
+  classFor: (item: Sentence) => string;
+  /** The records the chart points at right now: what leaves the chart. */
+  selected: Row[];
+}
+
+/**
+ * Binds one chart to a list of sentences. The list may grow while the chart is mounted:
+ * the event handler reads it through a ref, so the chart is built once per section.
+ */
+export function useReportChart(
+  spec: SectionSpec,
+  sentences: readonly Sentence[],
+  onJump?: (item: Sentence) => void,
+): ReportChart {
+  const surfaceRef = useRef<InteractiveChartSurface | null>(null);
+  const previewTimer = useRef<number | undefined>(undefined);
+  const pinnedRef = useRef<string | null>(null);
+  const [ready, setReady] = useState(false);
+  const [pinnedId, setPinnedId] = useState<string | null>(null);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [snapshot, setSnapshot] = useState<ChartSnapshot | null>(null);
+  const [annotated, setAnnotated] = useState<SemanticTarget | null>(null);
+  const [hoverTarget, setHoverTarget] = useState<SemanticTarget | null>(null);
+
+  const rows = useMemo(() => chartRows(spec.fixture.input), [spec.fixture]);
+  const byId = useMemo(() => new Map(sentences.map((item) => [item.id, item])), [sentences]);
+  // The rows each sentence points at, fixed for the life of the sentence.
+  const rowsBySentence = useMemo(() => new Map(sentences.map((item) => [item.id, sentenceRows(item, rows)])), [rows, sentences]);
+  const presetOps = useMemo(() => new Map(spec.presets.map((entry) => [entry.def.id, entry.op])), [spec.presets]);
+
+  const latest = useRef({ rows, sentences, rowsBySentence, presetOps, onJump });
+  latest.current = { rows, sentences, rowsBySentence, presetOps, onJump };
+
+  const interactions = useMemo<InteractionDef[]>(() => [
+    ...spec.presets.map((entry) => entry.def),
+    externalInteraction<ProbePayload>({
+      id: PROBE_ID,
+      handle: (payload, context) => {
+        payload.receive(context);
+        return null;
+      },
+    }),
+  ], [spec.presets]);
+
+  const probe = useCallback(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    void surface.dispatch(PROBE_ID, {
+      receive: (context: InteractionContext) => setSnapshot(snapshotOf(context)),
+    } satisfies ProbePayload).catch(() => undefined);
+  }, []);
+
+  // The runtime applies a preset's update after it emits the event, so read back twice.
+  const probeSoon = useCallback(() => {
+    window.setTimeout(probe, 40);
+    window.setTimeout(probe, 240);
+  }, [probe]);
+
+  const probeThrottled = useCallback(() => {
+    if (previewTimer.current !== undefined) return;
+    previewTimer.current = window.setTimeout(() => {
+      previewTimer.current = undefined;
+      probe();
+    }, 120);
+  }, [probe]);
+
+  useEffect(() => () => {
+    if (previewTimer.current !== undefined) window.clearTimeout(previewTimer.current);
+  }, []);
+
+  const onSurface = useCallback((surface: InteractiveChartSurface | null) => {
+    surfaceRef.current = surface;
+    setReady(false);
+    if (surface) {
+      void surface.ready.then(() => {
+        setReady(true);
+        probeSoon();
+      }).catch(() => undefined);
+    }
+  }, [probeSoon]);
+
+  const setPinned = useCallback((id: string | null) => {
+    pinnedRef.current = id;
+    setPinnedId(id);
+  }, []);
+
+  const unpin = useCallback(async () => {
+    setPinned(null);
+    await surfaceRef.current?.clearUpdate(PIN_ID);
+    probeSoon();
+  }, [probeSoon, setPinned]);
+
+  // One setUpdates call replaces every retained layer in a single render: the chart's own
+  // state goes and the sentence lands, so a CSS transition runs straight from one to the other.
+  const show = useCallback(async (item: Sentence | null) => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    setAnnotated(null);
+    if (!item) {
+      setPinned(null);
+      await surface.setUpdates([]);
+    } else {
+      await surface.setUpdates([{ id: PIN_ID, ops: item.ops }]);
+      setPinned(item.id);
+    }
+    probeSoon();
+  }, [probeSoon, setPinned]);
+
+  const pin = useCallback(async (item: Sentence) => {
+    if (pinnedRef.current === item.id) await unpin();
+    else await show(item);
+  }, [show, unpin]);
+
+  const clear = useCallback(() => {
+    void unpin();
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    for (const entry of spec.presets) void surface.clearUpdate(entry.def.id);
+    setAnnotated(null);
+    probeSoon();
+  }, [probeSoon, spec.presets, unpin]);
+
+  // Sentence -> chart, preview layer.
+  useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    const item = hoveredId ? byId.get(hoveredId) : undefined;
+    if (!item) {
+      // The preview emphasizes rows, so the chart counts them as its own state while it is
+      // up. Read the chart back once the layer goes, or the last reading stays polluted.
+      void surface.clearUpdate(PREVIEW_ID).then(probeSoon);
+      return;
+    }
+    void surface.applyUpdate({ id: PREVIEW_ID, ops: item.ops });
+  }, [byId, hoveredId, probeSoon]);
+
+  const preview = useCallback((id: string) => setHoveredId(id), []);
+  const endPreview = useCallback((id: string) => setHoveredId((current) => (current === id ? null : current)), []);
+
+  // Chart -> sentences.
+  const onSemanticEvent = useCallback((detail: FlintInteractionEventDetail) => {
+    const { event, interactionId } = detail;
+    const { rows: chart, sentences: items, rowsBySentence: rowsBy, presetOps: ops, onJump: jump } = latest.current;
+    const op = ops.get(interactionId);
+    if (event.phase === 'preview' || event.phase === 'start') {
+      if (event.target !== undefined) setHoverTarget(event.target);
+      if (op === 'set-viewport') probeThrottled();
+      return;
+    }
+    if (event.phase === 'cancel') {
+      setHoverTarget(null);
+      return;
+    }
+    setHoverTarget(null);
+    const target = event.target ?? null;
+    const levelFor = (item: Sentence, elements: readonly SemanticElement[]) =>
+      levelOf(overlap(rowsBy.get(item.id) ?? new Set<string>(), rowsOf(elements, chart)));
+    if (event.action.startsWith('double-activate-') && target) {
+      const best = items.find((item) => levelFor(item, target.elements) === 'full')
+        ?? items.find((item) => levelFor(item, target.elements) === 'partial');
+      if (best) {
+        void pin(best);
+        jump?.(best);
+        return;
+      }
+    }
+    // The reader's own hand owns the chart, so a gesture drops the pin. The sentence stays
+    // lit when the gesture points at its rows, by the same overlap as any other state.
+    if (op && pinnedRef.current) void unpin();
+    if (op === 'set-annotation') setAnnotated(target);
+    probeSoon();
+  }, [pin, probeSoon, probeThrottled, unpin]);
+
+  // The rows the chart points at, per slice of its state. A sentence compares with the slices its ops speak about.
+  const stateRowsByOp = useMemo<Partial<Record<ChartUpdateOp['op'], RowSet>>>(() => ({
+    'set-style': rowsOf(snapshot?.selected ?? [], rows),
+    'set-annotation': rowsOf(annotated?.elements ?? [], rows),
+    'set-viewport': new Set(snapshot?.viewport ? rowsInView(rows, snapshot.viewport).map(rowId) : []),
+  }), [annotated, rows, snapshot]);
+  const hoverRows = useMemo(() => (hoverTarget ? rowsOf(hoverTarget.elements, rows) : null), [hoverTarget, rows]);
+  const selected = useMemo(() => recordsOf(snapshot?.selected ?? [], rows), [rows, snapshot]);
+
+  // A sentence compares with the slices of the chart state its ops speak about.
+  const classFor = useCallback((item: Sentence): string => {
+    const classes = ['idr-fragment'];
+    const own = rowsBySentence.get(item.id) ?? sentenceRows(item, rows);
+    const state = new Set<string>();
+    for (const op of item.ops) for (const id of stateRowsByOp[op.op] ?? []) state.add(id);
+    const level = levelOf(overlap(own, state));
+    if (pinnedId === item.id || level === 'full') classes.push('is-active');
+    else if (level === 'partial') classes.push('is-related');
+    const hovered = hoverRows ? levelOf(overlap(own, hoverRows)) : null;
+    if (hoveredId === item.id || hovered === 'full') classes.push('is-preview');
+    else if (hovered === 'partial') classes.push('is-preview-related');
+    return classes.join(' ');
+  }, [hoverRows, hoveredId, pinnedId, rows, rowsBySentence, stateRowsByOp]);
+
+  return {
+    chartProps: { fixture: spec.fixture, interactions, chartId: `report-${spec.id}`, onSurface, onSemanticEvent },
+    rows,
+    ready,
+    hoveredId,
+    pinnedId,
+    preview,
+    endPreview,
+    pin,
+    show,
+    unpin,
+    clear,
+    classFor,
+    selected,
+  };
+}
+
+/* ======================================================================================
+ * Rendering sentences
+ * ====================================================================================== */
+
+/** The element id of a sentence on the page, for jumps and pins from the chart. */
+export const sentenceElementId = (sectionId: string, item: Sentence): string => `${sectionId}-${item.id}`;
+
+interface ReportSentenceProps {
+  sentence: Sentence;
+  report: ReportChart;
+  sectionId: string;
+  /** Rendered right after the sentence, for example a button that saves it. */
+  action?: ReactNode;
+}
+
+/** One bound sentence: hover to preview, click to pin, lit by the chart state. */
+export function ReportSentence({ sentence: item, report, sectionId, action }: ReportSentenceProps) {
+  return (
+    <>
+      <span
+        id={sentenceElementId(sectionId, item)}
+        role="button"
+        tabIndex={0}
+        className={report.classFor(item)}
+        aria-pressed={report.pinnedId === item.id}
+        onMouseEnter={() => report.preview(item.id)}
+        onMouseLeave={() => report.endPreview(item.id)}
+        onFocus={() => report.preview(item.id)}
+        onBlur={() => report.endPreview(item.id)}
+        onClick={() => void report.pin(item)}
+        onKeyDown={(keyboardEvent) => {
+          if (keyboardEvent.key !== 'Enter' && keyboardEvent.key !== ' ') return;
+          keyboardEvent.preventDefault();
+          void report.pin(item);
+        }}
+      >
+        {item.text}
+      </span>
+      {action}
+    </>
+  );
+}
+
+function sentenceOpsTitle(item: Sentence): string {
+  return [...new Set(item.ops.map((op) => OPS[op.op === 'set-viewport' || op.op === 'set-order' || op.op === 'set-annotation' ? op.op : 'set-style'].title))].join(' + ');
+}
+
+interface ReportParagraphProps {
+  parts: Paragraph;
+  report: ReportChart;
+  sectionId: string;
+  actionFor?: (item: Sentence) => ReactNode;
+}
+
+/** A paragraph of plain text and bound sentences. */
+export function ReportParagraph({ parts, report, sectionId, actionFor }: ReportParagraphProps) {
+  return (
+    <p>
+      {parts.map((part, index) => (typeof part === 'string'
+        ? <span key={index}>{part}</span>
+        : <ReportSentence key={part.id} sentence={part} report={report} sectionId={sectionId} action={actionFor?.(part)} />))}
+    </p>
+  );
+}
+
+/** A mounted interaction, as a chip; with `onRemove`, the chip has a cross that unmounts it. */
+export function PresetChip({ preset: entry, size = 13, onRemove }: { preset: Preset; size?: number; onRemove?: () => void }) {
+  const Icon = entry.icon;
+  return (
+    <span className={`idr-chip-interaction ${opClass(entry.op)}${onRemove ? ' is-editable' : ''}`} title={`${entry.def.id} · ${OPS[entry.op].title}`}>
+      <Icon size={size} strokeWidth={1.8} aria-hidden="true" />
+      <span>{entry.label}</span>
+      {onRemove && (
+        <button type="button" className="idr-chip-remove" onClick={onRemove} aria-label={`Remove ${entry.label}`} title="Remove this interaction">
+          <X size={10} aria-hidden="true" />
+        </button>
+      )}
+    </span>
+  );
+}
+
+/* ---------- editable presets ---------- */
+
+export interface EditablePresets {
+  presets: Preset[];
+  /** The options that can still be mounted without a gesture conflict. */
+  options: PresetOption[];
+  add: (id: string) => void;
+  remove: (id: string) => void;
+}
+
+/** The presets of a section as state: it starts from the spec, and the reader edits it. */
+export function usePresets(spec: SectionSpec): EditablePresets {
+  const catalog = useMemo(() => presetCatalog(spec.fixture), [spec.fixture]);
+  const [presets, setPresets] = useState<Preset[]>(spec.presets);
+  const options = useMemo(() => availablePresets(catalog, presets), [catalog, presets]);
+  const add = useCallback((id: string) => {
+    const option = catalog.find((candidate) => candidate.id === id);
+    if (option) setPresets((current) => (current.some((entry) => entry.def.id === id) ? current : [...current, presetOf(option)]));
+  }, [catalog]);
+  const remove = useCallback((id: string) => setPresets((current) => current.filter((entry) => entry.def.id !== id)), []);
+  return { presets, options, add, remove };
+}
+
+/** The chips of the mounted presets, each with a cross, and a menu that adds one more. */
+export function PresetEditor({ editable, label = 'Interactions on this chart' }: { editable: EditablePresets; label?: string }) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLLIElement>(null);
+
+  // A click outside or Escape closes the menu.
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (event: MouseEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKey = (event: globalThis.KeyboardEvent) => { if (event.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const none = editable.options.length === 0;
+  return (
+    <ul className="idr-preset-list" aria-label={label}>
+      {editable.presets.map((entry) => (
+        <li key={entry.def.id}><PresetChip preset={entry} onRemove={() => editable.remove(entry.def.id)} /></li>
+      ))}
+      <li className="idr-preset-add" ref={menuRef}>
+        <button
+          type="button"
+          className={`idr-preset-add-toggle${open ? ' is-open' : ''}`}
+          onClick={() => setOpen((current) => !current)}
+          disabled={none}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          title={none ? 'Every interaction that fits this chart is mounted, or would conflict with one' : 'Add an interaction'}
+        >
+          <Plus size={11} strokeWidth={2.2} aria-hidden="true" /> Add
+        </button>
+        {open && (
+          <div className="idr-preset-menu" role="menu" aria-label="Interactions to add">
+            {editable.options.map((option) => {
+              const Icon = option.icon;
+              return (
+                <button key={option.id} type="button" role="menuitem" onClick={() => { editable.add(option.id); setOpen(false); }}>
+                  <Icon size={13} strokeWidth={1.8} aria-hidden="true" className={`idr-preset-menu-icon ${opClass(option.op)}`} />
+                  <span>{option.label}</span>
+                  <span className="idr-preset-menu-kind">{OPS[option.op].title}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </li>
+    </ul>
+  );
+}
+
+/* ======================================================================================
+ * The agent
+ * ====================================================================================== */
+
+/** The model configuration lives in site/.env.local; see site/.env.example. */
+export function envConnection(): OpenAIConnection {
+  const env = import.meta.env;
+  return {
+    apiKey: env.VITE_OPENAI_API_KEY?.trim() ?? '',
+    model: env.VITE_OPENAI_MODEL?.trim() || DEFAULT_OPENAI_MODEL,
+    baseUrl: env.VITE_OPENAI_BASE_URL?.trim() || DEFAULT_OPENAI_BASE_URL,
+  };
+}
+
+export const CONNECTION = envConnection();
+
+export function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+const SYSTEM_PROMPT = [
+  'You are a data analyst embedded next to an interactive chart.',
+  'The user selects marks on the chart with a gesture. Every question arrives with a description of the chart, the selected records, and the other records for comparison.',
+  'Treat the selection as the subject of the question unless the user says otherwise. Use concrete numbers from the attached data and never invent values that are not in it.',
+  ...ANSWER_RULES,
+].join(' ');
+
+function chartDescription(spec: SectionSpec, chart: AgentChart): string[] {
+  const input = spec.fixture.input;
+  const chartSpec = input.chart_spec as { title?: string; chartType: string; encodings: Record<string, unknown> };
+  const types = (input.semantic_types ?? {}) as Record<string, string>;
+  return [
+    `Chart: "${chartSpec.title ?? spec.fixture.title}" (${chartSpec.chartType}). Source: ${spec.fixture.source}.`,
+    `Encodings: ${Object.entries(chartSpec.encodings).map(([channel, field]) => `${channel} = ${String(field)}`).join(', ')}.`,
+    `Fields: ${Object.entries(types).map(([field, type]) => `${field} (${type})`).join(', ')}.`,
+    `Update abilities on this chart: ${abilitiesText(chart)}. Other ops are unsupported here.`,
+  ];
+}
+
+/** Everything the model gets with a question: the chart, the selection, and the other rows. */
+function contextText(spec: SectionSpec, chart: AgentChart, selected: readonly Row[]): string {
+  const selectedIds = new Set(selected.map(rowId));
+  const rest = chart.rows.filter((row) => !selectedIds.has(rowId(row)));
+  const lines = chartDescription(spec, chart);
+  lines.push(`The chart shows ${chart.rows.length} records.`);
+  if (selected.length > 0) {
+    lines.push(`The user selected ${selected.length} of them.`, 'Selected records (JSON):', JSON.stringify(selected));
+    if (rest.length > 0) lines.push('The other records, for comparison (JSON):', JSON.stringify(rest));
+  } else {
+    lines.push('The user has not selected anything, so the question is about the whole chart.', 'All records (JSON):', JSON.stringify(chart.rows));
+  }
+  return lines.join('\n');
+}
+
+/**
+ * A message in the chat. What the reader sees is the paragraphs, on both sides; a question
+ * ends with a sentence for the selection that went with it, when there was one.
+ */
+export interface ChatTurn extends Message {
+  id: string;
+  /** Plain text of the paragraphs, as kept in the API history. */
+  text: string;
+  /** The full user message as sent to the API, including the data context. */
+  apiContent?: string;
+  pending?: boolean;
+  error?: string;
+}
+
+let turnCounter = 0;
+const nextTurnId = (): string => {
+  turnCounter += 1;
+  return `turn-${turnCounter}`;
+};
+
+export interface AgentChat {
+  turns: ChatTurn[];
+  /** Every bound sentence in the chat, for the chart to match against. */
+  sentences: Sentence[];
+  chart: AgentChart;
+  ask: (question: string) => Promise<void>;
+  stop: () => void;
+  busy: boolean;
+  draft: string;
+  setDraft: (draft: string) => void;
+  hasKey: boolean;
+}
+
+interface AgentChatOptions {
+  spec: SectionSpec;
+  connection: OpenAIConnection;
+  /** Messages already in the chat when the section mounts, in order, as context for what follows. */
+  opening?: readonly Message[];
+  /** The records the chart points at when the question goes out. */
+  getSelected: () => Row[];
+}
+
+function openingTurns(opening: readonly Message[] = []): ChatTurn[] {
+  return opening.map((message) => ({ ...message, id: nextTurnId(), text: paragraphsText(message.paragraphs) }));
+}
+
+/** The chat beside one chart. Answers arrive as paragraphs of sentences bound to that chart. */
+export function useAgentChat({ spec, connection, opening, getSelected }: AgentChatOptions): AgentChat {
+  const [turns, setTurns] = useState<ChatTurn[]>(() => openingTurns(opening));
+  const [draft, setDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const chart = useMemo(() => agentChartOf(spec.fixture, spec.presets), [spec.fixture, spec.presets]);
+  const sentences = useMemo(() => turns.flatMap((turn) => sentencesOf(turn.paragraphs)), [turns]);
+
+  const updateTurn = useCallback((id: string, patch: Partial<ChatTurn>) => {
+    setTurns((previous) => previous.map((turn) => (turn.id === id ? { ...turn, ...patch } : turn)));
+  }, []);
+
+  const ask = useCallback(async (question: string) => {
+    const trimmed = question.trim();
+    if (!trimmed || busy || !connection.apiKey) return;
+    const selected = getSelected();
+    const apiContent = `${trimmed}\n\n---\nContext from the chart:\n${contextText(spec, chart, selected)}`;
+    const userId = nextTurnId();
+    const about = selectionSentence(`${userId}-selection`, selected, chart);
+    const userTurn: ChatTurn = {
+      id: userId,
+      from: 'user',
+      text: trimmed,
+      apiContent,
+      paragraphs: [about ? [trimmed, ' · ', about] : [trimmed]],
+    };
+    const assistantTurn: ChatTurn = { id: nextTurnId(), from: 'agent', text: '', paragraphs: [], pending: true };
+    const history: ChatMessage[] = [
+      { role: 'system', content: SYSTEM_PROMPT },
+      ...turns.flatMap<ChatMessage>((turn) => {
+        if (turn.from === 'user') return [{ role: 'user', content: turn.apiContent ?? turn.text }];
+        return turn.text ? [{ role: 'assistant', content: turn.text }] : [];
+      }),
+      { role: 'user', content: apiContent },
+    ];
+    setTurns((previous) => [...previous, userTurn, assistantTurn]);
+    setDraft('');
+    setBusy(true);
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const receive = (parts: ReturnType<typeof extractParts>, pending: boolean) => {
+      const paragraphs = toParagraphs(parts, assistantTurn.id, chart);
+      updateTurn(assistantTurn.id, { paragraphs, text: paragraphsText(paragraphs), pending });
+    };
+    try {
+      const result = await streamChatCompletion({
+        connection,
+        messages: history,
+        responseFormat: answerSchema('chart_answer', false),
+        signal: controller.signal,
+        onText: (_delta, full) => {
+          const parts = extractParts(full);
+          if (parts.length > 0) receive(parts, true);
+        },
+      });
+      let parts: ReturnType<typeof extractParts>;
+      try {
+        parts = parseParts(result.content);
+      } catch {
+        parts = extractParts(result.content);
+        if (parts.length === 0 && result.content.trim()) parts = [{ text: result.content, chart: null, updates: [] }];
+      }
+      receive(parts, false);
+    } catch (error) {
+      const message = controller.signal.aborted ? 'Stopped.' : error instanceof Error ? error.message : String(error);
+      updateTurn(assistantTurn.id, { pending: false, error: message });
+    } finally {
+      abortRef.current = null;
+      setBusy(false);
+    }
+  }, [busy, chart, connection, getSelected, spec, turns, updateTurn]);
+
+  const stop = useCallback(() => abortRef.current?.abort(), []);
+
+  return { turns, sentences, chart, ask, stop, busy, draft, setDraft, hasKey: connection.apiKey.length > 0 };
+}
+
+interface AgentPanelProps {
+  chat: AgentChat;
+  report: ReportChart;
+  sectionId: string;
+  connection: OpenAIConnection;
+  /** When given, every bound sentence in an answer gets a button that adds it to the story, or takes it out. */
+  onAdopt?: (item: Sentence) => void;
+  /** Ids of the chat sentences already in the story; their button shows a check. */
+  adoptedIds?: ReadonlySet<string>;
+}
+
+/** Always two, so the panel keeps its height when a selection comes and goes. */
+function promptsFor(hasSelection: boolean): [string, string] {
+  return hasSelection
+    ? ['Summarize the selection in a few sentences.', 'How does this selection compare with the rest of the chart?']
+    : ['Describe the main pattern in this chart.', 'Which records stand out, and why?'];
+}
+
+/** The chat: turns, suggested questions, the selection chip, and the composer. */
+export function AgentPanel({ chat, report, sectionId, connection, onAdopt, adoptedIds }: AgentPanelProps) {
+  const messagesRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const container = messagesRef.current;
+    if (container) container.scrollTop = container.scrollHeight;
+  }, [chat.turns]);
+
+  const handleComposerKey = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      void chat.ask(chat.draft);
+    }
+  }, [chat]);
+
+  const selectedCount = report.selected.length;
+  const actionFor = onAdopt
+    ? (item: Sentence) => {
+      const added = adoptedIds?.has(item.id) ?? false;
+      return (
+        <button
+          type="button"
+          className={`idr-chat-adopt${added ? ' is-added' : ''}`}
+          title={added ? 'In your story · press to take it out' : 'Add this sentence to your story'}
+          aria-label={added ? 'Take this sentence out of your story' : 'Add this sentence to your story'}
+          aria-pressed={added}
+          onClick={() => onAdopt(item)}
+        >
+          {added ? <Check size={10} strokeWidth={2.5} aria-hidden="true" /> : '+'}
+        </button>
+      );
+    }
+    : undefined;
+
+  return (
+    <section className="it-detail-panel idr-chat-agent-panel" aria-label="Agent">
+      <div className="idr-chat-agent-head">
+        <h3 className="it-component-title">Agent</h3>
+        <span>{connection.model} via {hostOf(connection.baseUrl)}</span>
+      </div>
+
+      <div className="idr-chat-messages" ref={messagesRef}>
+        {chat.turns.length === 0 ? (
+          <div className="idr-chat-messages-empty">
+            <p>Select part of the chart, then ask. The selection goes with the question, and the answer's underlined sentences are bound to the chart.</p>
+            {!chat.hasKey && <p className="idr-chat-warning">Set VITE_OPENAI_API_KEY in site/.env.local to enable the agent.</p>}
+          </div>
+        ) : chat.turns.map((turn) => (
+          <div key={turn.id} className={`idr-chat-turn idr-chat-turn-${turn.from === 'user' ? 'user' : 'assistant'}`}>
+            {turn.from === 'user' ? (
+              <div className="idr-chat-bubble">
+                {turn.paragraphs.map((paragraph, index) => (
+                  <ReportParagraph key={index} parts={paragraph} report={report} sectionId={sectionId} />
+                ))}
+              </div>
+            ) : (
+              <>
+                <div className="idr-chat-bubble idr-chat-answer">
+                  {turn.paragraphs.length > 0
+                    ? turn.paragraphs.map((paragraph, index) => (
+                      <ReportParagraph key={index} parts={paragraph} report={report} sectionId={sectionId} actionFor={actionFor} />
+                    ))
+                    : turn.pending && <span className="idr-chat-thinking">Thinking…</span>}
+                  {turn.pending && turn.paragraphs.length > 0 && <span className="idr-chat-cursor" aria-hidden="true" />}
+                </div>
+                {turn.error && <div className="idr-chat-error">{turn.error}</div>}
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="idr-chat-suggestions">
+        {promptsFor(selectedCount > 0).map((prompt) => (
+          <button key={prompt} type="button" disabled={chat.busy || !chat.hasKey} onClick={() => void chat.ask(prompt)}>
+            {prompt}
+          </button>
+        ))}
+      </div>
+
+      <div className="idr-chat-context-row" aria-live="polite">
+        {selectedCount > 0 ? (
+          <span className="idr-chat-context-chip is-selection">
+            <Scan size={11} aria-hidden="true" />
+            {`Selected: ${selectedCount} of ${report.rows.rows.length} records go as context`}
+            <button type="button" onClick={report.clear} aria-label="Clear the selection" title="Clear">×</button>
+          </span>
+        ) : (
+          <span className="idr-chat-context-chip">
+            <Scan size={11} aria-hidden="true" />
+            Nothing selected · all {report.rows.rows.length} records go as context
+          </span>
+        )}
+      </div>
+      <form
+        className="idr-chat-composer"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void chat.ask(chat.draft);
+        }}
+      >
+        <textarea
+          rows={2}
+          placeholder={selectedCount > 0 ? `Ask about the ${selectedCount} selected…` : 'Ask about this chart…'}
+          value={chat.draft}
+          onChange={(event) => chat.setDraft(event.target.value)}
+          onKeyDown={handleComposerKey}
+          disabled={chat.busy}
+        />
+        {chat.busy ? (
+          <button type="button" className="idr-chat-send" onClick={chat.stop} title="Stop">
+            <Square size={13} aria-hidden="true" /> Stop
+          </button>
+        ) : (
+          <button type="submit" className="idr-chat-send" disabled={!chat.draft.trim() || !chat.hasKey} title="Send">
+            <Send size={13} aria-hidden="true" /> Send
+          </button>
+        )}
+      </form>
+    </section>
+  );
+}

--- a/site/src/playground/interactive-data-report.css
+++ b/site/src/playground/interactive-data-report.css
@@ -1,0 +1,713 @@
+/* The heading and the sections share one left edge. */
+.idr-page .dev-page-heading,
+.idr-page .it-examples {
+  width: min(100%, 1040px);
+}
+
+.idr-workspace {
+  grid-template-columns: minmax(300px, 0.9fr) minmax(0, 1.1fr);
+  align-items: start;
+  /* The shared workspace clips its content, which would also disable the sticky chart panel. */
+  overflow: visible;
+}
+
+/* A long report scrolls past the chart, so the chart stays in view below the sticky dev header. */
+.idr-workspace .it-chart-panel {
+  position: sticky;
+  top: 60px;
+  min-height: 320px;
+}
+
+.idr-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.idr-preset-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 4px;
+  max-width: 360px;
+  margin: 2px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idr-preset-list li {
+  display: contents;
+}
+
+/* The same icon-and-label combo as the interaction gallery's mode rail, shown as a static chip. */
+.idr-chip-interaction {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid #d7dde1;
+  border-radius: 12px;
+  padding: 3px 9px 3px 7px;
+  color: #4e5961;
+  background: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.idr-chip-interaction svg {
+  flex: none;
+  color: #176f58;
+}
+
+.idr-chip-interaction.idr-op-viewport svg { color: #5b7fb5; }
+.idr-chip-interaction.idr-op-order svg { color: #c0924a; }
+.idr-chip-interaction.idr-op-annotation svg { color: #4d9a74; }
+
+.idr-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.idr-report-panel {
+  gap: 0;
+}
+
+.idr-report {
+  margin-top: 14px;
+  color: #3b454c;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 13.5px;
+  line-height: 1.85;
+}
+
+.idr-report p {
+  margin: 0 0 12px;
+}
+
+.idr-fragment {
+  display: inline;
+  border-bottom: 1px dotted #b3bcc2;
+  border-radius: 2px;
+  padding: 1px 1px;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.idr-fragment:hover,
+.idr-fragment.is-preview {
+  border-bottom: 1px solid var(--it-accent);
+  color: #0f5b47;
+  background: #eef7f3;
+}
+
+.idr-fragment.is-preview-related {
+  border-bottom: 1px dashed var(--it-accent);
+  background: #f5faf8;
+}
+
+.idr-fragment.is-related {
+  border-bottom: 1px solid #9cc9b9;
+  background: #f3f8f6;
+}
+
+.idr-fragment.is-active {
+  border-bottom: 1px solid #176f58;
+  color: #0f5b47;
+  background: #d8efe5;
+}
+
+.idr-fragment.is-active.is-preview {
+  background: #c9e8db;
+}
+
+.idr-fragment:focus-visible {
+  outline: 2px solid var(--it-accent);
+  outline-offset: 1px;
+}
+
+.idr-key {
+  width: min(100%, 1040px);
+  margin-top: 10px;
+  color: #7a858d;
+  font-size: 10.5px;
+  line-height: 1.5;
+}
+
+.idr-key-intro {
+  max-width: 880px;
+  margin: 0 0 8px;
+  color: #4e5961;
+}
+
+.idr-key-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px 18px;
+  margin: 0;
+}
+
+.idr-key-item dt {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #4e5961;
+  font-weight: 600;
+}
+
+.idr-key-item dd {
+  margin: 3px 0 0;
+}
+
+.idr-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 9px;
+  border-bottom: 1px solid #b3bcc2;
+  border-radius: 2px;
+  background: transparent;
+}
+
+.idr-swatch.is-preview { border-bottom-color: var(--it-accent); background: #eef7f3; }
+.idr-swatch.is-active { border-bottom-color: #176f58; background: #d8efe5; }
+.idr-swatch.is-related { border-bottom-color: #9cc9b9; background: #f3f8f6; }
+
+@media (max-width: 760px) {
+  .idr-workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .idr-section-header {
+    flex-direction: column;
+  }
+
+  .idr-preset-list {
+    justify-content: flex-start;
+    max-width: none;
+  }
+}
+
+/* ---------- figures beyond the report panel ---------- */
+
+/* ---------- slides ---------- */
+
+.idr-slides {
+  grid-template-columns: minmax(300px, 0.9fr) minmax(0, 1.1fr);
+  align-items: stretch;
+  min-height: 400px;
+}
+
+/* The left panel scrolls sideways one slide at a time; the controls stay put under it. */
+.idr-slide-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  border-right: 1px solid #e9edef;
+}
+
+.idr-slide-scroller {
+  display: flex;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: thin;
+}
+
+.idr-slide {
+  display: flex;
+  flex: 0 0 100%;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+  height: 100%;
+  padding: 22px;
+  box-sizing: border-box;
+  opacity: 0.45;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  transition: opacity 260ms ease;
+}
+
+.idr-slide.is-active {
+  opacity: 1;
+}
+
+.idr-slide-count {
+  color: #7a858d;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.idr-slide-sentence {
+  margin: 0;
+  color: #0f5b47;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(18px, 1.8vw, 23px);
+  line-height: 1.35;
+  letter-spacing: -0.005em;
+  text-wrap: balance;
+}
+
+.idr-control {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  border: 1px solid transparent;
+  border-radius: 50%;
+  padding: 0;
+  color: #4e5961;
+  background: transparent;
+  place-items: center;
+  cursor: pointer;
+}
+
+.idr-control:hover:not(:disabled) {
+  border-color: #d7dde1;
+  color: #0f5b47;
+  background: #eef7f3;
+}
+
+.idr-control:disabled {
+  color: #c3cad0;
+  cursor: default;
+}
+
+.idr-control.is-playing {
+  color: #fff;
+  background: #176f58;
+}
+
+.idr-slide-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  border-top: 1px solid #e9edef;
+  padding: 10px 22px 12px;
+}
+
+.idr-dots {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 0 4px;
+  padding: 0;
+  list-style: none;
+}
+
+.idr-dots button {
+  display: block;
+  width: 6px;
+  height: 6px;
+  border: 0;
+  border-radius: 50%;
+  padding: 0;
+  background: #d7dde1;
+  cursor: pointer;
+  transition: background-color 160ms ease, transform 160ms ease;
+}
+
+.idr-dots li.is-done button {
+  background: #9cc9b9;
+}
+
+.idr-dots li.is-active button {
+  background: #176f58;
+  transform: scale(1.35);
+}
+
+.idr-slide-chart {
+  padding: 16px;
+}
+
+/*
+ * Vega keeps one SVG node per mark item and rewrites its attributes on each update, so a
+ * transition on those nodes carries a mark from one slide's state to the next.
+ */
+.idr-animated .idr-slide-chart svg.marks path {
+  transition: d 500ms ease, transform 500ms ease, opacity 500ms ease;
+}
+
+.idr-animated .idr-slide-chart svg.marks g,
+.idr-animated .idr-slide-chart svg.marks text {
+  transition: transform 500ms ease, opacity 500ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .idr-animated .idr-slide-chart svg.marks path,
+  .idr-animated .idr-slide-chart svg.marks g,
+  .idr-animated .idr-slide-chart svg.marks text,
+  .idr-dots button {
+    transition: none;
+  }
+}
+
+/* ---------- narrow screens ---------- */
+
+@media (max-width: 760px) {
+  .idr-slides,
+  .idr-story {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .idr-slide-panel {
+    max-height: 60vh;
+    border-right: 0;
+    border-bottom: 1px solid #e9edef;
+  }
+}
+
+/* ---------- the story section: the chart on the left, the story on the right ---------- */
+
+.idr-story {
+  grid-template-columns: minmax(0, 1.1fr) minmax(300px, 0.9fr);
+  align-items: stretch;
+  min-height: 400px;
+}
+
+.idr-story-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  border-left: 1px solid #e9edef;
+}
+
+.idr-story-panel .idr-slide-panel {
+  flex: 1 1 0;
+  min-height: 0;
+  border-right: 0;
+}
+
+/* The story as rows: a grip, the sentence, a pencil. */
+.idr-story-rows {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  padding: 10px 14px 22px 10px;
+  list-style: none;
+  color: #3b454c;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 13.5px;
+  line-height: 1.85;
+}
+
+.idr-story-row {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  gap: 6px;
+  align-items: start;
+  border-top: 2px solid transparent;
+  border-bottom: 2px solid transparent;
+  border-radius: 4px;
+  padding: 3px 4px;
+}
+
+.idr-story-row:hover {
+  background: #f7f9f9;
+}
+
+.idr-story-row.is-dragging {
+  opacity: 0.4;
+}
+
+.idr-story-row.is-drop-before {
+  border-top-color: var(--it-accent);
+}
+
+.idr-story-row.is-drop-after {
+  border-bottom-color: var(--it-accent);
+}
+
+.idr-story-text {
+  display: block;
+  min-width: 0;
+}
+
+.idr-grip,
+.idr-edit {
+  display: inline-grid;
+  width: 18px;
+  height: 22px;
+  border: 0;
+  border-radius: 3px;
+  padding: 0;
+  color: #9aa4ab;
+  background: transparent;
+  place-items: center;
+  cursor: pointer;
+}
+
+.idr-grip {
+  cursor: grab;
+}
+
+.idr-grip:active {
+  cursor: grabbing;
+}
+
+.idr-edit {
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.idr-story-row:hover .idr-edit,
+.idr-edit:focus-visible,
+.idr-edit-actions .idr-edit {
+  opacity: 1;
+}
+
+.idr-grip:hover,
+.idr-edit:hover {
+  color: var(--it-accent);
+  background: #eef7f3;
+}
+
+.idr-edit.is-done {
+  color: #fff;
+  background: var(--it-accent);
+}
+
+.idr-edit-actions {
+  display: inline-flex;
+  gap: 2px;
+}
+
+.idr-story-editor {
+  width: 100%;
+  border: 1px dashed var(--it-accent);
+  border-radius: 4px;
+  padding: 4px 6px;
+  color: #0f5b47;
+  background: #fff;
+  font: inherit;
+  line-height: 1.6;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.idr-story-empty {
+  padding: 12px 22px 22px;
+}
+
+/* Paragraph or slides. */
+.idr-format {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  padding: 16px 22px 0;
+}
+
+.idr-format button {
+  border: 0;
+  border-bottom: 2px solid transparent;
+  padding: 0 0 5px;
+  color: var(--it-muted);
+  background: transparent;
+  font: 600 11px/1.3 inherit;
+  cursor: pointer;
+}
+
+.idr-format button.is-active {
+  border-bottom-color: var(--it-accent);
+  color: var(--it-ink);
+}
+
+/* The reader's own sentence, from the chart's selection. */
+.idr-format .idr-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  border: 1px solid var(--it-line);
+  border-radius: 12px;
+  padding: 3px 9px 3px 7px;
+  color: #4e5961;
+  background: #fff;
+  font: 600 10px/1.3 inherit;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background-color 120ms ease;
+}
+
+/* With a selection on the chart the button is live: a solid green border, green text. */
+.idr-format .idr-add:not(:disabled) {
+  border-color: var(--it-accent);
+  color: #0f5b47;
+  background: #eef7f3;
+}
+
+.idr-format .idr-add:hover:not(:disabled) {
+  color: #fff;
+  background: var(--it-accent);
+}
+
+.idr-format .idr-add:disabled {
+  color: #b3bcc2;
+  cursor: default;
+}
+
+.idr-edit.is-delete:hover {
+  color: var(--it-warm);
+  background: #f7eee9;
+}
+
+.idr-warning {
+  margin: 10px 0 0;
+  color: var(--it-warm);
+  font-size: 12px;
+}
+
+.idr-warning code {
+  font-size: 11px;
+}
+
+/* ---------- a question in the chat is a paragraph too; its sentences sit on the green bubble ---------- */
+
+.idr-chat-turn-user .idr-chat-bubble p {
+  margin: 0;
+}
+
+.idr-chat-turn-user .idr-chat-bubble .idr-fragment {
+  border-bottom-color: rgba(255, 255, 255, 0.55);
+  color: inherit;
+  background: transparent;
+}
+
+.idr-chat-turn-user .idr-chat-bubble .idr-fragment:hover,
+.idr-chat-turn-user .idr-chat-bubble .idr-fragment.is-preview,
+.idr-chat-turn-user .idr-chat-bubble .idr-fragment.is-related,
+.idr-chat-turn-user .idr-chat-bubble .idr-fragment.is-active {
+  border-bottom-color: #fff;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+/* A sentence already in the story shows a check instead of the plus. */
+.idr-chat-adopt.is-added {
+  display: inline-grid;
+  border-color: var(--it-accent);
+  color: #fff;
+  background: var(--it-accent);
+}
+
+/* ---------- editable presets: a cross on each chip, a drop box to add one ---------- */
+
+.idr-chip-interaction.is-editable {
+  padding-right: 4px;
+}
+
+.idr-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: 1px;
+  border: 0;
+  border-radius: 50%;
+  padding: 0;
+  color: #9aa4ab;
+  background: transparent;
+  cursor: pointer;
+}
+
+.idr-chip-remove:hover {
+  color: var(--it-warm);
+  background: #f7eee9;
+}
+
+/* The other items are display: contents; this one needs a box to anchor the menu. */
+.idr-preset-list li.idr-preset-add {
+  position: relative;
+  display: inline-flex;
+}
+
+.idr-preset-add-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border: 1px dashed #b9c2c8;
+  border-radius: 12px;
+  padding: 3px 9px 3px 7px;
+  color: #56616a;
+  background: #fff;
+  font: 600 10px/1.3 inherit;
+  line-height: 1.3;
+  cursor: pointer;
+}
+
+.idr-preset-add-toggle:hover:not(:disabled),
+.idr-preset-add-toggle.is-open {
+  border-style: solid;
+  border-color: var(--it-accent);
+  color: #0f5b47;
+  background: #eef7f3;
+}
+
+.idr-preset-add-toggle:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* The menu: one row per interaction, icon then name, the op kind at the end. */
+.idr-preset-menu {
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 210px;
+  border: 1px solid #d7dde1;
+  border-radius: 8px;
+  padding: 5px;
+  background: #fff;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.1);
+}
+
+.idr-preset-menu button {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  border: 0;
+  border-radius: 6px;
+  padding: 6px 8px;
+  color: #3b454c;
+  background: transparent;
+  font: 600 11px/1.3 inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.idr-preset-menu button:hover {
+  background: #f1f5f4;
+  color: #0f5b47;
+}
+
+.idr-preset-menu-icon {
+  color: var(--it-accent);
+}
+
+.idr-preset-menu-icon.idr-op-viewport { color: #5b7fb5; }
+.idr-preset-menu-icon.idr-op-order { color: #c0924a; }
+.idr-preset-menu-icon.idr-op-annotation { color: #4d9a74; }
+
+.idr-preset-menu-kind {
+  color: #9aa4ab;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 10px;
+  font-weight: 400;
+}
+

--- a/site/src/playground/openai-chat-client.ts
+++ b/site/src/playground/openai-chat-client.ts
@@ -1,0 +1,163 @@
+/**
+ * Minimal browser client for the OpenAI chat-completions API with streaming
+ * and tool calls. The demo talks to the API directly from the page, so the key
+ * never leaves the visitor's browser except for the request to the API itself.
+ */
+
+export interface ChatToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+export type ChatMessage =
+  | { role: 'system'; content: string }
+  | { role: 'user'; content: string }
+  | { role: 'assistant'; content: string | null; tool_calls?: ChatToolCall[] }
+  | { role: 'tool'; content: string; tool_call_id: string };
+
+export interface ChatToolDefinition {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+    /** Strict schema mode: every property is required and no extra keys are allowed. */
+    strict?: boolean;
+  };
+}
+
+export interface OpenAIConnection {
+  apiKey: string;
+  model: string;
+  baseUrl: string;
+}
+
+export interface StreamChatOptions {
+  connection: OpenAIConnection;
+  messages: readonly ChatMessage[];
+  tools?: readonly ChatToolDefinition[];
+  /** Passed through as `response_format`, for example a strict JSON schema. */
+  responseFormat?: Record<string, unknown>;
+  signal?: AbortSignal;
+  /** Called with each text delta and the full text so far. */
+  onText?: (delta: string, full: string) => void;
+}
+
+export interface StreamChatResult {
+  content: string;
+  toolCalls: ChatToolCall[];
+  finishReason: string | null;
+}
+
+export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+export const DEFAULT_OPENAI_MODEL = 'gpt-4o-mini';
+
+async function readErrorDetail(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    try {
+      const json = JSON.parse(text) as { error?: { message?: string } };
+      return json.error?.message ?? text;
+    } catch {
+      return text;
+    }
+  } catch {
+    return '';
+  }
+}
+
+export async function streamChatCompletion(options: StreamChatOptions): Promise<StreamChatResult> {
+  const { connection, messages, tools, responseFormat, signal, onText } = options;
+  const url = `${connection.baseUrl.replace(/\/+$/, '')}/chat/completions`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${connection.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: connection.model,
+      messages,
+      stream: true,
+      ...(tools && tools.length > 0 ? { tools, tool_choice: 'auto' } : {}),
+      ...(responseFormat ? { response_format: responseFormat } : {}),
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new Error(`The API request failed (${response.status})${detail ? `: ${detail}` : '.'}`);
+  }
+  if (!response.body) throw new Error('The API response had no body to stream.');
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const toolCalls = new Map<number, ChatToolCall>();
+  let buffer = '';
+  let content = '';
+  let finishReason: string | null = null;
+
+  const consume = (payload: string) => {
+    let json: {
+      choices?: Array<{
+        finish_reason?: string | null;
+        delta?: {
+          content?: string | null;
+          tool_calls?: Array<{ index?: number; id?: string; function?: { name?: string; arguments?: string } }>;
+        };
+      }>;
+    };
+    try {
+      json = JSON.parse(payload);
+    } catch {
+      return;
+    }
+    const choice = json.choices?.[0];
+    if (!choice) return;
+    const delta = choice.delta ?? {};
+    if (typeof delta.content === 'string' && delta.content.length > 0) {
+      content += delta.content;
+      onText?.(delta.content, content);
+    }
+    for (const call of delta.tool_calls ?? []) {
+      const index = call.index ?? 0;
+      const current = toolCalls.get(index) ?? { id: '', type: 'function' as const, function: { name: '', arguments: '' } };
+      if (call.id) current.id = call.id;
+      if (call.function?.name) current.function.name += call.function.name;
+      if (call.function?.arguments) current.function.arguments += call.function.arguments;
+      toolCalls.set(index, current);
+    }
+    if (choice.finish_reason) finishReason = choice.finish_reason;
+  };
+
+  const consumeLines = () => {
+    let boundary = buffer.indexOf('\n');
+    while (boundary !== -1) {
+      const line = buffer.slice(0, boundary).trim();
+      buffer = buffer.slice(boundary + 1);
+      if (line.startsWith('data:')) {
+        const payload = line.slice(5).trim();
+        if (payload && payload !== '[DONE]') consume(payload);
+      }
+      boundary = buffer.indexOf('\n');
+    }
+  };
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    consumeLines();
+  }
+  buffer += decoder.decode();
+  buffer += '\n';
+  consumeLines();
+
+  return {
+    content,
+    toolCalls: [...toolCalls.entries()].sort((a, b) => a[0] - b[0]).map(([, call]) => call),
+    finishReason,
+  };
+}

--- a/site/tests/interactive-data-report-model.test.ts
+++ b/site/tests/interactive-data-report-model.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { countriesFixture, salesFixture } from '../src/playground/interaction-demo-data';
+import {
+  agentChartOf,
+  extractParts,
+  sentenceRows,
+  chartRows,
+  toParagraphs,
+  toSentence,
+  type AgentUpdate,
+} from '../src/playground/interactive-data-report-model';
+
+const where = (field: string, ...values: string[]): AgentUpdate['records'] =>
+  values.map((value) => ({ pairs: [{ field, value }] }));
+const highlight = (field: string, ...values: string[]): AgentUpdate =>
+  ({ op: 'highlight', records: where(field, ...values), text: null, x: null, y: null });
+const annotate = (field: string, value: string, text: string): AgentUpdate =>
+  ({ op: 'annotate', records: where(field, value), text, x: null, y: null });
+
+describe('the agent view of a chart', () => {
+  it('keys a scatter plot by its detail field', () => {
+    const chart = agentChartOf(countriesFixture, []);
+    expect(chart.keyFields).toEqual(['Country']);
+    expect(chart.annotationFields).toEqual(['Country', 'Continent']);
+    expect(chart.viewportAxes).toEqual([]);
+  });
+
+  it('keys a grouped bar chart by its discrete axis', () => {
+    const chart = agentChartOf(salesFixture, []);
+    expect(chart.keyFields).toEqual(['Region']);
+  });
+});
+
+describe('an agent part becomes a sentence', () => {
+  const countries = agentChartOf(countriesFixture, []);
+
+  it('turns a highlight into an emphasis on the key field, whatever column the clause names', () => {
+    const item = toSentence('s1', 'Asia stretches far', [highlight('Continent', 'Asia')], countries);
+    expect(item?.ops).toEqual([{
+      op: 'set-style',
+      targets: [{ select: { key: { Country: 'China' } } }, { select: { key: { Country: 'Japan' } } }, { select: { key: { Country: 'India' } } }],
+      value: { state: 'emphasized', mutedOpacity: 0.25 },
+    }]);
+    expect(sentenceRows(item!, chartRows(countriesFixture.input)).size).toBe(3);
+  });
+
+  it('matches numbers written as text', () => {
+    const item = toSentence('s2', 'the longest', [highlight('Life expectancy', '84.2')], countries);
+    expect(item?.ops[0]).toMatchObject({ targets: [{ select: { key: { Country: 'Japan' } } }] });
+  });
+
+  it('adds an emphasis to a lone note, and not to a note beside a highlight', () => {
+    const alone = toSentence('s3', 'Japan leads', [annotate('Country', 'Japan', '84.2 years')], countries);
+    expect(alone?.ops.map((op) => op.op)).toEqual(['set-annotation', 'set-style']);
+    const paired = toSentence('s4', 'Japan leads', [highlight('Country', 'Japan'), annotate('Country', 'Japan', '84.2 years')], countries);
+    expect(paired?.ops.map((op) => op.op)).toEqual(['set-style', 'set-annotation']);
+  });
+
+  it('drops a viewport when no navigation preset is mounted, and the whole sentence when nothing resolves', () => {
+    expect(toSentence('s5', 'zoom', [{ op: 'viewport', records: [], text: null, x: [1000, 5000], y: null }], countries)).toBeNull();
+    expect(toSentence('s6', 'nowhere', [highlight('Country', 'Atlantis')], countries)).toBeNull();
+  });
+
+  it('projects a bar chart clause onto the category axis', () => {
+    const sales = agentChartOf(salesFixture, []);
+    const item = toSentence('s7', 'Technology leads everywhere', [highlight('Segment', 'Technology')], sales);
+    expect(item?.ops[0]).toMatchObject({ targets: [{ select: { key: { Region: 'West' } } }, { select: { key: { Region: 'East' } } }, { select: { key: { Region: 'Central' } } }, { select: { key: { Region: 'South' } } }] });
+  });
+});
+
+describe('an answer becomes paragraphs', () => {
+  const countries = agentChartOf(countriesFixture, []);
+
+  it('keeps plain parts as text, binds the rest, and splits on a blank line', () => {
+    const paragraphs = toParagraphs([
+      { text: 'Japan leads', chart: null, updates: [highlight('Country', 'Japan')] },
+      { text: '.Then', chart: null, updates: [] },
+      { text: ' more.\n\nA new paragraph.', chart: null, updates: [] },
+    ], 'turn-1', countries);
+    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs[0].map((part) => (typeof part === 'string' ? part : `[${part.id}]`))).toEqual(['[turn-1-0]', '.Then', ' more.']);
+    expect(paragraphs[1]).toEqual(['A new paragraph.']);
+  });
+
+  it('reads complete parts out of a streaming answer', () => {
+    const partial = '{"parts":[{"text":"Japan leads","updates":[]},{"text":"and then","upd';
+    expect(extractParts(partial)).toEqual([{ text: 'Japan leads', chart: null, updates: [] }]);
+  });
+});


### PR DESCRIPTION
Adds **Demo: interactive data report** (`#/playground/interactive-data-report`), which consists of following sections: 
1. **Report.** Paragraphs beside the chart, with editable presets on the chart.
2. **Slides.** The same sentences one at a time, in a horizontal snapping scroller.
3. **Agent.** The selection goes with the question as context; answers come back as bound sentences.
4. **Story.** Sentences kept from the chat or written from a selection; editable, reorderable, readable as a paragraph or as slides.

**Structure.** 
`interactive-data-report-model.ts` holds the logic with no React: sentence and preset types and builders, the row matching (a sentence and the chart state both reduce to data rows), the preset catalog, and the agent wire format. 
`interactive-data-report-content.ts` holds what the sections say. 
`interactive-data-report-ui.tsx` holds the binding engine `useReportChart` and the shared components. 
`InteractiveDataReportLab.tsx` composes the sections. The model has unit tests.

**Library fix included.** Region and navigation gestures captured the pointer on `pointerdown`, so a plain click never reached a mark while select, lasso, brush, or pan was mounted. They now capture once a real drag begins. The demo mounts click highlight and select together and needs this.

**Verified.** `tsc` passes for `site` and `flint-js`; the `flint-js` suite (1486 tests) and the new model test pass; headless browser runs cover hover, pin, slides, the agent turn, the story controls, and the preset menu, with no console errors.

The agent needs `VITE_OPENAI_API_KEY` in `site/.env.local` (see `site/.env.example`); without it the chat shows the preset exchanges.