### PR TITLE
You draw it: freehand bespoke interaction demo and runtime fixes

### DIFF
--- a/packages/flint-js/src/core/interaction-semantics.ts
+++ b/packages/flint-js/src/core/interaction-semantics.ts
@@ -102,6 +102,9 @@ export function sourceRecordsForRenderedRecords(
 
 export function elementsFromHits(hits: readonly RenderHit[], keyField: string): SemanticElement[] {
     const seen = new Set<string>();
+    const startKeys = new Set(hits
+        .map((hit) => hit.datum[keyField])
+        .filter((key): key is string => typeof key === 'string'));
     const elements: SemanticElement[] = [];
     for (const hit of hits) {
         const key = hit.datum[keyField];
@@ -109,10 +112,15 @@ export function elementsFromHits(hits: readonly RenderHit[], keyField: string): 
         seen.add(key);
         const records = (hit.endDatum ? [hit.datum, hit.endDatum] : [hit.datum])
             .map((datum) => withoutRenderIdentity(datum, keyField));
+        // A path's final vertex only ever appears as a segment end, so the
+        // last segment carries its key too; otherwise hiding the path would
+        // strand that vertex as a zero-length stub.
+        const endKey = hit.endDatum?.[keyField];
+        const renderKeys = typeof endKey === 'string' && !startKeys.has(endKey) ? [key, endKey] : [key];
         elements.push(associateSemanticElementRenderKeys({
             value: withoutRenderIdentity(hit.datum, keyField),
             records,
-        }, [key]));
+        }, renderKeys));
     }
     return elements;
 }

--- a/packages/flint-js/src/interactive/affordances.ts
+++ b/packages/flint-js/src/interactive/affordances.ts
@@ -1,7 +1,7 @@
 import type { CanvasInteractionDef } from './interactions';
 
 export type InteractionAffordanceTarget = 'mark' | 'legend-item' | 'axis-label' | 'plot';
-export type InteractionCursor = 'activate' | 'drag' | 'region' | 'navigate' | 'inspect';
+export type InteractionCursor = 'activate' | 'drag' | 'region' | 'navigate' | 'inspect' | 'draw';
 export type InteractionHoverEffect = 'target' | 'cohort';
 
 export interface InteractionAffordance {
@@ -16,8 +16,22 @@ const CURSOR_PRIORITY: Record<InteractionCursor, number> = {
     inspect: 20,
     navigate: 30,
     region: 40,
+    draw: 45,
     drag: 50,
 };
+
+/**
+ * A pen for freehand input over the plot. Like an arrow cursor, its tip is the
+ * top-left hotspot and the body trails to the bottom right.
+ */
+const DRAW_CURSOR_SVG = [
+    "<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'>",
+    "<path d='M3 3l4.6 1.2L20 16.6a1.8 1.8 0 0 1 0 2.6l-.8.8a1.8 1.8 0 0 1-2.6 0L4.2 7.6z' ",
+    "fill='%23333333' stroke='%23ffffff' stroke-width='1.4' stroke-linejoin='round'/>",
+    "<path d='M18 14.6l-3.4 3.4' stroke='%23ffffff' stroke-width='1.2'/>",
+    '</svg>',
+].join('');
+export const DRAW_CURSOR = `url("data:image/svg+xml;utf8,${DRAW_CURSOR_SVG}") 3 3, crosshair`;
 
 export function resolveInteractionAffordance(
     interactions: readonly CanvasInteractionDef[],
@@ -47,6 +61,7 @@ export function affordanceCursor(affordance: InteractionAffordance | undefined):
         case 'region': return 'crosshair';
         case 'navigate': return 'grab';
         case 'inspect': return 'crosshair';
+        case 'draw': return DRAW_CURSOR;
         default: return undefined;
     }
 }

--- a/packages/flint-js/src/interactive/index.ts
+++ b/packages/flint-js/src/interactive/index.ts
@@ -34,7 +34,7 @@ export type {
     InteractionCursor,
     InteractionHoverEffect,
 } from './affordances';
