### PR TITLE
fix(tests): repair type errors in map test files

### DIFF
--- a/packages/flint-js/tests/map-levels.test.ts
+++ b/packages/flint-js/tests/map-levels.test.ts
@@ -246,7 +246,7 @@ describe('point in region', () => {
         expect(geometryContainsPoint(withHole, [12, 5])).toBe(false);
         const two = { type: 'MultiPolygon', coordinates: [withHole.coordinates, [[[20, 0], [30, 0], [30, 10], [20, 10], [20, 0]]]] };
         expect(geometryContainsPoint(two, [25, 5])).toBe(true);
-        expect(geometryContainsPoint(two, [15, 5])).toBe(true === false);
+        expect(geometryContainsPoint(two, [15, 5])).toBe(false);
         expect(geometryContainsPoint({ type: 'Point', coordinates: [1, 1] }, [1, 1])).toBe(false);
     });
 

--- a/packages/flint-js/tests/map-navigation.test.ts
+++ b/packages/flint-js/tests/map-navigation.test.ts
@@ -193,7 +193,7 @@ describe('geo navigation controller', () => {
         expect(zoomEast).toBeLessThan(fullLon + 1e-6);
 
         const pan = controller.resolve({
-            type: 'navigation', phase: 'move', operation: 'pan', axes: 'xy',
+            type: 'navigation', phase: 'preview', operation: 'pan', axes: 'xy',
             delta: { x: 0.1, y: 0 },
         }, GUARD)!;
         controller.apply(pan);


### PR DESCRIPTION
## Summary
- `tests/map-levels.test.ts`: replace `toBe(true === false)` with `toBe(false)` (TS2367)
- `tests/map-navigation.test.ts`: use `phase: 'preview'` for the in-progress pan; `'move'` is not a member of `InteractionPhase` (TS2322)

The `typecheck:js` step on dev failed after #119 (run 34274379837). Vitest does not check types, so the 30 tests in these files passed at runtime.

## Test plan
- [x] `npm run typecheck -w packages/flint-js` passes locally
- [x] `vitest run tests/map-navigation.test.ts tests/map-levels.test.ts` — 30 passed