### PR TITLE
demo: add timebox bespoke interaction

### DIFF
--- a/site/src/playground/BespokeInteractionLab.tsx
+++ b/site/src/playground/BespokeInteractionLab.tsx
@@ -3,6 +3,7 @@ import { ClimatePhaseStage } from './ClimatePhaseStage';
 import { FisheyeZoomStage } from './FisheyeZoomStage';
 import { ExplodedDetailStage } from './ExplodedDetailStage';
 import { IndexChartStage } from './IndexChartStage';
+import { TimeboxStage } from './TimeboxStage';
 import { YouDrawItStage } from './YouDrawItStage';
 import { MapSemanticZoomStage } from './MapSemanticZoomStage';
 import { ChinaSemanticZoomStage } from './ChinaSemanticZoomStage';
@@ -116,6 +117,24 @@ export function BespokeInteractionLab() {
         <article className="bespoke-case bespoke-case--single">
           <header className="bespoke-case-header">
             <div>
+              <h2>Timebox on sampled line series</h2>
+              <p>
+                Drag a box directly over a time window and value band; only the series whose sampled points
+                all remain inside that box survive the filter.
+              </p>
+              <div className="bespoke-pattern">
+                <strong>Flint in → Flint out</strong>
+                <strong>Host overlay + region drag → set-style</strong>
+              </div>
+            </div>
+            <span className="bespoke-status">Case 06</span>
+          </header>
+          <TimeboxStage />
+        </article>
+
+        <article className="bespoke-case bespoke-case--single">
+          <header className="bespoke-case-header">
+            <div>
               <h2>Semantic zoom: states to counties</h2>
               <p>
                 Zoom the US map; once the view narrows enough, the state choropleth becomes a county
@@ -128,7 +147,7 @@ export function BespokeInteractionLab() {
                 <strong>Level swap: Flint in → Flint out</strong>
               </div>
             </div>
-            <span className="bespoke-status">Case 06</span>
+            <span className="bespoke-status">Case 07</span>
           </header>
           <MapSemanticZoomStage />
         </article>
@@ -147,7 +166,7 @@ export function BespokeInteractionLab() {
                 <strong>Level swap: Flint in → Flint out</strong>
               </div>
             </div>
-            <span className="bespoke-status">Case 07</span>
+            <span className="bespoke-status">Case 08</span>
           </header>
           <ChinaSemanticZoomStage />
         </article>

--- a/site/src/playground/TimeboxStage.tsx
+++ b/site/src/playground/TimeboxStage.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ChartAssemblyInput } from 'flint-chart';
+import {
+  buildInteractiveChart,
+  rectangleTrigger,
+  type CanvasInteractionDef,
+  type ChartUpdate,
+  type InteractiveChartSurface,
+} from 'flint-chart/interactive';
+import { ScaleToFit } from '../components/ScaleToFit';
+import { INDEX_CHART_STOCKS } from '../data/index-chart-stocks';
+import {
+  filterRowsByTimebox,
+  isValidTimeboxDate,
+  normalizeTimeboxSelection,
+  prepareTimeboxData,
+  type TimeboxSelection,
+} from './timebox-model';
+import './timebox-stage.css';
+
+const VIEW_WIDTH = 900;
+const VIEW_HEIGHT = 520;
+const DATA_UPDATE_ID = 'timebox-data';
+const TIMEBOX_INTERACTION_ID = 'timebox-region';
+const PREPARED = prepareTimeboxData(INDEX_CHART_STOCKS.map((row) => ({
+  series: row.Symbol,
+  date: row.Date,
+  value: row.Close,
+})));
+
+function chartInput(rows = PREPARED.rows): ChartAssemblyInput {
+  return {
+    data: { values: rows },
+    semantic_types: {
+      Date: 'Date',
+      Series: 'Category',
+      IndexedValue: {
+        semanticType: 'Quantity',
+        intrinsicDomain: PREPARED.valueDomain,
+      },
+    },
+    field_display_names: {
+      Series: 'Ticker',
+      IndexedValue: 'Indexed close (first sample = 100)',
+      Value: 'Close price (USD)',
+    },
+    theme_spec: {
+      extends: 'datawrapper',
+      legend: { show: 'never' },
+    },
+    options: { addTooltips: false },
+    chart_spec: {
+      chartType: 'Line Chart',
+      title: 'Timebox filtering on indexed stock closes',
+      subtitle: 'Drag a box over date and indexed close. A stock stays only if every sampled point inside the time window falls within the box.',
+      encodings: { x: 'Date', y: 'IndexedValue', color: 'Series' },
+      baseSize: { width: VIEW_WIDTH, height: VIEW_HEIGHT },
+      canvasSize: { width: VIEW_WIDTH, height: VIEW_HEIGHT },
+      chartProperties: {
+        includeZero_y: false,
+        showPoints: false,
+      },
+    },
+  };
+}
+
+function formatDate(date: Date) {
+  return new Intl.DateTimeFormat('en', { month: 'short', year: 'numeric', timeZone: 'UTC' }).format(date);
+}
+
+function formatValue(value: number) {
+  return value.toFixed(1);
+}
+
+function selectionSummary(selection: TimeboxSelection | null) {
+  if (!selection) return null;
+  if (!isValidTimeboxDate(selection.startDate) || !isValidTimeboxDate(selection.endDate)) return null;
+  const normalized = normalizeTimeboxSelection(selection);
+  return {
+    date: `${formatDate(normalized.startDate)} to ${formatDate(normalized.endDate)}`,
+    value: `${formatValue(normalized.minValue)} to ${formatValue(normalized.maxValue)}`,
+  };
+}
+
+function selectionFromEvent(event: Parameters<NonNullable<CanvasInteractionDef['handle']>>[0]): TimeboxSelection | null {
+  if (event.action !== 'select-region') return null;
+  if (event.phase === 'start' || event.phase === 'cancel') return null;
+  const xDomain = event.geometry.domain?.x;
+  const yDomain = event.geometry.domain?.y;
+  if (xDomain?.kind !== 'interval' || yDomain?.kind !== 'interval') return null;
+  if (!isValidTimeboxDate(xDomain.start) || !isValidTimeboxDate(xDomain.end)) return null;
+  const minValue = Number(yDomain.start);
+  const maxValue = Number(yDomain.end);
+  if (!Number.isFinite(minValue) || !Number.isFinite(maxValue)) return null;
+  return normalizeTimeboxSelection({
+    startDate: xDomain.start,
+    endDate: xDomain.end,
+    minValue,
+    maxValue,
+  });
+}
+
+function allSeriesTargets() {
+  return PREPARED.series.map((series) => ({ select: { key: { Series: series.key } } }));
+}
+
+function retainedSeriesTargets(symbols: readonly string[]) {
+  return symbols.map((symbol) => ({ select: { key: { Series: symbol } } }));
+}
+
+function styleUpdate(retainedSymbols: readonly string[]): ChartUpdate {
+  return {
+    id: DATA_UPDATE_ID,
+    ops: retainedSymbols.length > 0
+      ? [{
+        op: 'set-style' as const,
+        targets: retainedSeriesTargets(retainedSymbols),
+        value: { state: 'emphasized' as const, mutedOpacity: 0.14 },
+      }]
+      : [{
+        op: 'set-style' as const,
+        targets: allSeriesTargets(),
+        value: { opacity: 0.14 },
+      }],
+  };
+}
+
+export function TimeboxStage() {
+  const mountRef = useRef<HTMLDivElement>(null);
+  const surfaceRef = useRef<InteractiveChartSurface | null>(null);
+  const [selection, setSelection] = useState<TimeboxSelection | null>(null);
+  const [retainedCount, setRetainedCount] = useState(PREPARED.series.length);
+  const [windowSampleCount, setWindowSampleCount] = useState(0);
+  const totalCount = PREPARED.series.length;
+  const summary = useMemo(() => selectionSummary(selection), [selection]);
+
+  const timeboxInteraction = useMemo<CanvasInteractionDef>(() => ({
+    id: TIMEBOX_INTERACTION_ID,
+    eventSource: rectangleTrigger('contain'),
+    affordances: [{ target: 'plot', cursor: 'region' }],
+    handle(event) {
+      if (event.action !== 'select-region' || event.phase !== 'commit') return null;
+      const nextSelection = selectionFromEvent(event);
+      if (!nextSelection) return null;
+      const filtered = filterRowsByTimebox(PREPARED, nextSelection);
+      setSelection(nextSelection);
+      setRetainedCount(filtered.retainedSymbols.length);
+      setWindowSampleCount(filtered.windowSampleCount);
+      return styleUpdate(filtered.retainedSymbols);
+    },
+  }), []);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return undefined;
+    const surface = buildInteractiveChart(mount, chartInput(), {
+      backend: 'vegalite',
+      renderer: 'svg',
+      interactions: [timeboxInteraction],
+      ariaLabel: 'Timebox filtering over indexed stock series',
+      chartId: 'timebox-stage',
+    });
+    surfaceRef.current = surface;
+    return () => {
+      surfaceRef.current = null;
+      surface.destroy();
+    };
+  }, [timeboxInteraction]);
+
+  const reset = () => {
+    setSelection(null);
+    setRetainedCount(totalCount);
+    setWindowSampleCount(0);
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    void (async () => {
+      await surface.applyUpdate({
+        id: DATA_UPDATE_ID,
+        ops: [{
+          op: 'set-style',
+          targets: [],
+          value: { state: 'normal' },
+        }],
+      });
+    })();
+  };
+
+  return (
+    <div className="ic-flint-dimpvis-shell timebox-shell">
+      <div className="ic-stage-meta">
+        <strong>Discrete timebox over sampled stock series</strong>
+        <span>
+          Drag a rectangular box directly on the plot. The prototype keeps only the tickers whose
+          sampled points within that time window all stay inside the indexed value band.
+        </span>
+      </div>
+      <div className="ic-toolbar timebox-toolbar">
+        <span className="ic-pill" data-active={selection !== null}>
+          {selection ? `Retained: ${retainedCount}/${totalCount}` : `Series: ${totalCount}`}
+        </span>
+        <span className="ic-pill" data-active={selection !== null}>
+          {summary ? `Time: ${summary.date}` : 'Time: none'}
+        </span>
+        <span className="ic-pill" data-active={selection !== null}>
+          {summary ? `Value: ${summary.value}` : 'Value: none'}
+        </span>
+        <button type="button" className="ic-pill" onClick={reset}>Reset</button>
+      </div>
+      <div className="ic-flint-dimpvis-panel">
+        <ScaleToFit height={540} minHeight={400} adaptiveHeight padding={8}>
+          <div className="ic-flint-dimpvis-mount timebox-mount" ref={mountRef} />
+        </ScaleToFit>
+      </div>
+      <div className="timebox-footer">
+        <span>
+          {selection
+            ? retainedCount === 0
+              ? `${windowSampleCount} sampled points were tested in the selected window, and no series satisfied the full timebox constraint.`
+              : `${windowSampleCount} sampled points were tested inside the selected time window.`
+            : 'No active box. Draw on the plot area to define a time window and value constraints.'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/site/src/playground/timebox-model.ts
+++ b/site/src/playground/timebox-model.ts
@@ -1,0 +1,179 @@
+export interface TimeboxInputRow {
+  series: string;
+  date: string | Date;
+  value: number;
+}
+
+export interface TimeboxPoint {
+  date: Date;
+  dateMs: number;
+  value: number;
+  indexedValue: number;
+}
+
+export interface TimeboxSeries {
+  key: string;
+  points: TimeboxPoint[];
+}
+
+export interface PreparedTimeboxData {
+  rows: TimeboxRow[];
+  series: TimeboxSeries[];
+  minDate: Date;
+  maxDate: Date;
+  valueDomain: [number, number];
+}
+
+export interface TimeboxRow {
+  Series: string;
+  Date: string;
+  Value: number;
+  IndexedValue: number;
+}
+
+export interface TimeboxSelection {
+  startDate: Date;
+  endDate: Date;
+  minValue: number;
+  maxValue: number;
+}
+
+export interface TimeboxFilterResult {
+  rows: TimeboxRow[];
+  retainedSymbols: string[];
+  windowSampleCount: number;
+}
+
+export function isValidTimeboxDate(value: unknown): value is Date {
+  return value instanceof Date && Number.isFinite(value.getTime());
+}
+
+function toUtcDate(value: string | Date): Date {
+  if (value instanceof Date) {
+    return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()));
+  }
+  return new Date(`${value}T00:00:00Z`);
+}
+
+function toIsoDate(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+export function normalizeTimeboxSelection(selection: TimeboxSelection): TimeboxSelection {
+  if (!isValidTimeboxDate(selection.startDate) || !isValidTimeboxDate(selection.endDate)) {
+    throw new Error('Timebox selection must contain valid start and end dates.');
+  }
+  const startDate = selection.startDate.getTime() <= selection.endDate.getTime()
+    ? selection.startDate
+    : selection.endDate;
+  const endDate = selection.startDate.getTime() <= selection.endDate.getTime()
+    ? selection.endDate
+    : selection.startDate;
+  const minValue = Math.min(selection.minValue, selection.maxValue);
+  const maxValue = Math.max(selection.minValue, selection.maxValue);
+  return { startDate, endDate, minValue, maxValue };
+}
+
+export function prepareTimeboxData(rows: readonly TimeboxInputRow[]): PreparedTimeboxData {
+  const grouped = new Map<string, TimeboxPoint[]>();
+  let minIndexedValue = Number.POSITIVE_INFINITY;
+  let maxIndexedValue = Number.NEGATIVE_INFINITY;
+  let minDateMs = Number.POSITIVE_INFINITY;
+  let maxDateMs = Number.NEGATIVE_INFINITY;
+
+  for (const row of rows) {
+    const date = toUtcDate(row.date);
+    const dateMs = date.getTime();
+    minDateMs = Math.min(minDateMs, dateMs);
+    maxDateMs = Math.max(maxDateMs, dateMs);
+    const points = grouped.get(row.series) ?? [];
+    points.push({ date, dateMs, value: row.value, indexedValue: 0 });
+    grouped.set(row.series, points);
+  }
+
+  const series: TimeboxSeries[] = [...grouped.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, points]) => {
+      const sorted = [...points].sort((left, right) => left.dateMs - right.dateMs);
+      const baseline = sorted[0]?.value ?? 1;
+      const normalized = sorted.map((point) => {
+        const indexedValue = (point.value / baseline) * 100;
+        minIndexedValue = Math.min(minIndexedValue, indexedValue);
+        maxIndexedValue = Math.max(maxIndexedValue, indexedValue);
+        return { ...point, indexedValue };
+      });
+      return { key, points: normalized };
+    });
+
+  const rowsWithIndex = series.flatMap((series) => series.points.map((point) => ({
+    Series: series.key,
+    Date: toIsoDate(point.date),
+    Value: point.value,
+    IndexedValue: point.indexedValue,
+  })));
+  const valuePadding = Math.max(6, (maxIndexedValue - minIndexedValue) * 0.08);
+  return {
+    rows: rowsWithIndex,
+    series,
+    minDate: new Date(minDateMs),
+    maxDate: new Date(maxDateMs),
+    valueDomain: [Math.max(0, minIndexedValue - valuePadding), maxIndexedValue + valuePadding],
+  };
+}
+
+export function filterRowsByTimebox(
+  prepared: PreparedTimeboxData,
+  selection: TimeboxSelection | null,
+): TimeboxFilterResult {
+  if (!selection) {
+    return {
+      rows: prepared.rows,
+      retainedSymbols: prepared.series.map((series) => series.key),
+      windowSampleCount: 0,
+    };
+  }
+
+  if (!isValidTimeboxDate(selection.startDate) || !isValidTimeboxDate(selection.endDate)) {
+    return {
+      rows: prepared.rows,
+      retainedSymbols: prepared.series.map((series) => series.key),
+      windowSampleCount: 0,
+    };
+  }
+
+  const normalized = normalizeTimeboxSelection(selection);
+  const startMs = normalized.startDate.getTime();
+  const endMs = normalized.endDate.getTime();
+  const retainedSymbols: string[] = [];
+  let windowSampleCount = 0;
+
+  for (const series of prepared.series) {
+    const windowPoints = series.points.filter((point) => point.dateMs >= startMs && point.dateMs <= endMs);
+    windowSampleCount += windowPoints.length;
+    if (windowPoints.length === 0) continue;
+    const inside = windowPoints.every((point) =>
+      point.indexedValue >= normalized.minValue && point.indexedValue <= normalized.maxValue);
+    if (inside) retainedSymbols.push(series.key);
+  }
+
+  const retainedSet = new Set(retainedSymbols);
+  return {
+    rows: prepared.rows.filter((row) => retainedSet.has(row.Series)),
+    retainedSymbols,
+    windowSampleCount,
+  };
+}
+
+export function timeboxOverlayRow(selection: TimeboxSelection) {
+  if (!isValidTimeboxDate(selection.startDate) || !isValidTimeboxDate(selection.endDate)) {
+    throw new Error('Timebox overlay requires valid start and end dates.');
+  }
+  const normalized = normalizeTimeboxSelection(selection);
+  return {
+    StartDate: normalized.startDate,
+    EndDate: normalized.endDate,
+    MinValue: normalized.minValue,
+    MaxValue: normalized.maxValue,
+    Label: `${toIsoDate(normalized.startDate)} to ${toIsoDate(normalized.endDate)}`,
+  };
+}

--- a/site/src/playground/timebox-stage.css
+++ b/site/src/playground/timebox-stage.css
@@ -1,0 +1,22 @@
+.timebox-shell {
+  padding: 12px 12px 14px;
+}
+
+.timebox-mount {
+  min-height: 520px;
+}
+
+.timebox-toolbar {
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.timebox-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 4px;
+  color: #68737c;
+  font-size: 11px;
+  line-height: 1.45;
+}


### PR DESCRIPTION
Introduce a discrete timebox prototype in the bespoke interaction lab so stock series can be filtered by dragging a data-space box. Keep unmatched series muted instead of removing them so repeated selections preserve context.