-export { affordanceCursor, resolveInteractionAffordance } from './affordances';
+export { DRAW_CURSOR, affordanceCursor, resolveInteractionAffordance } from './affordances';
 export type {
     AnnotationCandidate,
     AnnotationConnection,

--- a/packages/flint-js/src/interactive/language/events.ts
+++ b/packages/flint-js/src/interactive/language/events.ts
@@ -120,6 +120,12 @@ export type PlotGeometry =
 export interface DomainGeometry {
     x?: DomainCoordinate;
     y?: DomainCoordinate;
+    points?: readonly DomainPoint[];
+}
+
+export interface DomainPoint {
+    x?: unknown;
+    y?: unknown;
 }
 
 export type DomainCoordinate =

--- a/packages/flint-js/src/vegalite/interactions/gestures/region.ts
+++ b/packages/flint-js/src/vegalite/interactions/gestures/region.ts
@@ -55,6 +55,8 @@ export interface VegaRegionGestureOptions {
     setSuppressClick(suppress: boolean): void;
     setDragging(dragging: boolean): void;
     resetViewport?(): void;
+    /** Escape outside a drag clears the retained selection. Defaults to true; the dismiss policy can turn it off. */
+    escapeClears?: boolean;
 }
 
 export interface VegaRegionGestureController {
@@ -604,6 +606,8 @@ export function mountVegaRegionGesture(options: VegaRegionGestureOptions): VegaR
     };
     const keyDown = (event: KeyboardEvent): void => {
         if (event.key !== 'Escape') return;
+        // Outside a drag, Escape is a dismiss gesture; honour a policy that disables it.
+        if (!dragStart && options.escapeClears === false) return;
         if (interaction.eventSource.viewport) resetViewport?.();
         if (dragStart) {
             setSelected(new Set(committed));

--- a/packages/flint-js/src/vegalite/interactions/presentation/data-overlay.ts
+++ b/packages/flint-js/src/vegalite/interactions/presentation/data-overlay.ts
@@ -25,11 +25,14 @@ export function orderedOverlayRows(spec: ChartOverlaySpec): readonly Record<stri
     const rows = [...spec.data.values];
     const field = spec.encodings.order?.field;
     if (!field) return rows;
+    // Dates order by time, not by their string form.
+    const ordinal = (value: unknown): number | undefined =>
+        typeof value === 'number' ? value : value instanceof Date ? value.getTime() : undefined;
     return rows.sort((left, right) => {
-        const a = left[field];
-        const b = right[field];
-        if (typeof a === 'number' && typeof b === 'number') return a - b;
-        return String(a ?? '').localeCompare(String(b ?? ''));
+        const a = ordinal(left[field]);
+        const b = ordinal(right[field]);
+        if (a !== undefined && b !== undefined) return a - b;
+        return String(left[field] ?? '').localeCompare(String(right[field] ?? ''));
     });
 }
 

--- a/packages/flint-js/src/vegalite/interactions/runtime.ts
+++ b/packages/flint-js/src/vegalite/interactions/runtime.ts
@@ -2235,6 +2235,7 @@ export function mountVegaInteractions(
         setSuppressClick: (suppress) => { suppressClick = suppress; },
         setDragging: (dragging) => { regionDragging = dragging; },
         resetViewport: resetViewportRegion,
+        escapeClears: dismissPolicy.escape,
     }) : undefined;
     const navigationGesture = navigationInteraction ? mountVegaNavigationGesture({
         container,

--- a/packages/flint-js/src/vegalite/interactions/runtime.ts
+++ b/packages/flint-js/src/vegalite/interactions/runtime.ts
@@ -1029,8 +1029,15 @@ export function mountVegaInteractions(
                                         .filter((channel) => op.value[channel] !== undefined)
                                         .map((channel) => [channel, op.value[channel]]),
                                 );
-                                if (Object.keys(style).length > 0) {
-                                    stylesByKey[key] = { ...stylesByKey[key], ...style };
+                                if (Object.keys(style).length === 0) continue;
+                                // A path's first vertex resolves under the path key, but the
+                                // rendered item keeps the plain row key, and Vega styles a
+                                // whole line from that first item. Style both spellings.
+                                const styleKeys = key.endsWith(PATH_KEY_SUFFIX)
+                                    ? [key, key.slice(0, -PATH_KEY_SUFFIX.length)]
+                                    : [key];
+                                for (const styleKey of styleKeys) {
+                                    stylesByKey[styleKey] = { ...stylesByKey[styleKey], ...style };
                                 }
                             }
                         }

--- a/packages/flint-js/src/vegalite/interactions/runtime.ts
+++ b/packages/flint-js/src/vegalite/interactions/runtime.ts
@@ -202,24 +202,57 @@ export function domainForPlotGeometry(
     scaleFor: (name: string) => {
         invert?(value: number): unknown;
     } | undefined,
+    fallbackScales?: Partial<Record<'x' | 'y', string>>,
 ): DomainGeometry | undefined {
-    if (!plot || plot.kind !== 'rect') return undefined;
-    const domain: DomainGeometry = {};
-    for (const axis of ['x', 'y'] as const) {
-        const config = axes?.[axis];
-        if (!config) continue;
-        const scale = scaleFor(config.scale);
-        if (typeof scale?.invert !== 'function') continue;
-        const lower = axis === 'x' ? plot.rect.x : plot.rect.y;
-        const upper = lower + (axis === 'x' ? plot.rect.width : plot.rect.height);
-        const lowerValue = scale.invert(lower);
-        const upperValue = scale.invert(upper);
-        const start = axis === 'y' ? upperValue : lowerValue;
-        const end = axis === 'y' ? lowerValue : upperValue;
-        if (start === undefined || end === undefined) continue;
-        domain[axis] = { kind: 'interval', start, end };
+    if (!plot) return undefined;
+    // Navigation axes name the authoritative scales; the overlay scales cover
+    // charts that project overlays but do not navigate.
+    const inverter = (axis: 'x' | 'y'): ((pixel: number) => unknown) | undefined => {
+        const name = axes?.[axis]?.scale ?? fallbackScales?.[axis];
+        if (!name) return undefined;
+        const scale = scaleFor(name);
+        if (typeof scale?.invert !== 'function') return undefined;
+        return (pixel: number) => scale.invert!(pixel);
+    };
+    if (plot.kind === 'rect') {
+        const domain: DomainGeometry = {};
+        for (const axis of ['x', 'y'] as const) {
+            const invert = inverter(axis);
+            if (!invert) continue;
+            const lower = axis === 'x' ? plot.rect.x : plot.rect.y;
+            const upper = lower + (axis === 'x' ? plot.rect.width : plot.rect.height);
+            const lowerValue = invert(lower);
+            const upperValue = invert(upper);
+            const start = axis === 'y' ? upperValue : lowerValue;
+            const end = axis === 'y' ? lowerValue : upperValue;
+            if (start === undefined || end === undefined) continue;
+            domain[axis] = { kind: 'interval', start, end };
+        }
+        return domain.x || domain.y ? domain : undefined;
     }
-    return domain.x || domain.y ? domain : undefined;
+    if (plot.kind === 'point' || plot.kind === 'drag') {
+        const point = plot.kind === 'point' ? plot.point : plot.current;
+        const domain: DomainGeometry = {};
+        for (const axis of ['x', 'y'] as const) {
+            const invert = inverter(axis);
+            if (!invert) continue;
+            const value = invert(axis === 'x' ? point.x : point.y);
+            if (value === undefined) continue;
+            domain[axis] = { kind: 'value', value };
+        }
+        return domain.x || domain.y ? domain : undefined;
+    }
+    if (plot.kind === 'polygon') {
+        const invertX = inverter('x');
+        const invertY = inverter('y');
+        if (!invertX && !invertY) return undefined;
+        const points = plot.polygon.points.map((vertex) => ({
+            ...(invertX ? { x: invertX(vertex.x) } : {}),
+            ...(invertY ? { y: invertY(vertex.y) } : {}),
+        }));
+        return { points };
+    }
+    return undefined;
 }
 
 export function nearestReorderHit(
@@ -1210,7 +1243,7 @@ export function mountVegaInteractions(
     );
     // A region can be read as data domains, which is what viewport updates need.
     const domainForGeometry = (plot: CanvasInteractionEvent['geometry']['plot']) =>
-        domainForPlotGeometry(plot, plan.navigationAxes, (name) => view.scale(name));
+        domainForPlotGeometry(plot, plan.navigationAxes, (name) => view.scale(name), plan.overlayScales);
     const dispatch = async (
         interaction: CanvasInteractionDef,
         event: SemanticInteractionEvent,
@@ -2058,6 +2091,8 @@ export function mountVegaInteractions(
         } else if (elementDrag.projection) {
             canvasEvent.geometry.projection = elementDrag.projection;
         }
+        const dragDomain = domainForGeometry(canvasEvent.geometry.plot);
+        if (dragDomain) canvasEvent.geometry.domain = dragDomain;
         emitCanvasInteractionEvent(elementDragInteraction, canvasEvent);
         const request = invokeHandler
             ? elementDragInteraction.handle?.(canvasEvent, context()) ?? null

--- a/packages/flint-js/tests/data-overlay.test.ts
+++ b/packages/flint-js/tests/data-overlay.test.ts
@@ -6,6 +6,22 @@ import type { ChartOverlaySpec } from '../src/interactive/language/updates';
 import { orderedOverlayRows, projectPointToPath } from '../src/vegalite/interactions/presentation/data-overlay';
 
 describe('retained data overlays', () => {
+    it('orders a path by time when the order field holds dates', () => {
+        const values = [
+            { Year: new Date(Date.UTC(2016, 0, 1)), x: 3, y: 4 },
+            { Year: new Date(Date.UTC(2013, 6, 1)), x: 1, y: 2 },
+            { Year: new Date(Date.UTC(2014, 0, 1)), x: 2, y: 3 },
+        ];
+        const spec: ChartOverlaySpec = {
+            mark: 'line',
+            data: { values },
+            encodings: { x: { field: 'x' }, y: { field: 'y' }, order: { field: 'Year' } },
+            role: 'drawn-line',
+        };
+
+        expect(orderedOverlayRows(spec).map((row) => row.x)).toEqual([1, 2, 3]);
+    });
+
     it('orders a path without mutating application rows', () => {
         const values = [
             { Year: 2000, x: 3, y: 4 },

--- a/packages/flint-js/tests/interactions.test.ts
+++ b/packages/flint-js/tests/interactions.test.ts
@@ -3293,6 +3293,58 @@ describe('legend, inspect, zoom, and touch presets', () => {
         expect(domain).toEqual({ y: { kind: 'interval', start: 35, end: 25 } });
     });
 
+    it('inverts a point gesture through the overlay scales when no axis navigates', () => {
+        const domain = domainForPlotGeometry(
+            { kind: 'point', point: { x: 50, y: 20 } },
+            undefined,
+            (name) => name === 'x'
+                ? { invert: (pixel: number) => 2000 + pixel / 10 }
+                : { invert: (pixel: number) => 60 - pixel / 2 },
+            { x: 'x', y: 'y' },
+        );
+
+        expect(domain).toEqual({
+            x: { kind: 'value', value: 2005 },
+            y: { kind: 'value', value: 50 },
+        });
+    });
+
+    it('inverts the current point of an element drag', () => {
+        const domain = domainForPlotGeometry(
+            {
+                kind: 'drag',
+                start: { x: 0, y: 0 },
+                current: { x: 30, y: 40 },
+                delta: { x: 30, y: 40 },
+            },
+            { x: { scale: 'x', signal: 'xDomain', type: 'linear' } },
+            () => ({ invert: (pixel: number) => pixel * 2 }),
+            { y: 'y' },
+        );
+
+        expect(domain).toEqual({
+            x: { kind: 'value', value: 60 },
+            y: { kind: 'value', value: 80 },
+        });
+    });
+
+    it('inverts every polygon vertex and skips axes without an invertible scale', () => {
+        const domain = domainForPlotGeometry(
+            { kind: 'polygon', polygon: { points: [{ x: 10, y: 5 }, { x: 20, y: 15 }, { x: 30, y: 25 }] } },
+            undefined,
+            (name) => name === 'x' ? { invert: (pixel: number) => pixel / 10 } : {},
+            { x: 'x', y: 'y' },
+        );
+
+        expect(domain).toEqual({ points: [{ x: 1 }, { x: 2 }, { x: 3 }] });
+        expect(domainForPlotGeometry(
+            { kind: 'polygon', polygon: { points: [{ x: 10, y: 5 }] } },
+            undefined,
+            () => undefined,
+            { x: 'x' },
+        )).toBeUndefined();
+    });
+
     it('normalizes viewport brush geometry without scanning marks', () => {
         const view = {
             width: () => 100,

--- a/packages/flint-js/tests/interactions.test.ts
+++ b/packages/flint-js/tests/interactions.test.ts
@@ -1142,6 +1142,13 @@ describe('interaction definitions', () => {
         ))).toBe('pointer');
         expect(resolveInteractionAffordance([hoverGroupFocus({ groupBy: 'Series' })], 'mark'))
             .toMatchObject({ hover: 'cohort' });
+        const freehand = {
+            id: 'freehand', eventSource: lassoTrigger('contain', false),
+            affordances: [{ target: 'plot' as const, cursor: 'draw' as const }],
+        };
+        const drawCursor = affordanceCursor(resolveInteractionAffordance([freehand, select()], 'plot'));
+        expect(drawCursor).toMatch(/^url\("data:image\/svg\+xml/);
+        expect(drawCursor).toMatch(/, crosshair$/);
     });
 
     it('declares affordances only for configured click highlight targets', () => {

--- a/packages/flint-js/tests/semantic-interactions.test.ts
+++ b/packages/flint-js/tests/semantic-interactions.test.ts
@@ -7,6 +7,7 @@ import type { CanvasInteractionDef, ClickHighlightOptions, RenderHit, SemanticEl
 import { dragTrigger } from '../src/interactive/triggers';
 import {
     associateSemanticElementRenderKeys,
+    elementsFromHits,
     MUTED_HOVER_FILL,
     MUTED_HOVER_STROKE,
     legendMatchedHits,
@@ -4185,5 +4186,32 @@ describe('set-style visibility', () => {
         expect(bars()).toHaveLength(2);
         expect(yDomain()[1]).toBe(fullMax);
         view.finalize();
+    });
+});
+
+describe('elementsFromHits', () => {
+    const key = '__flint_interaction_key';
+    const row = (year: number, id: string) => ({ Year: year, Share: year - 2000, Segment: 'Hidden', [key]: id });
+
+    it('gives the terminal vertex of a path to the last segment', () => {
+        const hits: RenderHit[] = [
+            { datum: row(2012, 'a'), endDatum: row(2013, 'b'), source: 'mark', markType: 'line' },
+            { datum: row(2013, 'b'), endDatum: row(2014, 'c'), source: 'mark', markType: 'line' },
+        ];
+        const elements = elementsFromHits(hits, key);
+        expect(elements).toHaveLength(2);
+        expect(semanticElementRenderKeys(elements[0])).toEqual(['a']);
+        expect(semanticElementRenderKeys(elements[1])).toEqual(['b', 'c']);
+        expect(elements[1].value).toEqual({ Year: 2013, Share: 13, Segment: 'Hidden' });
+    });
+
+    it('keeps one key per element when every vertex starts a segment', () => {
+        const hits: RenderHit[] = [
+            { datum: row(2012, 'a'), endDatum: row(2013, 'b'), source: 'mark', markType: 'line' },
+            { datum: row(2013, 'b'), endDatum: row(2012, 'a'), source: 'mark', markType: 'line' },
+            { datum: row(2020, 'z'), source: 'mark', markType: 'symbol' },
+        ];
+        const elements = elementsFromHits(hits, key);
+        expect(elements.map((element) => semanticElementRenderKeys(element))).toEqual([['a'], ['b'], ['z']]);
     });
 });

--- a/site/src/playground/BespokeInteractionLab.tsx
+++ b/site/src/playground/BespokeInteractionLab.tsx
@@ -3,6 +3,7 @@ import { ClimatePhaseStage } from './ClimatePhaseStage';
 import { FisheyeZoomStage } from './FisheyeZoomStage';
 import { ExplodedDetailStage } from './ExplodedDetailStage';
 import { IndexChartStage } from './IndexChartStage';
+import { YouDrawItStage } from './YouDrawItStage';
 import './bespoke-interaction-lab.css';
 
 export function BespokeInteractionLab() {
@@ -92,6 +93,23 @@ export function BespokeInteractionLab() {
           </div>
         </article>
 
+        <article className="bespoke-case bespoke-case--single">
+          <header className="bespoke-case-header">
+            <div>
+              <h2>You draw it</h2>
+              <p>
+                Draw the future part of a line chart with a freehand stroke; the chart reveals the real
+                series and scores the guess.
+              </p>
+              <div className="bespoke-pattern">
+                <strong>Flint in → Flint out</strong>
+                <strong>Reveal: external in → Flint out</strong>
+              </div>
+            </div>
+            <span className="bespoke-status">Case 05</span>
+          </header>
+          <YouDrawItStage />
+        </article>
       </div>
     </div>
   );

--- a/site/src/playground/YouDrawItStage.tsx
+++ b/site/src/playground/YouDrawItStage.tsx
@@ -1,0 +1,308 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ChartAssemblyInput } from 'flint-chart';
+import {
+  buildInteractiveChart,
+  externalInteraction,
+  lassoTrigger,
+  type CanvasInteractionDef,
+  type ChartUpdate,
+  type InteractiveChartSurface,
+} from 'flint-chart/interactive';
+import { ScaleToFit } from '../components/ScaleToFit';
+import {
+  COAL_SHARE_ROWS,
+  DRAW_START_YEAR,
+  SHARE_DOMAIN,
+  YEAR_DOMAIN,
+} from './you-draw-it-data';
+import {
+  DRAW_INTERACTION_ID,
+  HIDE_UPDATE_ID,
+  REVEAL_INTERACTION_ID,
+  SCORE_UPDATE_ID,
+  anchorPath,
+  clearRevealUpdate,
+  dateToYear,
+  describeScore,
+  drawBounds,
+  drawnLineUpdate,
+  extendPath,
+  frontSample,
+  hideFutureUpdate,
+  isComplete,
+  missingYears,
+  promptUpdate,
+  resampleYearly,
+  revealUpdate,
+  scoreGuess,
+  scoreUpdate,
+  splitRows,
+  type DrawnPath,
+  type GuessScore,
+  type StagePhase,
+} from './you-draw-it-model';
+import './interaction-candidates.css';
+import './you-draw-it-stage.css';
+
+const VIEW_SIZE = { width: 900, height: 520 };
+const REVEAL_DURATION_MS = 1400;
+const BOUNDS = drawBounds(COAL_SHARE_ROWS, DRAW_START_YEAR, SHARE_DOMAIN);
+const CHART_ROWS = splitRows(COAL_SHARE_ROWS, DRAW_START_YEAR);
+
+type RevealPayload = { progress: number };
+
+function chartInput(): ChartAssemblyInput {
+  return {
+    data: { values: CHART_ROWS },
+    semantic_types: {
+      Year: 'Year',
+      Share: { semanticType: 'Quantity', intrinsicDomain: [...SHARE_DOMAIN] as [number, number] },
+      Segment: 'Category',
+    },
+    field_display_names: {
+      Share: 'Share of net generation (%)',
+    },
+    theme_spec: {
+      extends: 'datawrapper',
+      legend: { show: 'never' },
+      ink: { series: { categorical: ['#18a1cd', '#18a1cd'] } },
+    },
+    options: { addTooltips: false },
+    chart_spec: {
+      chartType: 'Line Chart',
+      title: 'Share of U.S. electricity from coal',
+      subtitle: `Percent of net generation, ${YEAR_DOMAIN[0]} to ${YEAR_DOMAIN[1]}. Draw where you think the line went after ${DRAW_START_YEAR}.`,
+      encodings: { x: 'Year', y: 'Share', color: 'Segment' },
+      baseSize: VIEW_SIZE,
+      canvasSize: VIEW_SIZE,
+      chartProperties: { includeZero_y: true, showPoints: false },
+    },
+  };
+}
+
+function candidatesFromDomainPoints(points: readonly { x?: unknown; y?: unknown }[] | undefined) {
+  if (!points) return [];
+  return points.flatMap((point) => {
+    // The temporal x scale inverts to a Date; the model works in fractional years.
+    const year = point.x instanceof Date || typeof point.x === 'number' ? dateToYear(point.x) : Number.NaN;
+    const value = Number(point.y);
+    return Number.isFinite(year) && Number.isFinite(value) ? [{ year, value }] : [];
+  });
+}
+
+function phaseHint(phase: StagePhase, path: DrawnPath): string {
+  switch (phase) {
+    case 'idle':
+      return `Press in the plot after ${DRAW_START_YEAR} and move across the years. Every year takes the value under the pointer; move back to redraw a part.`;
+    case 'drawing': {
+      const missing = missingYears(path, BOUNDS);
+      const total = BOUNDS.endYear - BOUNDS.startYear;
+      return `${total - missing.length} of ${total} years drawn. ${missing.length === 1 ? `Year ${missing[0]} is still empty.` : `Fill ${missing[0]} to ${missing[missing.length - 1]} to finish.`}`;
+    }
+    case 'complete':
+      return `All ${BOUNDS.endYear - BOUNDS.startYear} years drawn. Click Finish drawing to reveal the real line, or keep redrawing.`;
+    case 'revealing':
+      return 'The real line grows in through an external interaction, one frame at a time.';
+    case 'revealed':
+      return 'Reset hides the future rows again and clears your line.';
+  }
+}
+
+export function YouDrawItStage() {
+  const input = useMemo(() => chartInput(), []);
+  const mountRef = useRef<HTMLDivElement>(null);
+  const surfaceRef = useRef<InteractiveChartSurface | null>(null);
+  const committedPathRef = useRef<DrawnPath>(anchorPath(BOUNDS));
+  const phaseRef = useRef<StagePhase>('idle');
+  const [phase, setPhase] = useState<StagePhase>('idle');
+  const [path, setPath] = useState<DrawnPath>(committedPathRef.current);
+  const [score, setScore] = useState<GuessScore | null>(null);
+  const [revealRun, setRevealRun] = useState(0);
+  const handledRevealRunRef = useRef(0);
+
+  const updatePhase = useCallback((next: StagePhase) => {
+    phaseRef.current = next;
+    setPhase(next);
+  }, []);
+
+  const drawInteraction = useMemo<CanvasInteractionDef>(() => ({
+    id: DRAW_INTERACTION_ID,
+    eventSource: lassoTrigger('contain', false),
+    affordances: [{ target: 'plot', cursor: 'draw' }],
+    handle(event): ChartUpdate | null {
+      if (event.action !== 'select-lasso') return null;
+      if (event.phase === 'start') return null;
+      if (phaseRef.current === 'revealing' || phaseRef.current === 'revealed') {
+        // The region gesture parks its own selection preview under this
+        // interaction id, so a stray stroke must restate the finished line
+        // or the commit would promote that preview in its place.
+        return event.phase === 'cancel' ? null : drawnLineUpdate(committedPathRef.current, true, BOUNDS);
+      }
+      if (event.phase === 'cancel') {
+        setPath(committedPathRef.current);
+        updatePhase(committedPathRef.current.samples.length > 1 ? 'drawing' : 'idle');
+        return null;
+      }
+      const candidates = candidatesFromDomainPoints(event.geometry.domain?.points);
+      if (candidates.length === 0) {
+        // An empty commit (a click) still has to restate the retained line.
+        return committedPathRef.current.samples.length > 1
+          ? drawnLineUpdate(committedPathRef.current, false)
+          : null;
+      }
+      // The polygon carries every point since the stroke began, so each
+      // preview repaints from the last committed stroke.
+      const next = extendPath(committedPathRef.current, candidates, BOUNDS);
+      if (event.phase === 'commit') committedPathRef.current = next;
+      setPath(next);
+      // A complete line stays editable; only the Finish button reveals.
+      updatePhase(isComplete(next, BOUNDS) ? 'complete' : 'drawing');
+      return drawnLineUpdate(next, false, BOUNDS);
+    },
+  }), [updatePhase]);
+
+  const revealInteraction = useMemo(() => externalInteraction<RevealPayload>({
+    id: REVEAL_INTERACTION_ID,
+    handle({ progress }) {
+      return revealUpdate(COAL_SHARE_ROWS, BOUNDS, progress);
+    },
+  }), []);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return undefined;
+    const surface = buildInteractiveChart(mount, input, {
+      backend: 'vegalite',
+      renderer: 'svg',
+      interactions: [drawInteraction, revealInteraction],
+      updates: [hideFutureUpdate(), promptUpdate(BOUNDS, true)],
+      // The default dismiss policy drops every retained set-style op on a
+      // click that hits no element, which would unhide the future rows.
+      dismiss: false,
+      ariaLabel: 'You draw it: share of U.S. electricity from coal',
+      chartId: 'you-draw-it-coal',
+    });
+    surfaceRef.current = surface;
+    return () => {
+      surfaceRef.current = null;
+      surface.destroy();
+    };
+  }, [drawInteraction, input, revealInteraction]);
+
+  useEffect(() => {
+    // Only the Finish button advances revealRun, and each run reveals once.
+    // The ref guard keeps a remount (for example a dev hot reload) from
+    // replaying the reveal.
+    if (revealRun === 0 || revealRun === handledRevealRunRef.current) return undefined;
+    if (phaseRef.current !== 'complete') return undefined;
+    handledRevealRunRef.current = revealRun;
+    const surface = surfaceRef.current;
+    if (!surface) return undefined;
+    let cancelled = false;
+    let frame = 0;
+    const finishedPath = committedPathRef.current;
+    const drawnYearly = resampleYearly(finishedPath);
+    const nextScore = scoreGuess(drawnYearly, COAL_SHARE_ROWS, BOUNDS.startYear);
+    const start = performance.now();
+    updatePhase('revealing');
+    // Freeze the drawn line: dashed, no front marker.
+    void surface.applyUpdate(drawnLineUpdate(finishedPath, true, BOUNDS));
+
+    const finish = async () => {
+      await surface.dispatch(REVEAL_INTERACTION_ID, { progress: 1 });
+      if (cancelled) return;
+      // The retained hide update goes away after the overlay covers the same
+      // path, so the swap is invisible.
+      await surface.clearUpdate(HIDE_UPDATE_ID);
+      await surface.applyUpdate(clearRevealUpdate());
+      if (nextScore) {
+        const drawnEnd = finishedPath.samples[finishedPath.samples.length - 1].value;
+        await surface.applyUpdate(scoreUpdate(nextScore, COAL_SHARE_ROWS, BOUNDS, drawnEnd));
+      }
+      if (cancelled) return;
+      setScore(nextScore);
+      updatePhase('revealed');
+    };
+
+    const tick = async (time: number) => {
+      if (cancelled) return;
+      const progress = Math.min(1, (time - start) / REVEAL_DURATION_MS);
+      if (progress >= 1) {
+        await finish();
+        return;
+      }
+      await surface.dispatch(REVEAL_INTERACTION_ID, { progress });
+      if (cancelled) return;
+      frame = window.requestAnimationFrame((next) => void tick(next));
+    };
+    frame = window.requestAnimationFrame((time) => void tick(time));
+
+    return () => {
+      cancelled = true;
+      if (frame !== 0) window.cancelAnimationFrame(frame);
+    };
+  }, [revealRun, updatePhase]);
+
+  const finishDrawing = () => {
+    if (phaseRef.current !== 'complete') return;
+    setRevealRun((run) => run + 1);
+  };
+
+  const reset = () => {
+    const surface = surfaceRef.current;
+    committedPathRef.current = anchorPath(BOUNDS);
+    setPath(committedPathRef.current);
+    setScore(null);
+    updatePhase('idle');
+    if (!surface) return;
+    void (async () => {
+      await surface.clearUpdate(DRAW_INTERACTION_ID);
+      await surface.clearUpdate(REVEAL_INTERACTION_ID);
+      await surface.clearUpdate(SCORE_UPDATE_ID);
+      await surface.applyUpdate(hideFutureUpdate());
+      await surface.applyUpdate(promptUpdate(BOUNDS, true));
+    })();
+  };
+
+  const front = frontSample(path);
+  const progress = phase === 'drawing' || phase === 'complete'
+    ? `Last: ${front.year} · ${front.value.toFixed(1)}%`
+    : phase === 'revealed' && score
+      ? `Revealed · ${score.meanAbsError.toFixed(1)} pt mean error`
+      : null;
+
+  return (
+    <div className="ic-flint-dimpvis-shell ydi-stage">
+      <div className="ic-stage-meta">
+        <strong>You draw it</strong>
+        <span>
+          The chart shows coal's share of U.S. generation up to {DRAW_START_YEAR}. Draw the rest of the line,
+          then the real values appear and the chart scores your guess.
+        </span>
+      </div>
+      <div className="ic-flint-dimpvis-panel">
+        <ScaleToFit height={540} minHeight={400} adaptiveHeight padding={8}>
+          <div className="ic-flint-dimpvis-mount" ref={mountRef} />
+        </ScaleToFit>
+      </div>
+      <div className="ydi-stage__footer">
+        <div className="ic-toolbar">
+          <button
+            type="button"
+            className="ic-pill"
+            data-active={phase === 'complete'}
+            disabled={phase !== 'complete'}
+            onClick={finishDrawing}
+          >
+            Finish drawing
+          </button>
+          <button type="button" className="ic-pill" onClick={reset}>Reset</button>
+        </div>
+        <span className="ydi-stage__hint">
+          {progress ? `${progress} — ` : ''}
+          {phase === 'revealed' && score ? describeScore(score).detail : phaseHint(phase, path)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/site/src/playground/you-draw-it-data.ts
+++ b/site/src/playground/you-draw-it-data.ts
@@ -1,0 +1,44 @@
+/**
+ * Share of U.S. utility-scale electricity generation from coal, in percent.
+ *
+ * Approximate annual values from EIA Electric Power Monthly, rounded to one
+ * decimal. Good enough for the drawing prototype; swap in exact figures before
+ * the story ships.
+ */
+export interface CoalShareRow {
+  Year: number;
+  Share: number;
+}
+
+export const COAL_SHARE_ROWS: readonly CoalShareRow[] = [
+  { Year: 2000, Share: 51.7 },
+  { Year: 2001, Share: 51.0 },
+  { Year: 2002, Share: 50.1 },
+  { Year: 2003, Share: 50.8 },
+  { Year: 2004, Share: 49.8 },
+  { Year: 2005, Share: 49.6 },
+  { Year: 2006, Share: 49.0 },
+  { Year: 2007, Share: 48.5 },
+  { Year: 2008, Share: 48.2 },
+  { Year: 2009, Share: 44.4 },
+  { Year: 2010, Share: 44.8 },
+  { Year: 2011, Share: 42.3 },
+  { Year: 2012, Share: 37.4 },
+  { Year: 2013, Share: 38.9 },
+  { Year: 2014, Share: 38.6 },
+  { Year: 2015, Share: 33.2 },
+  { Year: 2016, Share: 30.4 },
+  { Year: 2017, Share: 30.1 },
+  { Year: 2018, Share: 27.4 },
+  { Year: 2019, Share: 23.5 },
+  { Year: 2020, Share: 19.3 },
+  { Year: 2021, Share: 21.8 },
+  { Year: 2022, Share: 19.5 },
+  { Year: 2023, Share: 16.2 },
+  { Year: 2024, Share: 15.0 },
+];
+
+/** The reader draws from this year to the end of the series. */
+export const DRAW_START_YEAR = 2012;
+export const YEAR_DOMAIN: readonly [number, number] = [2000, 2024];
+export const SHARE_DOMAIN: readonly [number, number] = [0, 60];

--- a/site/src/playground/you-draw-it-model.ts
+++ b/site/src/playground/you-draw-it-model.ts
@@ -1,0 +1,473 @@
+import type { ChartUpdate, ChartUpdateOp } from 'flint-chart/interactive';
+import type { CoalShareRow } from './you-draw-it-data';
+
+export type Segment = 'Actual' | 'Hidden';
+
+export interface ChartRow extends CoalShareRow {
+  Segment: Segment;
+}
+
+export interface DrawnSample {
+  year: number;
+  value: number;
+}
+
+/** One sample per drawn whole year in increasing order; the first one is the fixed anchor. */
+export interface DrawnPath {
+  samples: readonly DrawnSample[];
+  /** The year the pointer painted last. */
+  frontYear?: number;
+}
+
+export interface DrawBounds {
+  startYear: number;
+  endYear: number;
+  startValue: number;
+  minValue: number;
+  maxValue: number;
+}
+
+export interface GuessScore {
+  meanAbsError: number;
+  meanSignedError: number;
+  worstYear: number;
+  worstError: number;
+  comparedYears: number;
+}
+
+export type StagePhase = 'idle' | 'drawing' | 'complete' | 'revealing' | 'revealed';
+
+export const HIDE_UPDATE_ID = 'you-draw-it-hide-future';
+export const PROMPT_UPDATE_ID = 'you-draw-it-prompt';
+export const DRAW_INTERACTION_ID = 'you-draw-it-draw';
+export const REVEAL_INTERACTION_ID = 'you-draw-it-reveal';
+export const SCORE_UPDATE_ID = 'you-draw-it-score';
+
+const DRAWN_STROKE = '#333333';
+const TRUTH_STROKE = '#18a1cd';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/** The chart's x axis is temporal, so overlays and pointer values convert between fractional years and UTC dates. */
+export function yearToDate(year: number): Date {
+  const whole = Math.floor(year);
+  const start = Date.UTC(whole, 0, 1);
+  const end = Date.UTC(whole + 1, 0, 1);
+  return new Date(start + ((end - start) * (year - whole)));
+}
+
+export function dateToYear(value: Date | number): number {
+  const ms = value instanceof Date ? value.getTime() : Number(value);
+  if (!Number.isFinite(ms)) return Number.NaN;
+  const whole = new Date(ms).getUTCFullYear();
+  const start = Date.UTC(whole, 0, 1);
+  const end = Date.UTC(whole + 1, 0, 1);
+  return whole + ((ms - start) / (end - start));
+}
+
+function overlayRow<T extends { Year: number }>(row: T): Omit<T, 'Year'> & { Year: Date } {
+  return { ...row, Year: yearToDate(row.Year) };
+}
+
+function interpolateAt(samples: readonly DrawnSample[], year: number): number {
+  if (year <= samples[0].year) return samples[0].value;
+  const last = samples[samples.length - 1];
+  if (year >= last.year) return last.value;
+  let index = 1;
+  while (samples[index].year < year) index += 1;
+  const left = samples[index - 1];
+  const right = samples[index];
+  const span = right.year - left.year;
+  if (span <= 0) return right.value;
+  return left.value + ((right.value - left.value) * ((year - left.year) / span));
+}
+
+/** Rows before the draw start stay visible; the rest become the hidden truth. Both include the start year so the paths join. */
+export function splitRows(rows: readonly CoalShareRow[], startYear: number): ChartRow[] {
+  const out: ChartRow[] = [];
+  for (const row of rows) {
+    if (row.Year <= startYear) out.push({ ...row, Segment: 'Actual' });
+    if (row.Year >= startYear) out.push({ ...row, Segment: 'Hidden' });
+  }
+  return out;
+}
+
+export function drawBounds(
+  rows: readonly CoalShareRow[],
+  startYear: number,
+  valueDomain: readonly [number, number],
+): DrawBounds {
+  const start = rows.find((row) => row.Year === startYear);
+  if (!start) throw new Error(`No row for the draw start year ${startYear}.`);
+  return {
+    startYear,
+    endYear: Math.max(...rows.map((row) => row.Year)),
+    startValue: start.Share,
+    minValue: valueDomain[0],
+    maxValue: valueDomain[1],
+  };
+}
+
+export function anchorPath(bounds: DrawBounds): DrawnPath {
+  return { samples: [{ year: bounds.startYear, value: bounds.startValue }] };
+}
+
+function nearestYear(year: number, bounds: DrawBounds): number {
+  return Math.round(clamp(year, bounds.startYear, bounds.endYear));
+}
+
+/**
+ * Paint pointer samples onto the path. Each whole year keeps one value: the
+ * year under the pointer takes the pointer's value, years the pointer crosses
+ * between two samples take the interpolated value, and every other year keeps
+ * what it had. The reader can move back and redraw a part; the anchor year
+ * never changes.
+ */
+export function extendPath(
+  path: DrawnPath,
+  candidates: readonly { year: number; value: number }[],
+  bounds: DrawBounds,
+): DrawnPath {
+  const values = new Map(path.samples.map((sample) => [sample.year, sample.value]));
+  const paint = (year: number, value: number) => {
+    if (year <= bounds.startYear) return;
+    values.set(year, clamp(value, bounds.minValue, bounds.maxValue));
+  };
+  let previous: { year: number; value: number } | undefined;
+  let frontYear = path.frontYear;
+  for (const candidate of candidates) {
+    if (!Number.isFinite(candidate.year) || !Number.isFinite(candidate.value)) continue;
+    const current = {
+      year: clamp(candidate.year, bounds.startYear, bounds.endYear),
+      value: clamp(candidate.value, bounds.minValue, bounds.maxValue),
+    };
+    const target = nearestYear(current.year, bounds);
+    if (previous) {
+      const from = nearestYear(previous.year, bounds);
+      const step = target >= from ? 1 : -1;
+      for (let year = from; year !== target + step; year += step) {
+        const span = current.year - previous.year;
+        const t = Math.abs(span) < 1e-9 ? 1 : clamp((year - previous.year) / span, 0, 1);
+        paint(year, previous.value + ((current.value - previous.value) * t));
+      }
+    } else {
+      paint(target, current.value);
+    }
+    if (target > bounds.startYear) frontYear = target;
+    previous = current;
+  }
+  const samples = [...values.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([year, value]) => ({ year, value }));
+  return { samples, ...(frontYear !== undefined ? { frontYear } : {}) };
+}
+
+/** Years after the anchor that still have no value. */
+export function missingYears(path: DrawnPath, bounds: DrawBounds): number[] {
+  const drawn = new Set(path.samples.map((sample) => sample.year));
+  const missing: number[] = [];
+  for (let year = bounds.startYear + 1; year <= bounds.endYear; year += 1) {
+    if (!drawn.has(year)) missing.push(year);
+  }
+  return missing;
+}
+
+export function isComplete(path: DrawnPath, bounds: DrawBounds): boolean {
+  return missingYears(path, bounds).length === 0;
+}
+
+/** The sample the pointer painted last, or the anchor before any stroke. */
+export function frontSample(path: DrawnPath): DrawnSample {
+  const front = path.frontYear === undefined
+    ? undefined
+    : path.samples.find((sample) => sample.year === path.frontYear);
+  return front ?? path.samples[path.samples.length - 1];
+}
+
+/** One row per drawn whole year, the anchor included. */
+export function resampleYearly(path: DrawnPath): CoalShareRow[] {
+  return path.samples.map((sample) => ({ Year: sample.year, Share: sample.value }));
+}
+
+export function scoreGuess(
+  drawn: readonly CoalShareRow[],
+  truth: readonly CoalShareRow[],
+  startYear: number,
+): GuessScore | null {
+  const truthByYear = new Map(truth.map((row) => [row.Year, row.Share]));
+  let absSum = 0;
+  let signedSum = 0;
+  let count = 0;
+  let worstYear = startYear;
+  let worstError = 0;
+  for (const row of drawn) {
+    if (row.Year <= startYear) continue;
+    const actual = truthByYear.get(row.Year);
+    if (actual === undefined) continue;
+    const error = row.Share - actual;
+    absSum += Math.abs(error);
+    signedSum += error;
+    count += 1;
+    if (Math.abs(error) > Math.abs(worstError)) {
+      worstError = error;
+      worstYear = row.Year;
+    }
+  }
+  if (count === 0) return null;
+  return {
+    meanAbsError: absSum / count,
+    meanSignedError: signedSum / count,
+    worstYear,
+    worstError,
+    comparedYears: count,
+  };
+}
+
+export function describeScore(score: GuessScore): { headline: string; detail: string } {
+  const headline = `Your line was off by ${score.meanAbsError.toFixed(1)} points on average.`;
+  const direction = score.meanSignedError > 1
+    ? 'You drew coal higher than it went.'
+    : score.meanSignedError < -1
+      ? 'You drew coal lower than it went.'
+      : 'You stayed close on both sides.';
+  const worst = `Largest miss in ${score.worstYear}: ${Math.abs(score.worstError).toFixed(1)} points.`;
+  return { headline, detail: `${direction} ${worst}` };
+}
+
+/** The hidden truth up to a fraction of the way from the start year to the end year. */
+export function revealRows(
+  truth: readonly CoalShareRow[],
+  bounds: DrawBounds,
+  progress: number,
+): CoalShareRow[] {
+  const hidden = truth.filter((row) => row.Year >= bounds.startYear);
+  const frontYear = bounds.startYear + ((bounds.endYear - bounds.startYear) * clamp(progress, 0, 1));
+  const shown = hidden.filter((row) => row.Year <= frontYear);
+  const samples = hidden.map((row) => ({ year: row.Year, value: row.Share }));
+  if (shown.length === 0 || shown[shown.length - 1].Year < frontYear) {
+    shown.push({ Year: frontYear, Share: interpolateAt(samples, frontYear) });
+  }
+  return shown;
+}
+
+// ---- Chart updates -------------------------------------------------------
+
+/**
+ * The future rows stay in the data so the temporal x axis keeps its full
+ * range; they only lose their ink. An explicit per-key opacity outranks the
+ * emphasis and muted states, so a stray selection cannot leak them back.
+ */
+export function hideFutureUpdate(): ChartUpdate {
+  return {
+    id: HIDE_UPDATE_ID,
+    ops: [{
+      op: 'set-style',
+      targets: [{ select: { key: { Segment: 'Hidden' } } }],
+      value: { opacity: 0 },
+    }],
+  };
+}
+
+export function promptUpdate(bounds: DrawBounds, visible: boolean): ChartUpdate {
+  const midYear = (bounds.startYear + bounds.endYear) / 2;
+  const midValue = (bounds.minValue + bounds.maxValue) / 2;
+  return {
+    id: PROMPT_UPDATE_ID,
+    ops: [
+      {
+        // The last known value marks where the reader's line begins.
+        op: 'set-overlay',
+        name: 'draw-start-point',
+        value: {
+          mark: 'point',
+          role: 'draw-start',
+          data: { values: [{ Year: yearToDate(bounds.startYear), Share: bounds.startValue }] },
+          encodings: { x: { field: 'Year' }, y: { field: 'Share' } },
+          style: { fill: TRUTH_STROKE, stroke: '#ffffff', strokeWidth: 1.5, pointRadius: 5 },
+        },
+      },
+      {
+        op: 'set-overlay',
+        name: 'draw-prompt',
+        value: visible ? {
+          mark: 'text',
+          role: 'draw-prompt',
+          data: { values: [{ Year: yearToDate(midYear), Share: midValue, Label: `Draw the line to ${bounds.endYear}` }] },
+          encodings: { x: { field: 'Year' }, y: { field: 'Share' }, text: { field: 'Label' } },
+          style: { fill: '#333333', fontSize: 14, fontWeight: 'bold', textAlign: 'middle' },
+        } : null,
+      },
+      {
+        op: 'set-overlay',
+        name: 'draw-prompt-hint',
+        value: visible ? {
+          mark: 'text',
+          role: 'draw-prompt',
+          data: { values: [{ Year: yearToDate(midYear), Share: midValue, Label: 'Press to the right of the blue dot and move across the years' }] },
+          encodings: { x: { field: 'Year' }, y: { field: 'Share' }, text: { field: 'Label' } },
+          style: { fill: '#999999', fontSize: 11, textAlign: 'middle', dy: 18 },
+        } : null,
+      },
+    ],
+  };
+}
+
+/** The reader's line is always dashed; `finished` only removes the front marker. */
+export function drawnLineUpdate(path: DrawnPath, finished: boolean, bounds?: DrawBounds): ChartUpdate {
+  const rows = path.samples.map((sample) => ({ Year: sample.year, Share: sample.value }));
+  const frontPoint = frontSample(path);
+  const front = { Year: frontPoint.year, Share: frontPoint.value };
+  const frontLabel = `${front.Year} · ${front.Share.toFixed(1)}%`;
+  // Near the right edge the label would leave the plot, so it sits left of the dot.
+  const nearEnd = bounds !== undefined && front.Year >= bounds.endYear - 2;
+  const ops: ChartUpdateOp[] = [
+    { op: 'set-overlay', name: 'draw-prompt', value: null },
+    { op: 'set-overlay', name: 'draw-prompt-hint', value: null },
+    {
+      op: 'set-overlay',
+      name: 'drawn-line',
+      value: {
+        mark: 'line',
+        role: 'drawn-line',
+        data: { values: rows.map(overlayRow) },
+        encodings: { x: { field: 'Year' }, y: { field: 'Share' }, order: { field: 'Year' } },
+        style: { stroke: DRAWN_STROKE, strokeWidth: 2.5, strokeDash: [6, 4] },
+      },
+    },
+    {
+      op: 'set-overlay',
+      name: 'drawn-front',
+      value: finished ? null : {
+        mark: 'point',
+        role: 'drawn-front',
+        data: { values: [overlayRow(front)] },
+        encodings: { x: { field: 'Year' }, y: { field: 'Share' } },
+        style: { fill: DRAWN_STROKE, stroke: '#ffffff', strokeWidth: 1.5, pointRadius: 5 },
+      },
+    },
+    {
+      op: 'set-overlay',
+      name: 'drawn-front-label',
+      value: finished ? null : {
+        mark: 'text',
+        role: 'drawn-front-label',
+        data: { values: [{ ...overlayRow(front), Label: frontLabel }] },
+        encodings: { x: { field: 'Year' }, y: { field: 'Share' }, text: { field: 'Label' } },
+        style: nearEnd
+          ? { fill: '#3a434a', fontSize: 10, fontWeight: 'bold', textAlign: 'end', dx: -10, dy: -10 }
+          : { fill: '#3a434a', fontSize: 10, fontWeight: 'bold', textAlign: 'start', dx: 10, dy: -10 },
+      },
+    },
+  ];
+  return { id: DRAW_INTERACTION_ID, ops };
+}
+
+export function revealUpdate(
+  truth: readonly CoalShareRow[],
+  bounds: DrawBounds,
+  progress: number,
+): ChartUpdate {
+  const rows = revealRows(truth, bounds, progress).map((row) => ({ Year: yearToDate(row.Year), Share: row.Share }));
+  return {
+    id: REVEAL_INTERACTION_ID,
+    ops: [{
+      op: 'set-overlay',
+      name: 'truth-reveal',
+      value: rows.length < 2 ? null : {
+        mark: 'line',
+        role: 'truth-reveal',
+        data: { values: rows },
+        encodings: { x: { field: 'Year' }, y: { field: 'Share' }, order: { field: 'Year' } },
+        style: { stroke: TRUTH_STROKE, strokeWidth: 2.5 },
+      },
+    }],
+  };
+}
+
+export function clearRevealUpdate(): ChartUpdate {
+  return {
+    id: REVEAL_INTERACTION_ID,
+    ops: [{ op: 'set-overlay', name: 'truth-reveal', value: null }],
+  };
+}
+
+export function scoreUpdate(
+  score: GuessScore,
+  truth: readonly CoalShareRow[],
+  bounds: DrawBounds,
+  drawnEnd: number,
+): ChartUpdate {
+  const text = describeScore(score);
+  const finalTruth = truth[truth.length - 1];
+  // End labels: the drawn label sits inside the gap between the two ends when
+  // the gap has room, otherwise on the far side; the actual label always sits
+  // on the far side of the actual end.
+  const drawnAbove = drawnEnd >= finalTruth.Share;
+  const roomInGap = Math.abs(drawnEnd - finalTruth.Share) >= 3;
+  const drawnDy = drawnAbove ? (roomInGap ? 14 : -8) : (roomInGap ? -8 : 14);
+  const actualDy = drawnAbove ? 14 : -8;
+  const labelYear = bounds.startYear + ((bounds.endYear - bounds.startYear) * 0.08);
+  const labelValue = bounds.maxValue - ((bounds.maxValue - bounds.minValue) * 0.04);
+  return {
+    id: SCORE_UPDATE_ID,
+    ops: [
+      {
+        op: 'set-overlay',
+        name: 'score-headline',
+        value: {
+          mark: 'text',
+          role: 'score',
+          data: { values: [{ Year: yearToDate(labelYear), Share: labelValue, Label: text.headline }] },
+          encodings: { x: { field: 'Year' }, y: { field: 'Share' }, text: { field: 'Label' } },
+          style: { fill: '#333333', fontSize: 12, fontWeight: 'bold', textAlign: 'start' },
+        },
+      },
+      {
+        op: 'set-overlay',
+        name: 'score-detail',
+        value: {
+          mark: 'text',
+          role: 'score',
+          data: { values: [{ Year: yearToDate(labelYear), Share: labelValue, Label: text.detail }] },
+          encodings: { x: { field: 'Year' }, y: { field: 'Share' }, text: { field: 'Label' } },
+          style: { fill: '#666666', fontSize: 11, textAlign: 'start', dy: 16 },
+        },
+      },
+      {
+        op: 'set-overlay',
+        name: 'score-gap',
+        value: {
+          mark: 'rule',
+          role: 'score-gap',
+          data: { values: [{ Year: yearToDate(finalTruth.Year), Share: finalTruth.Share, YearEnd: yearToDate(finalTruth.Year), ShareEnd: drawnEnd }] },
+          encodings: { x: { field: 'Year' }, y: { field: 'Share' }, x2: { field: 'YearEnd' }, y2: { field: 'ShareEnd' } },
+          style: { stroke: '#c04a4a', strokeWidth: 1.5, strokeDash: [3, 2] },
+        },
+      },
+      {
+        op: 'set-overlay',
+        name: 'score-end-actual',
+        value: {
+          mark: 'text',
+          role: 'score',
+          data: { values: [{ Year: yearToDate(finalTruth.Year), Share: finalTruth.Share, Label: `Actual ${finalTruth.Share.toFixed(1)}%` }] },
+          encodings: { x: { field: 'Year' }, y: { field: 'Share' }, text: { field: 'Label' } },
+          style: { fill: TRUTH_STROKE, fontSize: 11, fontWeight: 'bold', textAlign: 'end', dx: -10, dy: actualDy },
+        },
+      },
+      {
+        op: 'set-overlay',
+        name: 'score-end-drawn',
+        value: {
+          mark: 'text',
+          role: 'score',
+          data: { values: [{ Year: yearToDate(finalTruth.Year), Share: drawnEnd, Label: `Your line ${drawnEnd.toFixed(1)}%` }] },
+          encodings: { x: { field: 'Year' }, y: { field: 'Share' }, text: { field: 'Label' } },
+          style: { fill: DRAWN_STROKE, fontSize: 11, fontWeight: 'bold', textAlign: 'end', dx: -10, dy: drawnDy },
+        },
+      },
+    ],
+  };
+}

--- a/site/src/playground/you-draw-it-stage.css
+++ b/site/src/playground/you-draw-it-stage.css
@@ -1,0 +1,28 @@
+.ydi-stage {
+  position: relative;
+}
+
+.ydi-stage .ic-flint-dimpvis-mount {
+  position: relative;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.ydi-stage__hint {
+  color: #66707a;
+  font-size: 10px;
+}
+
+.ydi-stage__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 4px;
+}
+
+.ydi-stage .ic-pill:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary

Adds Case 05 "You draw it" to the advanced prototypes page, plus the interaction-runtime changes it needed. The line chart shows a line to 2012; the user draws the rest with a lasso stroke under a pen cursor, and a **Finish drawing** button reveals the real line and displays the score.

Four commits, in order:

1. **feat(interactions): report data-space coordinates for point, drag, and polygon gestures.** `domainForPlotGeometry` now inverts point, drag, and polygon geometry (not only rectangle brushes) and falls back to the overlay scales when no axis navigates. `DomainGeometry` gains `points`. Bespoke demos no longer have to measure the plot and fit their own scales.
2. **fix(interactions): path segment, per-key style, overlay.** Three bugs surfaced by hiding a line by selector and drawing overlays on a temporal axis: a hidden line left its terminal vertex as a stub; per-key `opacity`/`stroke` styles on a line never reached the first vertex (Vega paints a whole line from it), so they silently did nothing; overlay rows with Date order fields sorted as strings.
3. **fix(interactions): let the dismiss policy govern Escape in the region gesture.** With `dismiss: false`, Escape no longer clears the region gesture's retained selection. Default charts keep their behaviour.
4. **demo: you draw it bespoke interaction.** The stage, model, data, and styles; a `draw` affordance cursor (inline pen, exported as `DRAW_CURSOR`). Drawing rule: one value per whole year, the year under the pointer takes the pointer value, crossed years interpolate, other years keep theirs, so the reader can move back and redraw. Future rows stay in the data at zero opacity so the temporal axis keeps its range. The chart mounts with `dismiss: false`, because the default policy strips every retained `set-style` op on a click that hits no element, which unhid the future rows.

## Notes
- The data values are approximate EIA figures and should be replaced before the story ships.

## Test plan

- [x] `npm run typecheck -w packages/flint-js`, eslint on the touched files, `vitest run` (64 files, 1492 tests pass; new tests for geometry inversion, terminal vertex keys, Date ordering, the draw cursor)
- [x] `tsc --noEmit` in `site/`